### PR TITLE
[BUILD] Include rocm cross compile env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,8 @@ stage('Build') {
            echo LLVM_CONFIG=llvm-config-4.0 >> config.mk
            echo USE_RPC=1 >> config.mk
            echo USE_BLAS=openblas >> config.mk
+           echo USE_ROCM=1 >> config.mk
+           echo ROCM_PATH=/opt/rocm >> config.mk
            """
         make('gpu', '-j2')
         sh "mv lib/libtvm.so lib/libtvm_llvm40.so"

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -34,6 +34,9 @@ RUN bash /install/ubuntu_install_java.sh
 COPY install/ubuntu_install_nodejs.sh /install/ubuntu_install_nodejs.sh
 RUN bash /install/ubuntu_install_nodejs.sh
 
+COPY install/ubuntu_install_rocm.sh /install/ubuntu_install_rocm.sh
+RUN bash /install/ubuntu_install_rocm.sh
+
 # Enable doxygen for c++ doc build
 RUN apt-get install -y doxygen graphviz
 

--- a/tests/ci_build/install/ubuntu_install_rocm.sh
+++ b/tests/ci_build/install/ubuntu_install_rocm.sh
@@ -1,0 +1,4 @@
+# Install ROCm cross compilation toolchain.
+wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list
+apt-get update && apt-get install -y --force-yes rocm-dev


### PR DESCRIPTION
cc @adityaatluri One thing to confirm. On env that only installed rocm-dev, but without amd device, we would ideally want the following code to execute correctly, can you confirm that? This requires the rocm runtime to run, and the result is correct

```python
if not tvm.rocm(0).exist:
     print("Rocm device does not exists..")
     return
```