### PR TITLE
[BACKEND] initial llvm codegen for amdgpu

### DIFF
--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -29,3 +29,4 @@ from .ndarray import register_extension
 from .schedule import create_schedule
 from .build_module import build, lower, build_config
 from .tag import tag_scope
+from .contrib import rocm as _rocm

--- a/python/tvm/_ffi/ndarray.py
+++ b/python/tvm/_ffi/ndarray.py
@@ -59,6 +59,8 @@ def context(dev_type, dev_id=0):
         if dev_type not in TVMContext.STR2MASK:
             if dev_type.find("nvptx") != -1:
                 dev_type = "cuda"
+            if dev_type.find("rocm") != -1:
+                dev_type = "rocm"
         if dev_type not in TVMContext.STR2MASK:
             raise ValueError("Unknown device type %s" % dev_type)
         dev_type = TVMContext.STR2MASK[dev_type]

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -1,8 +1,4 @@
-# tvm.contrib.rocm
-"""Utility to convert object file to HSA Code Object
-The object file received from LLVM PassManager is relocatable ELF object.
-The routine in this file uses lld to convert it to shared ELF object.
-"""
+"""Utility for ROCm backend"""
 from . import util
 
 @tvm.register_func("tvm_callback_rocm_link")
@@ -11,12 +7,12 @@ def callback_rocm_link(obj_bin):
 
     Parameters
     ----------
-    obj_bin : str
+    obj_bin : bytearray
         The object file
 
     Return
     ------
-    cobj_bin : str
+    cobj_bin : bytearray
         The HSA Code Object
     """
     tmp_dir = util.tempdir()

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -1,9 +1,19 @@
 """Utility for ROCm backend"""
-import sys, subprocess
+import subprocess
 from . import util
 from ..api import register_func
 
 def rocm_link(in_file, out_file):
+    """Link relocatable ELF object to shared ELF object using lld
+
+    Parameters
+    ----------
+    in_file : str
+        Input file name (relocatable ELF object file)
+
+    out_file : str
+        Output file name (shared ELF object file)
+    """
     cmd = ["ld.lld"]
     cmd += ["-shared"]
     cmd += [in_file]
@@ -14,7 +24,7 @@ def rocm_link(in_file, out_file):
         args, shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    (out, _) = proc.communicate()
+    proc.communicate()
 
 @register_func("tvm_callback_rocm_link")
 def callback_rocm_link(obj_bin):

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -4,10 +4,22 @@ from . import util
 
 @tvm.register_func("tvm_callback_rocm_link")
 def callback_rocm_link(obj_bin):
+    """Links object file generated from LLVM to HSA Code Object
+
+    Parameters
+    ----------
+    obj_bin : str
+        The object file
+
+    Return
+    ------
+    cobj_bin : str
+        The HSA Code Object
+    """
     tmp_dir = util.tempdir()
     tmp_obj = temp_dir.reloath("rocm_kernel.o")
     tmp_cobj = temp_dir.reloath("rocm_kernel.co")
     with open(tmp_obj, "wb") as out_file:
         out_file.write(bytes(obj_bin))
-    cobj_bin = bytearray(open(temp_cobj, "rb").read())
+    cobj_bin = bytearray(open(tmp_cobj, "rb").read())
     return cobj_bin

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -1,5 +1,4 @@
 """Utility for ROCm backend"""
-import sys
 import subprocess
 from . import util
 from ..api import register_func
@@ -23,9 +22,9 @@ def rocm_link(in_file, out_file):
     (out, _) = proc.communicate()
 
     if proc.returncode != 0:
-        sys.stderr.write("Linking error using ld.lld:\n")
-        sys.stderr.write(str(out))
-        sys.stderr.flush()
+        msg = "Linking error using ld.lld:\n"
+        msg += str(out)
+        raise RuntimeError(msg)
 
 @register_func("tvm_callback_rocm_link")
 def callback_rocm_link(obj_bin):

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -1,0 +1,7 @@
+# tvm.contrib.rocm
+
+from . import util
+
+@tvm.register_func("tvm_callback_rocm_link")
+def callback_rocm_link(obj_bin):
+    return obj_bin

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -4,4 +4,10 @@ from . import util
 
 @tvm.register_func("tvm_callback_rocm_link")
 def callback_rocm_link(obj_bin):
-    return obj_bin
+    tmp_dir = util.tempdir()
+    tmp_obj = temp_dir.reloath("rocm_kernel.o")
+    tmp_cobj = temp_dir.reloath("rocm_kernel.co")
+    with open(tmp_obj, "wb") as out_file:
+        out_file.write(bytes(obj_bin))
+    cobj_bin = bytearray(open(temp_cobj, "rb").read())
+    return cobj_bin

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -1,5 +1,8 @@
 # tvm.contrib.rocm
-
+"""Utility to convert object file to HSA Code Object
+The object file received from LLVM PassManager is relocatable ELF object.
+The routine in this file uses lld to convert it to shared ELF object.
+"""
 from . import util
 
 @tvm.register_func("tvm_callback_rocm_link")
@@ -17,8 +20,8 @@ def callback_rocm_link(obj_bin):
         The HSA Code Object
     """
     tmp_dir = util.tempdir()
-    tmp_obj = temp_dir.reloath("rocm_kernel.o")
-    tmp_cobj = temp_dir.reloath("rocm_kernel.co")
+    tmp_obj = tmp_dir.reloath("rocm_kernel.o")
+    tmp_cobj = tmp_dir.reloath("rocm_kernel.co")
     with open(tmp_obj, "wb") as out_file:
         out_file.write(bytes(obj_bin))
     cobj_bin = bytearray(open(tmp_cobj, "rb").read())

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -16,7 +16,6 @@ def rocm_link(in_file, out_file):
         Output file name (shared ELF object file)
     """
     args = "ld.lld -shared " + in_file + " -o " + out_file
-    print args
     proc = subprocess.Popen(
         args, shell=True,
         stdout=subprocess.PIPE,

--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -14,9 +14,9 @@ def rocm_link(in_file, out_file):
     out_file : str
         Output file name (shared ELF object file)
     """
-    args = "ld.lld -shared " + in_file + " -o " + out_file
+    args = ["ld.lld", "-shared", in_file, "-o", out_file]
     proc = subprocess.Popen(
-        args, shell=True,
+        args,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
     (out, _) = proc.communicate()

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -20,7 +20,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
  public:
   void AddFunction(const LoweredFunc& f) final {
     // add function as void return value
-    CodeGenLLVM::AddFunctionInternal(f, true, AMDGPU);
+    CodeGenLLVM::AddFunctionInternal(f, true);
     // annotate as kernel function
 /*
     module_->getOrInsertNamedMetadata("nvvm.annotations")

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -148,7 +148,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   llvm::raw_svector_ostream dest_hsaco(data_hsaco), dest_ll(data_ll);
   dest_hsaco.SetUnbuffered();
   dest_ll.SetUnbuffered();
-  module->print(dest_ll, nullptr);
+//  module->print(dest_ll, nullptr);
   std::string printdest_ll(data_ll.begin(), data_ll.end());
 
   llvm::legacy::PassManager pass;
@@ -157,24 +157,11 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
       pass, dest_hsaco, llvm::TargetMachine::CGFT_ObjectFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
 
-  auto FileName = "/tmp/output.o";
-  std::error_code EC;
-  llvm::raw_fd_ostream dest(FileName, EC, llvm::sys::fs::F_None);
-
-  llvm::legacy::PassManager p;
-  auto FileType = llvm::TargetMachine::CGFT_ObjectFile;
-
-  if (tm->addPassesToEmitFile(p, dest, FileType)) {
-    LOG(FATAL) << "Couldn't dump to file";
-  }
-
-  p.run(*module);
-  dest.flush();
-
-
   pass.run(*module);
+  module->print(dest_ll, nullptr);
   std::string hsaco(data_hsaco.begin(), data_hsaco.end());
   std::string ll(data_ll.begin(), data_ll.end());
+  LOG(WARNING) << ll;
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);
 }
 

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -7,6 +7,7 @@
 #if TVM_ROCM_RUNTIME
 
 #include <tvm/runtime/device_api.h>
+#include <tvm/runtime/c_runtime_api.h>
 #include "./codegen_llvm.h"
 #include "../build_common.h"
 #include "../../pass/ir_util.h"

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -192,11 +192,6 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   std::unique_ptr<llvm::Module> mObjFile = llvm::CloneModule(module.get());
   llvm::legacy::PassManager pass;
 
-  auto fnAsm = "output.s";
-  auto fnObj = "output.co";
-  std::error_code EC;
-  llvm::raw_fd_ostream destAsmFile(fnAsm, EC, llvm::sys::fs::F_None);
-  llvm::raw_fd_ostream destObjFile(fnObj, EC, llvm::sys::fs::F_None);
 
   CHECK(tm->addPassesToEmitFile(
             pass, destObj, llvm::TargetMachine::CGFT_ObjectFile) == 0)

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -15,12 +15,12 @@
 namespace tvm {
 namespace codegen {
 
-// NVPTX code generator.
+// AMDGPU code generator.
 class CodeGenAMDGPU : public CodeGenLLVM {
  public:
   void AddFunction(const LoweredFunc& f) final {
     // add function as void return value
-    CodeGenLLVM::AddFunctionInternal(f, true);
+    CodeGenLLVM::AddFunctionInternal(f, true, AMDGPU);
     // annotate as kernel function
 /*
     module_->getOrInsertNamedMetadata("nvvm.annotations")
@@ -169,5 +169,5 @@ TVM_REGISTER_API("codegen.build_rocm")
 
 }  // namespace codegen
 }  // namespace tvm
-#endif   // TVM_CUDA_RUNTIME
+#endif   // TVM_ROCM_RUNTIME
 #endif  // TVM_LLVM_VERSION

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -140,13 +140,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   CHECK(target.length(
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
-  std::string triple("amdgcn-amd-amdhsa-hcc");
-  std::string error;
-  auto llvmTarget = llvm::TargetRegistry::lookupTarget(triple, error);
-  auto features = "";
-  llvm::TargetOptions opt;
-  auto RM = llvm::Optional<llvm::Reloc::Model>();
-  llvm::TargetMachine* tm = llvmTarget->createTargetMachine(triple, "gfx900", features, opt, RM);
+  llvm::TargetMachine* tm = GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx900" + target.substr(4, target.length() - 4));
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
   cg->Init(funcs[0]->name, tm, ctx.get(), false, false);

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -1,0 +1,171 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file codegen_nvptx.cc
+ * \brief NVPTX code generator.
+ */
+#ifdef TVM_LLVM_VERSION
+#if TVM_ROCM_RUNTIME
+
+#include <tvm/runtime/device_api.h>
+#include "./codegen_llvm.h"
+#include "../build_common.h"
+#include "../../pass/ir_util.h"
+#include "../../runtime/rocm/rocm_module.h"
+
+namespace tvm {
+namespace codegen {
+
+// NVPTX code generator.
+class CodeGenAMDGPU : public CodeGenLLVM {
+ public:
+  void AddFunction(const LoweredFunc& f) final {
+    // add function as void return value
+    CodeGenLLVM::AddFunctionInternal(f, true);
+    // annotate as kernel function
+    module_->getOrInsertNamedMetadata("nvvm.annotations")
+        ->addOperand(llvm::MDNode::get(*ctx_, {
+              llvm::ValueAsMetadata::get(function_),
+              llvm::MDString::get(*ctx_, "kernel"),
+              llvm::ValueAsMetadata::get(ConstInt32(1)) }));
+  }
+
+  void VisitStmt_(const Allocate* op) final {
+    CHECK(!is_zero(op->condition));
+    llvm::Value* buf = nullptr;
+    if (op->new_expr.defined()) {
+      CHECK_EQ(op->free_function, "nop");
+      buf = MakeValue(op->new_expr);
+    } else {
+      int32_t constant_size = op->constant_allocation_size();
+      CHECK_GT(constant_size, 0)
+          << "Can only handle constant size stack allocation in GPU";
+      StorageInfo& info = alloc_storage_info_[op->buffer_var.get()];
+      if (constant_size % 4 == 0 && info.alignment == 0) {
+        info.alignment = GetTempAllocaAlignment(op->type, constant_size);
+      }
+      // maximum necessary alignment in the NV devices
+      if (info.alignment > 16) {
+        info.alignment = 16;
+      }
+      if (info.scope.rank == 2) {
+        // const int local_address_space = 5;
+        // TODO(tqchen): for higher version of LLVM, local address space can be set.
+        llvm::AllocaInst* alloca = builder_->CreateAlloca(
+            LLVMType(op->type), ConstInt32(constant_size));
+        if (alloca->getAlignment() < static_cast<uint32_t>(info.alignment)) {
+          alloca->setAlignment(info.alignment);
+        }
+        buf = alloca;
+      } else {
+        CHECK_EQ(info.scope.rank, 1)
+            << "Can only allocate shared or local memory inside kernel";
+        // Shared memory: address space  == 3
+        const unsigned shared_address_space = 3;
+        llvm::Type* type = llvm::ArrayType::get(LLVMType(op->type), constant_size);
+        // Allocate shared memory in global, address_space = 3
+        llvm::GlobalVariable *global = new llvm::GlobalVariable(
+            *module_, type, false, llvm::GlobalValue::PrivateLinkage, 0, ".shared",
+            nullptr, llvm::GlobalValue::NotThreadLocal, shared_address_space);
+        global->setAlignment(info.alignment);
+        buf = global;
+      }
+    }
+    buf = builder_->CreatePointerCast(
+        buf, LLVMType(op->type)->getPointerTo(
+            buf->getType()->getPointerAddressSpace()));
+    CHECK(!var_map_.count(op->buffer_var.get()));
+    var_map_[op->buffer_var.get()] = buf;
+    this->VisitStmt(op->body);
+  }
+
+  // Return the thread index via intrinsics.
+  llvm::Value* GetThreadIndex(const IterVar& iv) final {
+    runtime::ThreadScope ts = runtime::ThreadScope::make(iv->thread_tag);
+    llvm::Intrinsic::ID intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x;
+    if (ts.rank == 1) {
+      switch (ts.dim_index) {
+        case 0: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_x; break;
+        case 1: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_y; break;
+        case 2: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_z; break;
+        default: LOG(FATAL) << "unknown thread idx";
+      }
+    }
+    /*
+    else {
+      CHECK_EQ(ts.rank, 0);
+      switch (ts.dim_index) {
+        case 0: intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x; break;
+        case 1: intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_y; break;
+        case 2: intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_z; break;
+        default: LOG(FATAL) << "unknown thread idx";
+      }
+    }
+    */
+    llvm::Function* f = llvm::Intrinsic::getDeclaration(module_.get(), intrin_id);
+    return builder_->CreateCall(f, {});
+  }
+
+  llvm::Value* CreateStorageSync(const Call* op) final {
+    const std::string& sync = op->args[0].as<StringImm>()->value;
+    if (sync == "warp") {
+      // TODO(tqchen) warp sync in CUDA9
+      return nullptr;
+    } else if (sync == "shared") {
+      llvm::Function* f = llvm::Intrinsic::getDeclaration(
+          module_.get(),
+          ::llvm::Intrinsic::amdgcn_s_barrier);
+      return builder_->CreateCall(f, {});
+    } else {
+      LOG(FATAL) << "Do not support sync " << sync;
+      return nullptr;
+    }
+  }
+
+  void InitPassManagerBuilder(llvm::PassManagerBuilder* builder) final {
+    // Additional optimization hook to tweak the builder.
+  }
+
+ protected:
+  void InitTarget(llvm::TargetMachine* tm) final {
+    // Maximum vector lane = float4
+    native_vector_bits_ = 4 * 32;
+    CodeGenLLVM::InitTarget(tm);
+  }
+};
+
+runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
+  CHECK(1) << target;
+  CHECK(target.length(
+) >= 5 &&
+        target.substr(0, 5) == "rocm");
+  llvm::TargetMachine* tm = GetLLVMTargetMachine(
+      " -mcpu=gfx900" +
+      target.substr(5, target.length() - 5));
+  std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
+  std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
+  cg->Init(funcs[0]->name, tm, ctx.get(), false, false);
+  for (LoweredFunc f :  funcs) {
+    cg->AddFunction(f);
+  }
+  std::unique_ptr<llvm::Module> module = cg->Finish();
+  llvm::SmallString<8> data;
+  llvm::raw_svector_ostream dest(data);
+  dest.SetUnbuffered();
+  llvm::legacy::PassManager pass;
+  CHECK(tm->addPassesToEmitFile(
+      pass, dest, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
+      << "Cannot emit target CGFT_ObjectFile";
+  pass.run(*module);
+  std::string hsaco(data.begin(), data.end());
+  return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), "");
+}
+
+TVM_REGISTER_API("codegen.build_amdgcn")
+.set_body([](TVMArgs args, TVMRetValue* rv) {
+    *rv = BuildAMDGPU(args[0], args[1]);
+  });
+
+}  // namespace codegen
+}  // namespace tvm
+#endif   // TVM_CUDA_RUNTIME
+#endif  // TVM_LLVM_VERSION

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -14,14 +14,6 @@
 #include "../../pass/ir_util.h"
 #include "../../runtime/rocm/rocm_module.h"
 
-namespace llvm {
-  extern "C" void LLVMInitializeAMDGPUTargetInfo();
-  extern "C" void LLVMInitializeAMDGPUTarget();
-  extern "C" void LLVMInitializeAMDGPUTargetMC();
-  extern "C" void LLVMInitializeAMDGPUAsmParser();
-  extern "C" void LLVMInitializeAMDGPUAsmPrinter();
-}
-
 namespace tvm {
 namespace codegen {
 
@@ -144,33 +136,10 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   CHECK(target.length(
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
-//  llvm::TargetMachine* tm = \
+  llvm::TargetMachine* tm = \
     GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx900" + \
     target.substr(4, target.length() - 4));
-  auto TargetTriple = std::string("amdgcn-amd-amdhsa-hcc");
 
-  llvm::LLVMInitializeAMDGPUTargetInfo();
-  llvm::LLVMInitializeAMDGPUTarget();
-  llvm::LLVMInitializeAMDGPUTargetMC();
-  llvm::LLVMInitializeAMDGPUAsmParser();
-  llvm::LLVMInitializeAMDGPUAsmPrinter();
-
-  std::string Error;
-  auto Target = llvm::TargetRegistry::lookupTarget(TargetTriple, Error);
-
-  if (!Target) {
-    LOG(WARNING) << Error;
-  }
-
-  auto GPU = "gfx900";
-  auto Features = "";
-
-  llvm::TargetOptions opt;
-  auto RM = llvm::Optional<llvm::Reloc::Model>();
-  auto tm = Target->createTargetMachine(TargetTriple, GPU, Features, opt, RM);
-
-
-  LOG(WARNING) << target;
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
   cg->Init(funcs[0]->name, tm, ctx.get(), false, false);

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -156,7 +156,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   std::string Error;
   auto Target = llvm::TargetRegistry::lookupTarget(TargetTriple, Error);
 
-  if(!Target) {
+  if (!Target) {
     LOG(WARNING) << Error;
   }
 
@@ -227,8 +227,6 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 
   LOG(WARNING) << ll;
   LOG(WARNING) << isa;
-  
-
 
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);
 }

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -201,7 +201,10 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   CHECK(tm->addPassesToEmitFile(
             pass, destObj, llvm::TargetMachine::CGFT_ObjectFile) == 0)
             << "Cannot emit target CGFT_ObjectFile";
+  pass.run(*mObj);
+  std::string obj(dataObj.begin(), dataObj.end());
 
+/*
   CHECK(tm->addPassesToEmitFile(
             pass, destAsm, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
             << "Cannot emit target CGFT_AssemblyFile";
@@ -229,16 +232,16 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 
   LOG(WARNING) << ll;
   LOG(WARNING) << isa;
+*/
 
   const auto* f = tvm::runtime::Registry::Get("tvm_callback_rocm_link");
   CHECK(f != nullptr) << "Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm";
 
-  std::string obj_blob;
   TVMByteArray arr;
-  arr.data = &obj_blob[0];
-  arr.size = obj_blob.length();
+  arr.data = &obj[0];
+  arr.size = obj.length();
 
-  std::string hso = (*f)(obj_blob);
+  std::string hsaco = (*f)(arr), ll;
 
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);
 }

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -232,6 +232,13 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   const auto* f = Registry::Get("tvm_callback_rocm_link");
   CHECK(f != nullptr) << “Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm”;
 
+  std::string obj_blob;
+  TVMByteArray arr;
+  arr.data = &obj_blob[0];
+  arr.size = obj_blob.length();
+
+  std::string hso = (*f)(obj_blob);
+
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);
 }
 

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -38,7 +38,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
       if (constant_size % 4 == 0 && info.alignment == 0) {
         info.alignment = GetTempAllocaAlignment(op->type, constant_size);
       }
-      // maximum necessary alignment in the NV devices
+      // maximum necessary alignment in the AMD devices
       if (info.alignment > 16) {
         info.alignment = 16;
       }

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -91,8 +91,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
         case 2: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_z; break;
         default: LOG(FATAL) << "unknown thread idx";
       }
-    }
-    else {
+    } else {
       CHECK_EQ(ts.rank, 0);
       switch (ts.dim_index) {
         case 0: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_x; break;

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -92,17 +92,15 @@ class CodeGenAMDGPU : public CodeGenLLVM {
         default: LOG(FATAL) << "unknown thread idx";
       }
     }
-    /*
     else {
       CHECK_EQ(ts.rank, 0);
       switch (ts.dim_index) {
-        case 0: intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x; break;
-        case 1: intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_y; break;
-        case 2: intrin_id = ::llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_z; break;
+        case 0: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_x; break;
+        case 1: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_y; break;
+        case 2: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_z; break;
         default: LOG(FATAL) << "unknown thread idx";
       }
     }
-    */
     llvm::Function* f = llvm::Intrinsic::getDeclaration(module_.get(), intrin_id);
     return builder_->CreateCall(f, {});
   }

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -229,8 +229,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 
   LOG(WARNING) << ll;
   LOG(WARNING) << isa;
-  
-  const auto* f = Registry::Get("tvm_callback_rocm_link”);
+  const auto* f = Registry::Get("tvm_callback_rocm_link");
   CHECK(f != nullptr) << “Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm”;
 
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -164,8 +164,8 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   llvm::legacy::PassManager p;
   auto FileType = llvm::TargetMachine::CGFT_ObjectFile;
 
-  if(tm->addPassesToEmitFile(p, dest, FileType)) {
-   LOG(FATAL) << "Couldn't dump to file";
+  if (tm->addPassesToEmitFile(p, dest, FileType)) {
+    LOG(FATAL) << "Couldn't dump to file";
   }
 
   p.run(*module);

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -132,7 +132,6 @@ class CodeGenAMDGPU : public CodeGenLLVM {
 };
 
 runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
-  CHECK(1) << target;
   CHECK(target.length(
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
@@ -167,36 +166,6 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
             << "Cannot emit target CGFT_ObjectFile";
   pass.run(*mObj);
   std::string obj(dataObj.begin(), dataObj.end());
-
-/*
-  CHECK(tm->addPassesToEmitFile(
-            pass, destAsm, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
-            << "Cannot emit target CGFT_AssemblyFile";
-
-  CHECK(tm->addPassesToEmitFile(
-            pass, destObjFile, llvm::TargetMachine::CGFT_ObjectFile) == 0)
-            << "Cannot emit target CGFT_ObjectFile";
-
-  CHECK(tm->addPassesToEmitFile(
-            pass, destAsmFile, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
-            << "Cannot emit target CGFT_AssemblyFile";
-
-
-  pass.run(*mAsm);
-  pass.run(*mObj);
-  pass.run(*mAsmFile);
-  pass.run(*mObjFile);
-
-  destAsmFile.flush();
-  destObjFile.flush();
-
-  std::string ll(data_ll.begin(), data_ll.end());
-  std::string hsaco(dataObj.begin(), dataObj.end());
-  std::string isa(dataAsm.begin(), dataAsm.end());
-
-  LOG(WARNING) << ll;
-  LOG(WARNING) << isa;
-*/
 
   const auto* f = tvm::runtime::Registry::Get("tvm_callback_rocm_link");
   CHECK(f != nullptr) << "Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm";

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -8,6 +8,7 @@
 
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/c_runtime_api.h>
+#include <tvm/runtime/registry.h>
 #include "./codegen_llvm.h"
 #include "../build_common.h"
 #include "../../pass/ir_util.h"
@@ -228,6 +229,9 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 
   LOG(WARNING) << ll;
   LOG(WARNING) << isa;
+  
+  const auto* f = Registry::Get("tvm_callback_rocm_link”);
+  CHECK(f != nullptr) << “Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm”;
 
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);
 }

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -140,7 +140,9 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   CHECK(target.length(
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
-  llvm::TargetMachine* tm = GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx900" + target.substr(4, target.length() - 4));
+  llvm::TargetMachine* tm = \
+    GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx900" + \
+    target.substr(4, target.length() - 4));
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
   cg->Init(funcs[0]->name, tm, ctx.get(), false, false);

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -229,8 +229,9 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 
   LOG(WARNING) << ll;
   LOG(WARNING) << isa;
-  const auto* f = Registry::Get("tvm_callback_rocm_link");
-  CHECK(f != nullptr) << “Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm”;
+
+  const auto* f = tvm::runtime::Registry::Get("tvm_callback_rocm_link");
+  CHECK(f != nullptr) << "Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm";
 
   std::string obj_blob;
   TVMByteArray arr;

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -156,10 +156,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   module->print(dest_ll, nullptr);
   std::unique_ptr<llvm::Module> mAsm = llvm::CloneModule(module.get());
   std::unique_ptr<llvm::Module> mObj = llvm::CloneModule(module.get());
-  std::unique_ptr<llvm::Module> mAsmFile = llvm::CloneModule(module.get());
-  std::unique_ptr<llvm::Module> mObjFile = llvm::CloneModule(module.get());
   llvm::legacy::PassManager pass;
-
 
   CHECK(tm->addPassesToEmitFile(
             pass, destObj, llvm::TargetMachine::CGFT_ObjectFile) == 0)
@@ -174,7 +171,8 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   arr.data = &obj[0];
   arr.size = obj.length();
 
-  std::string hsaco = (*f)(arr), ll;
+  std::string hsaco = (*f)(arr);
+  std::string ll(data_ll.begin(), data_ll.end());
 
   return ROCMModuleCreate(hsaco, "hsaco", ExtractFuncInfo(funcs), ll);
 }

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -89,7 +89,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
         case 0: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_x; break;
         case 1: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_y; break;
         case 2: intrin_id = ::llvm::Intrinsic::amdgcn_workitem_id_z; break;
-        default: LOG(FATAL) << "unknown thread idx";
+        default: LOG(FATAL) << "unknown workitem idx";
       }
     } else {
       CHECK_EQ(ts.rank, 0);
@@ -97,7 +97,7 @@ class CodeGenAMDGPU : public CodeGenLLVM {
         case 0: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_x; break;
         case 1: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_y; break;
         case 2: intrin_id = ::llvm::Intrinsic::amdgcn_workgroup_id_z; break;
-        default: LOG(FATAL) << "unknown thread idx";
+        default: LOG(FATAL) << "unknown workgroup idx";
       }
     }
     llvm::Function* f = llvm::Intrinsic::getDeclaration(module_.get(), intrin_id);

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -113,7 +113,8 @@ void CodeGenLLVM::AddFunctionInternal(const LoweredFunc& f, bool ret_void, CGDev
       ret_void ? t_void_ : t_int_, arg_type, false);
   // setup the function.
   function_ = llvm::cast<llvm::Function>(module_->getOrInsertFunction(f->name, ftype));
-  function_->setCallingConv(dev_type == AMDGPU ? llvm::CallingConv::AMDGPU_KERNEL : llvm::CallingConv::C);
+  function_->setCallingConv(dev_type == AMDGPU ? \ 
+    llvm::CallingConv::AMDGPU_KERNEL : llvm::CallingConv::C);
   // set handle argument to be non alias.
   if (is_restricted_) {
     for (size_t i = 0; i < f->args.size(); ++i) {

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -113,7 +113,7 @@ void CodeGenLLVM::AddFunctionInternal(const LoweredFunc& f, bool ret_void, CGDev
       ret_void ? t_void_ : t_int_, arg_type, false);
   // setup the function.
   function_ = llvm::cast<llvm::Function>(module_->getOrInsertFunction(f->name, ftype));
-  function_->setCallingConv(dev_type == AMDGPU ? \ 
+  function_->setCallingConv(dev_type == AMDGPU ?
     llvm::CallingConv::AMDGPU_KERNEL : llvm::CallingConv::C);
   // set handle argument to be non alias.
   if (is_restricted_) {

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -195,8 +195,7 @@ void CodeGenLLVM::Optimize() {
   target_machine_->adjustPassManager(builder);
 #endif
 
-  if(target_machine_->getTarget().getName() == std::string("amdgcn")) {
-
+  if (target_machine_->getTarget().getName() == std::string("amdgcn")) {
     llvm::legacy::FunctionPassManager amdgcnFPM(module_.get());
     llvm::legacy::PassManager amdgcnMPM;
     builder.populateFunctionPassManager(amdgcnFPM);

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -24,6 +24,14 @@ namespace codegen {
 using namespace ir;
 
 /*!
+ * \brief select codegen path for a device
+ */
+enum CGDeviceType {
+  OTHERS = 0,
+  AMDGPU,
+};
+
+/*!
  * \brief A base class to generate a LLVM.
  */
 class CodeGenLLVM :
@@ -148,7 +156,7 @@ class CodeGenLLVM :
   virtual void Optimize();
   // Get the maximim storage align bits of buffer pointer given storage scope.
   virtual int NativeVectorBits(const runtime::StorageScope& storage_scope) const;
-  void AddFunctionInternal(const LoweredFunc& f, bool ret_void);
+  void AddFunctionInternal(const LoweredFunc& f, bool ret_void, CGDeviceType dev_type = OTHERS);
   // Create extern call
   llvm::CallInst* CreateCallExtern(llvm::Type* ret,
                                    const std::string& name,

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -23,13 +23,6 @@ namespace codegen {
 
 using namespace ir;
 
-/*!
- * \brief select codegen path for a device
- */
-enum CGDeviceType {
-  OTHERS = 0,
-  AMDGPU,
-};
 
 /*!
  * \brief A base class to generate a LLVM.
@@ -156,7 +149,7 @@ class CodeGenLLVM :
   virtual void Optimize();
   // Get the maximim storage align bits of buffer pointer given storage scope.
   virtual int NativeVectorBits(const runtime::StorageScope& storage_scope) const;
-  void AddFunctionInternal(const LoweredFunc& f, bool ret_void, CGDeviceType dev_type = OTHERS);
+  void AddFunctionInternal(const LoweredFunc& f, bool ret_void);
   // Create extern call
   llvm::CallInst* CreateCallExtern(llvm::Type* ret,
                                    const std::string& name,

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -149,6 +149,9 @@ class CodeGenLLVM :
   virtual void Optimize();
   // Get the maximim storage align bits of buffer pointer given storage scope.
   virtual int NativeVectorBits(const runtime::StorageScope& storage_scope) const;
+  // Get correct address space depending on the backend
+  virtual unsigned GetGlobalAddressSpace();
+
   void AddFunctionInternal(const LoweredFunc& f, bool ret_void);
   // Create extern call
   llvm::CallInst* CreateCallExtern(llvm::Type* ret,

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -112,7 +112,6 @@ GetLLVMTargetMachine(const std::string& target_str,
   } else {
     opt.FloatABIType = llvm::FloatABI::Hard;
   }
-  LOG(WARNING) << "CPU: " << cpu;
   llvm::TargetMachine* tm = target->createTargetMachine(
       target_triple, cpu, attr, opt, llvm::Reloc::PIC_);
   return tm;

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -112,6 +112,7 @@ GetLLVMTargetMachine(const std::string& target_str,
   } else {
     opt.FloatABIType = llvm::FloatABI::Hard;
   }
+  LOG(WARNING)<< "CPU: "<<cpu;
   llvm::TargetMachine* tm = target->createTargetMachine(
       target_triple, cpu, attr, opt, llvm::Reloc::PIC_);
   return tm;

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -112,7 +112,7 @@ GetLLVMTargetMachine(const std::string& target_str,
   } else {
     opt.FloatABIType = llvm::FloatABI::Hard;
   }
-  LOG(WARNING)<< "CPU: "<<cpu;
+  LOG(WARNING) << "CPU: "<<cpu;
   llvm::TargetMachine* tm = target->createTargetMachine(
       target_triple, cpu, attr, opt, llvm::Reloc::PIC_);
   return tm;

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -112,7 +112,7 @@ GetLLVMTargetMachine(const std::string& target_str,
   } else {
     opt.FloatABIType = llvm::FloatABI::Hard;
   }
-  LOG(WARNING) << "CPU: "<<cpu;
+  LOG(WARNING) << "CPU: " << cpu;
   llvm::TargetMachine* tm = target->createTargetMachine(
       target_triple, cpu, attr, opt, llvm::Reloc::PIC_);
   return tm;

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -127,7 +127,7 @@ bool RuntimeEnabled(const std::string& target) {
     f_name = "codegen.build_nvptx";
   } else if (target.length() >= 4 && target.substr(0, 4) == "rocm") {
     f_name = "codegen.build_rocm";
-  }else if (target.length() >= 4 && target.substr(0, 4) == "llvm") {
+  } else if (target.length() >= 4 && target.substr(0, 4) == "llvm") {
     const PackedFunc* pf = runtime::Registry::Get("codegen.llvm_target_enabled");
     if (pf == nullptr) return false;
     return (*pf)(target);

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -125,7 +125,9 @@ bool RuntimeEnabled(const std::string& target) {
     f_name = "device_api.vpi";
   } else if (target.length() >= 5 && target.substr(0, 5) == "nvptx") {
     f_name = "codegen.build_nvptx";
-  } else if (target.length() >= 4 && target.substr(0, 4) == "llvm") {
+  } else if (target.length() >= 4 && target.substr(0, 4) == "rocm") {
+    f_name = "codegen.build_rocm";
+  }else if (target.length() >= 4 && target.substr(0, 4) == "llvm") {
     const PackedFunc* pf = runtime::Registry::Get("codegen.llvm_target_enabled");
     if (pf == nullptr) return false;
     return (*pf)(target);

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -60,8 +60,8 @@ class ROCMModuleNode : public runtime::ModuleNode {
   }
 
   std::string GetSource(const std::string& format) final {
-    if(format == fmt_) return data_;
-    if(fmt_ == "hsaco") LOG(WARNING)<<"HSACO"; return data_;
+    if (format == fmt_) { return data_; }
+    if (fmt_ == "hsaco") { return data_; }
     return "";
   }
 

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -205,7 +205,6 @@ Module ROCMModuleCreate(
     std::string hip_source) {
   std::shared_ptr<ROCMModuleNode> n =
       std::make_shared<ROCMModuleNode>(data, fmt, fmap, hip_source);
-  LOG(WARNING) << hip_source;
   return Module(n);
 }
 

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -69,6 +69,7 @@ class ROCMModuleNode : public runtime::ModuleNode {
   hipFunction_t GetFunc(int device_id, const std::string& func_name) {
     std::lock_guard<std::mutex> lock(mutex_);
     // must recheck under the lock scope
+
     if (module_[device_id] == nullptr) {
       ROCM_DRIVER_CALL(hipModuleLoadData(&(module_[device_id]), data_.c_str()));
     }
@@ -146,7 +147,9 @@ class ROCMWrappedFunc {
     if (fcache_[device_id] == nullptr) {
       fcache_[device_id] = m_->GetFunc(device_id, func_name_);
     }
+
     hipStream_t strm = static_cast<hipStream_t>(ROCMThreadEntry::ThreadLocal()->stream);
+
     ThreadWorkLoad wl = thread_axis_cfg_.Extract(args);
     void* config[] = {
       HIP_LAUNCH_PARAM_BUFFER_POINTER, &packed_args,
@@ -187,7 +190,6 @@ PackedFunc ROCMModuleNode::GetFunction(
   CHECK_EQ(sptr_to_self.get(), this);
   CHECK_NE(name, symbol::tvm_module_main)
       << "Device function do not have main";
-
   auto it = fmap_.find(name);
   if (it == fmap_.end()) return PackedFunc();
   const FunctionInfo& info = it->second;

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -59,6 +59,12 @@ class ROCMModuleNode : public runtime::ModuleNode {
     stream->Write(data_);
   }
 
+  std::string GetSource(const std::string& format) final {
+    if(format == fmt_) return data_;
+    if(fmt_ == "hsaco") LOG(WARNING)<<"HSACO"; return data_;
+    return "";
+  }
+
   // get a CUfunction from primary context in device_id
   hipFunction_t GetFunc(int device_id, const std::string& func_name) {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -203,6 +203,7 @@ Module ROCMModuleCreate(
     std::string hip_source) {
   std::shared_ptr<ROCMModuleNode> n =
       std::make_shared<ROCMModuleNode>(data, fmt, fmap, hip_source);
+  LOG(WARNING) << hip_source;
   return Module(n);
 }
 

--- a/tests/python/integration/test_gemm.py
+++ b/tests/python/integration/test_gemm.py
@@ -85,11 +85,8 @@ def test_gemm():
         np.testing.assert_allclose(
             c.asnumpy(), np.dot(a_np, b_np.T), rtol=1e-5)
 
-<<<<<<< a45d3b01f7900010a9694c2b606dad22ddbe1768
-=======
     check_device("nvptx -mcpu=sm_20")
     check_device("rocm")
->>>>>>> added initial llvm codegen for amdgpu
     check_device("metal")
     check_device("opencl")
     check_device("cuda")

--- a/tests/python/integration/test_gemm.py
+++ b/tests/python/integration/test_gemm.py
@@ -85,6 +85,11 @@ def test_gemm():
         np.testing.assert_allclose(
             c.asnumpy(), np.dot(a_np, b_np.T), rtol=1e-5)
 
+<<<<<<< a45d3b01f7900010a9694c2b606dad22ddbe1768
+=======
+    check_device("nvptx -mcpu=sm_20")
+    check_device("rocm")
+>>>>>>> added initial llvm codegen for amdgpu
     check_device("metal")
     check_device("opencl")
     check_device("cuda")

--- a/tests/python/unittest/test_codegen_device.py
+++ b/tests/python/unittest/test_codegen_device.py
@@ -82,6 +82,7 @@ def test_add_pipeline():
     check_target("cuda", host="llvm")
     check_module_save("cuda", host="stackvm")
     check_target("nvptx", host="llvm")
+    check_target("rocm", host="llvm")
 
 if __name__ == "__main__":
     test_add_pipeline()


### PR DESCRIPTION
The test results:

``` shell
$ python test_gemm.py
skip because nvptx -mcpu=sm_20 is not enabled..
skip because rocm is not enabled..
skip because metal is not enabled..
skip because opencl is not enabled..
skip because cuda is not enabled..
$
```
``` shell
$ python test_codegen_device.py
$
```
