### PR TITLE
[TEST] Add memoize to save test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ jvm/*/*/target/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
-.pkl_memoize_cache
+.pkl_memoize_*
 
 .emscripten*
 .m2

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ jvm/*/*/target/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+.pkl_memoize_cache
 
 .emscripten*
 .m2

--- a/python/tvm/_ffi/ndarray.py
+++ b/python/tvm/_ffi/ndarray.py
@@ -253,7 +253,7 @@ def register_extension(cls):
 
     .. code-block:: python
 
-       @tvm.register_dltensor
+       @tvm.register_extension
        class MyTensor(object):
            def __init__(self):
                self.handle = _LIB.NewDLTensor()

--- a/python/tvm/contrib/pickle_memoize.py
+++ b/python/tvm/contrib/pickle_memoize.py
@@ -1,7 +1,7 @@
 """Memoize result of function via pickle, used for cache testcases."""
 # pylint: disable=broad-except,superfluous-parens
 import os
-
+import sys
 import atexit
 from decorator import decorate
 from .._ffi.base import string_types
@@ -20,9 +20,10 @@ class Cache(object):
     """
     cache_by_key = {}
     def __init__(self, key):
-        if not os.path.exists(".pkl_memoize_cache"):
-            os.mkdir(".pkl_memoize_cache")
-        self.path = os.path.join(".pkl_memoize_cache", key)
+        cache_dir = ".pkl_memoize_py{0}".format(sys.version_info[0])
+        if not os.path.exists(cache_dir):
+            os.mkdir(cache_dir)
+        self.path = os.path.join(cache_dir, key)
         if os.path.exists(self.path):
             try:
                 self.cache = pickle.load(open(self.path, "rb"))

--- a/python/tvm/contrib/pickle_memoize.py
+++ b/python/tvm/contrib/pickle_memoize.py
@@ -55,8 +55,8 @@ def memoize(key):
 
     Returns
     -------
-    fregister : function
-        Register function.
+    fmemoize : function
+        The decorator function to perform memoization.
     """
     def _register(f):
         """Registration function"""

--- a/python/tvm/contrib/pickle_memoize.py
+++ b/python/tvm/contrib/pickle_memoize.py
@@ -1,0 +1,90 @@
+"""Memoize result of function via pickle, used for cache testcases."""
+# pylint: disable=broad-except,superfluous-parens
+import os
+
+import atexit
+from decorator import decorate
+from .._ffi.base import string_types
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+class Cache(object):
+    """A cache object for result cache.
+
+    Parameters
+    ----------
+    key: str
+       The file key to the function
+    """
+    cache_by_key = {}
+    def __init__(self, key):
+        if not os.path.exists(".pkl_memoize_cache"):
+            os.mkdir(".pkl_memoize_cache")
+        self.path = os.path.join(".pkl_memoize_cache", key)
+        if os.path.exists(self.path):
+            try:
+                self.cache = pickle.load(open(self.path, "rb"))
+            except Exception:
+                self.cache = {}
+        else:
+            self.cache = {}
+        self.dirty = False
+
+    def save(self):
+        if self.dirty:
+            print("Save memoize result to %s" % self.path)
+            with open(self.path, "wb") as out_file:
+                pickle.dump(self.cache, out_file, pickle.HIGHEST_PROTOCOL)
+
+@atexit.register
+def _atexit():
+    """Save handler."""
+    for value in Cache.cache_by_key.values():
+        value.save()
+
+
+def memoize(key):
+    """Memoize the result of function and reuse multiple times.
+
+    Parameters
+    ----------
+    key: str
+        The unique key to the file
+
+    Returns
+    -------
+    fregister : function
+        Register function.
+    """
+    def _register(f):
+        """Registration function"""
+        allow_types = (string_types, int, float)
+        fkey = key + "." + f.__name__ + ".pkl"
+        if fkey not in Cache.cache_by_key:
+            Cache.cache_by_key[fkey] = Cache(fkey)
+        cache = Cache.cache_by_key[fkey]
+        cargs = tuple(x.cell_contents for x in f.__closure__)
+        cargs = (len(cargs),) + cargs
+
+        def _memoized_f(func, *args, **kwargs):
+            assert not kwargs, "Only allow positional call"
+            key = cargs + args
+            for arg in key:
+                if isinstance(arg, tuple):
+                    for x in arg:
+                        assert isinstance(x, allow_types)
+                else:
+                    assert isinstance(arg, allow_types)
+            if key in cache.cache:
+                print("Use memoize {0}{1}".format(fkey, key))
+                return cache.cache[key]
+            res = func(*args)
+            cache.cache[key] = res
+            cache.dirty = True
+            return res
+
+        return decorate(f, _memoized_f)
+
+    return _register

--- a/topi/tests/python/test_topi_conv2d_nchw.py
+++ b/topi/tests/python/test_topi_conv2d_nchw.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import tvm
 import topi
+from tvm.contrib.pickle_memoize import memoize
 from topi.util import get_const_tuple
 
 
@@ -16,10 +17,19 @@ def verify_conv2d_nchw(batch, in_channel, in_size, num_filter, kernel, stride, p
     s1 = topi.cuda.schedule_conv2d_nchw([B])
     s2 = topi.cuda.schedule_conv2d_nchw([C])
 
-    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
-    w_np = np.random.uniform(size=get_const_tuple(W.shape)).astype(W.dtype)
-    b_np = topi.testing.conv2d_nchw_python(a_np, w_np, stride, padding)
-    c_np = np.maximum(b_np, 0)
+    a_shape = get_const_tuple(A.shape)
+    w_shape = get_const_tuple(W.shape)
+    dtype = A.dtype
+
+    @memoize("topi.tests.test_topi_conv2d.verify_con2d_nchw")
+    def get_ref_data():
+        a_np = np.random.uniform(size=a_shape).astype(dtype)
+        w_np = np.random.uniform(size=w_shape).astype(dtype)
+        b_np = topi.testing.conv2d_nchw_python(a_np, w_np, stride, padding)
+        c_np = np.maximum(b_np, 0)
+        return a_np, w_np, b_np, c_np
+
+    a_np, w_np, b_np, c_np = get_ref_data()
 
     def check_device(device):
         if not tvm.module.enabled(device):


### PR DESCRIPTION
Quite a few of our topi testcases relies on a reference numpy/scipy implementation which can be quite slow. This PR introduce a memoize function that tries to remember the input result pair generated by the function and pickle them to a ```.pkl_memoize_py2```  (or py3) folder, so next time function is called, the result is fetched from cache. This can enable cache across multiple run of testcase if CI workspace is preserved (which is our case)

The cache is done with keys in closure and function arguments, I have updated the testcases to use this syntax. In order to guarantee correctness, the restriction is that the memoized function can only capture or take int, str, float or tuple of them and these are used as cache key.
