### PR TITLE
[LLVM] Protect ll module when call emit pass

### DIFF
--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -147,14 +147,16 @@ runtime::Module BuildNVPTX(Array<LoweredFunc> funcs, std::string target) {
   llvm::raw_svector_ostream dest_ptx(data_ptx), dest_ll(data_ll);
   dest_ptx.SetUnbuffered();
   dest_ll.SetUnbuffered();
+  // print ll
+  module->print(dest_ll, nullptr);
+  std::string ll(data_ll.begin(), data_ll.end());
+  // emit ptx
   llvm::legacy::PassManager pass;
   CHECK(tm->addPassesToEmitFile(
       pass, dest_ptx, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
   pass.run(*module);
-  module->print(dest_ll, nullptr);
   std::string ptx(data_ptx.begin(), data_ptx.end());
-  std::string ll(data_ll.begin(), data_ll.end());
   return CUDAModuleCreate(ptx, "ptx", ExtractFuncInfo(funcs), ll);
 }
 

--- a/src/codegen/llvm/llvm_common.h
+++ b/src/codegen/llvm/llvm_common.h
@@ -28,6 +28,7 @@
 #include <llvm/IR/MDBuilder.h>
 
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Transforms/IPO.h>

--- a/src/codegen/llvm/llvm_module.cc
+++ b/src/codegen/llvm/llvm_module.cc
@@ -68,19 +68,21 @@ class LLVMModuleNode final : public runtime::ModuleNode {
     CHECK_EQ(ecode.value(), 0) << "Cannot open file: " << file_name
                                << " " << ecode.message();
     if (fmt == "o" || fmt == "obj") {
+      std::unique_ptr<llvm::Module> m = llvm::CloneModule(mptr_);
       llvm::legacy::PassManager pass;
       CHECK(tm_);
       CHECK(tm_->addPassesToEmitFile(
           pass, dest, llvm::TargetMachine::CGFT_ObjectFile) == 0)
           << "Cannot emit target CGFT_ObjectFile";
-      pass.run(*mptr_);
+      pass.run(*m);
     } else if (fmt == "s" || fmt == "asm") {
+      std::unique_ptr<llvm::Module> m = llvm::CloneModule(mptr_);
       llvm::legacy::PassManager pass;
       CHECK(tm_);
       CHECK(tm_->addPassesToEmitFile(
           pass, dest, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
           << "Cannot emit target CGFT_AssemblyFile";
-      pass.run(*mptr_);
+      pass.run(*m);
     } else if (fmt == "ll") {
       mptr_->print(dest, nullptr);
     } else if (fmt == "bc") {


### PR DESCRIPTION
clone them before calling emit as emit can mutate the module