### PR TITLE
[DOCS] Add prerequisites about zlib1g-dev

### DIFF
--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -50,7 +50,7 @@ Install prerequisites first:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python python-setuptools gcc libtinfo-dev zlib1g-dev
+sudo apt-get install -y python python-dev python-setuptools gcc libtinfo-dev zlib1g-dev
 ```
 
 The configuration of tvm can be modified by ```config.mk```

--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -50,7 +50,7 @@ Install prerequisites first:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python gcc libtinfo-dev zlib1g-dev
+sudo apt-get install -y python python-setuptools gcc libtinfo-dev zlib1g-dev
 ```
 
 The configuration of tvm can be modified by ```config.mk```

--- a/docs/how_to/install.md
+++ b/docs/how_to/install.md
@@ -50,7 +50,7 @@ Install prerequisites first:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y python gcc libtinfo-dev
+sudo apt-get install -y python gcc libtinfo-dev zlib1g-dev
 ```
 
 The configuration of tvm can be modified by ```config.mk```


### PR DESCRIPTION
Add prerequisites about zlib1g-dev. It occurs `/usr/bin/ld: cannot find -lz` without zlib1g-dev installation.