### PR TITLE
Case-sensitive CMake module for OpenCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ else(USE_CUDA)
 endif(USE_CUDA)
 
 if(USE_OPENCL)
-  find_package(OPENCL QUIET REQUIRED)
+  find_package(OpenCL QUIET REQUIRED)
   message(STATUS "Build with OpenCL support")
   include_directories(${OPENCL_INCLUDE_DIRS})
   list(APPEND TVM_RUNTIME_LINKER_LIBS ${OpenCL_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ else(USE_OPENCL)
 endif(USE_OPENCL)
 
 if(USE_METAL)
-  find_package(OPENCL QUIET REQUIRED)
+  find_package(OpenCL QUIET REQUIRED)
   message(STATUS "Build with Metal support")
   FIND_LIBRARY(METAL_LIB Metal)
   FIND_LIBRARY(FOUNDATION_LIB Foundation)


### PR DESCRIPTION
Case-sensitive CMake module for OpenCL, see https://github.com/Kitware/CMake/blob/master/Modules/FindOpenCL.cmake .