### PR TITLE
rocm runtime fix. set default gcn arch to be gfx803

### DIFF
--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -136,7 +136,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
   llvm::TargetMachine* tm = \
-    GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx900" + \
+    GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx803" + \
     target.substr(4, target.length() - 4));
 
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -152,7 +152,7 @@ class ROCMWrappedFunc {
 
     ThreadWorkLoad wl = thread_axis_cfg_.Extract(args);
     void* config[] = {
-      HIP_LAUNCH_PARAM_BUFFER_POINTER, &packed_args,
+      HIP_LAUNCH_PARAM_BUFFER_POINTER, packed_args,
       HIP_LAUNCH_PARAM_BUFFER_SIZE, &packed_nbytes,
       HIP_LAUNCH_PARAM_END
     };


### PR DESCRIPTION
This commit enables passing test_codegen_device.py and test_gemm.py with rocm backend.