### PR TITLE
[CODEGEN] Skip unrolled hint, export symbol on win32

### DIFF
--- a/src/codegen/codegen.cc
+++ b/src/codegen/codegen.cc
@@ -46,10 +46,15 @@ std::string PackImportsToC(const runtime::Module& mod, bool system_lib) {
   }
   // translate to C program
   std::ostringstream os;
+  os << "#ifdef _WIN32\n"
+     << "#define TVM_EXPORT __declspec(dllexport)\n"
+     << "#else\n"
+     << "#define TVM_EXPORT\n"
+     << "#endif\n";
   os << "#ifdef __cplusplus\n"
      << "extern \"C\" {\n"
      << "#endif\n";
-  os << "extern const char " << runtime::symbol::tvm_dev_mblob << "[];\n";
+  os << "TVM_EXPORT extern const char " << runtime::symbol::tvm_dev_mblob << "[];\n";
   uint64_t nbytes = bin.length();
   os << "const char " << runtime::symbol::tvm_dev_mblob
      << "[" << bin.length() + sizeof(nbytes) << "] = {\n  ";
@@ -82,7 +87,6 @@ std::string PackImportsToC(const runtime::Module& mod, bool system_lib) {
   os << "#ifdef __cplusplus\n"
      << "}\n"
      << "#endif\n";
-
   return os.str();
 }
 }  // namespace codegen

--- a/src/codegen/llvm/codegen_cpu.cc
+++ b/src/codegen/llvm/codegen_cpu.cc
@@ -697,7 +697,8 @@ void CodeGenCPU::VisitStmt_(const AttrStmt* op) {
 
 void CodeGenCPU::VisitStmt_(const For* op) {
   CHECK(is_zero(op->min));
-  if (op->for_type == ForType::Serial) {
+  if (op->for_type == ForType::Serial ||
+      op->for_type == ForType::Unrolled) {
     CodeGenLLVM::VisitStmt_(op);
   } else if (op->for_type == ForType::Parallel) {
     if (parallel_env_.penv == nullptr) {

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -891,7 +891,12 @@ void CodeGenLLVM::VisitStmt_(const Store* op) {
 
 void CodeGenLLVM::VisitStmt_(const For* op) {
   CHECK(is_zero(op->min));
-  CHECK(op->for_type == ForType::Serial);
+  if (op->for_type == ForType::Unrolled) {
+    LOG(WARNING) << "Unroll hint get ignore at CodeGenLLVM backend, "
+                 << " consider set unroll_explicit=True";
+  } else {
+    CHECK(op->for_type == ForType::Serial);
+  }
   CreateSerialFor(MakeValue(op->min), MakeValue(op->extent),
                   ConstInt32(1), op->loop_var, op->body);
 }


### PR DESCRIPTION
cc @yajiedesign This might help the export library work on win32