### PR TITLE
added support for rocm gpu autodetect

### DIFF
--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -141,9 +141,9 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   tvmCtx.device_id = 0;
   TVMRetValue val;
   tvm::runtime::DeviceAPI::Get(tvmCtx)->GetAttr(tvmCtx, tvm::runtime::kExist, &val);
-  if(val.operator int() == 1) {
+  if (val.operator int() == 1) {
     tvm::runtime::DeviceAPI::Get(tvmCtx)->GetAttr(tvmCtx, tvm::runtime::kComputeVersion, &val);
-  }else{
+  } else {
     val = 803;
   }
 

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -135,9 +135,15 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   CHECK(target.length(
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
+  TVMContext tvmCtx;
+  tvmCtx.device_type = kROCM;
+  tvmCtx.device_id = 0;
+  TVMRetValue val;
+  tvm::runtime::DeviceAPI::Get(tvmCtx)->GetAttr(tvmCtx, tvm::runtime::kComputeVersion, &val);
+
   llvm::TargetMachine* tm = \
-    GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx803" + \
-    target.substr(4, target.length() - 4));
+    GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx" + \
+    std::to_string(int(val)) + target.substr(4, target.length() - 4));
 
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -143,7 +143,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 
   llvm::TargetMachine* tm = \
     GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx" + \
-    std::to_string(int(val)) + target.substr(4, target.length() - 4));
+    std::to_string(static_cast<int>(val)) + target.substr(4, target.length() - 4));
 
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -135,15 +135,21 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   CHECK(target.length(
 ) >= 4 &&
         target.substr(0, 4) == "rocm");
+
   TVMContext tvmCtx;
   tvmCtx.device_type = kROCM;
   tvmCtx.device_id = 0;
   TVMRetValue val;
-  tvm::runtime::DeviceAPI::Get(tvmCtx)->GetAttr(tvmCtx, tvm::runtime::kComputeVersion, &val);
+  tvm::runtime::DeviceAPI::Get(tvmCtx)->GetAttr(tvmCtx, tvm::runtime::kExist, &val);
+  if(val.operator int() == 1) {
+    tvm::runtime::DeviceAPI::Get(tvmCtx)->GetAttr(tvmCtx, tvm::runtime::kComputeVersion, &val);
+  }else{
+    val = 803;
+  }
 
   llvm::TargetMachine* tm = \
     GetLLVMTargetMachine("-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx" + \
-    std::to_string(static_cast<int>(val)) + target.substr(4, target.length() - 4));
+    std::to_string(val.operator int())+ target.substr(4, target.length() - 4));
 
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -47,7 +47,7 @@ class ROCMDeviceAPI final : public DeviceAPI {
       case kComputeVersion:
         hipDeviceProp_t prop;
         ROCM_CALL(hipGetDeviceProperties(&prop, ctx.device_id));
-        value = prop.gcnArch;
+        *rv = prop.gcnArch;
         return;
     }
     *rv = value;

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -44,7 +44,11 @@ class ROCMDeviceAPI final : public DeviceAPI {
         value = 64;
         break;
       }
-      case kComputeVersion: return;
+      case kComputeVersion:
+        hipDeviceProp_t prop;
+        ROCM_CALL(hipGetDeviceProperties(&prop, ctx.device_id));
+        value = prop.gcnArch;
+        return;
     }
     *rv = value;
   }


### PR DESCRIPTION
Generates IR and kernel object files depending on the rocm gpu present in the system.