### PR TITLE
enable rocm target for topi/recipes. add timing util to gemm test.

### DIFF
--- a/topi/recipe/conv/depthwise_conv2d_test.py
+++ b/topi/recipe/conv/depthwise_conv2d_test.py
@@ -69,7 +69,7 @@ def test_depthwise_conv2d_nchw():
         if not tvm.module.enabled(device):
             print("Skip because %s is not enabled" % device)
             return
-        ctx = tvm.gpu(0) if device == "cuda" else tvm.cl(0)
+        ctx = tvm.context(device, 0)
         # Build the kernel
         f1 = tvm.build(s1, [Input, Filter, DepthwiseConv2d], device)
         f2 = tvm.build(s2, [Input, Filter, Scale, Shift, ScaleShift], device)
@@ -111,12 +111,13 @@ def test_depthwise_conv2d_nchw():
         np.testing.assert_allclose(relu_tvm.asnumpy(), relu_scipy, rtol=1e-5)
         print("success")
 
-    with tvm.build_config(auto_unroll_max_step=32,
-                          auto_unroll_min_depth=0,
-                          unroll_explicit=False,
-                          detect_global_barrier=False,
-                          restricted_func=True):
-        check_device("cuda")
+    for device in ['cuda', 'opencl', 'rocm']:
+        with tvm.build_config(auto_unroll_max_step=32,
+                              auto_unroll_min_depth=0,
+                              unroll_explicit=device == 'rocm',
+                              detect_global_barrier=False,
+                              restricted_func=True):
+            check_device(device)
 
 def test_depthwise_conv2d_nhwc():
     """You may test different settings."""
@@ -159,7 +160,7 @@ def test_depthwise_conv2d_nhwc():
         if not tvm.module.enabled(device):
             print("Skip because %s is not enabled" % device)
             return
-        ctx = tvm.gpu(0) if device == "cuda" else tvm.cl(0)
+        ctx = tvm.context(device, 0)
         # Build the kernel
         f1 = tvm.build(s1, [Input, Filter, DepthwiseConv2d], device)
         f2 = tvm.build(s2, [Input, Filter, Scale, Shift, ScaleShift], device)
@@ -200,12 +201,13 @@ def test_depthwise_conv2d_nhwc():
         np.testing.assert_allclose(relu_tvm.asnumpy(), relu_scipy, rtol=1e-5)
         print("success")
 
-    with tvm.build_config(auto_unroll_max_step=32,
-                          auto_unroll_min_depth=0,
-                          unroll_explicit=False,
-                          detect_global_barrier=False,
-                          restricted_func=True):
-        check_device("cuda")
+    for device in ['cuda', 'opencl', 'rocm']:
+        with tvm.build_config(auto_unroll_max_step=32,
+                              auto_unroll_min_depth=0,
+                              unroll_explicit=device == 'rocm',
+                              detect_global_barrier=False,
+                              restricted_func=True):
+            check_device(device)
 
 if __name__ == "__main__":
     test_depthwise_conv2d_nchw()

--- a/topi/recipe/conv/test_conv2d_hwcn_map.py
+++ b/topi/recipe/conv/test_conv2d_hwcn_map.py
@@ -5,7 +5,7 @@ import scipy.signal
 import tvm
 from tvm.contrib import nvcc
 import topi
-from topi.nn.util import get_const_tuple
+from topi.util import get_const_tuple
 
 TASK = "conv2d_hwcn_map"
 USE_MANUAL_CODE = False
@@ -55,14 +55,14 @@ def test_conv2d_hwcn_map():
         if not tvm.module.enabled(device):
             print("Skip because %s is not enabled" % device)
             return
-        ctx = tvm.gpu(0) if device == "cuda" else tvm.cl(0)
+        ctx = tvm.context(device, 0)
         a = tvm.nd.array(a_np, ctx)
         w = tvm.nd.array(w_np, ctx)
         b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), ctx)
         c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), ctx)
         with tvm.build_config(auto_unroll_max_step=32,
                               auto_unroll_min_depth=0,
-                              unroll_explicit=False):
+                              unroll_explicit=device == 'rocm'):
             func1 = tvm.build(s1, [A, W, B], device)
             func1(a, w, b)
             np.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
@@ -70,7 +70,7 @@ def test_conv2d_hwcn_map():
             func2(a, w, c)
             np.testing.assert_allclose(c.asnumpy(), c_np, rtol=1e-5)
 
-    for device in ['cuda', 'opencl']:
+    for device in ['cuda', 'opencl', 'rocm']:
         check_device(device)
 
 


### PR DESCRIPTION
This commit adds three more tests for rocm backend. All three tests pass.

The import path of get_const_tuple was updated from topi.nn.util to topi.util, following recent change.
  
On R9 Nano, the added timing utility for the gemm recipe shows the following output. Note the difference in performance between OpenCL and Rocm backend.

$ python cuda_gemm_square.py 
Device cuda
Skip because cuda is not enabled
**Device opencl**
[18:43:46] src/runtime/opencl/opencl_device_api.cc:195: Initialize OpenCL platform 'AMD Accelerated Parallel Processing'
[18:43:46] src/runtime/opencl/opencl_device_api.cc:215: opencl(0)='gfx803' cl_device_id=0x7f2277ed4670
average time cost of 10 runs = 3.6301 ms, **4732.62** GFLOPS.
**Device rocm**
average time cost of 10 runs = 3.305 ms, **5198.14** GFLOPS.
