### PR TITLE
[PYTHON] Improve equality wrapper

### DIFF
--- a/python/tvm/expr.py
+++ b/python/tvm/expr.py
@@ -152,6 +152,9 @@ class EqualOp(NodeGeneric, ExprOp):
     b : Expr
         Right operand.
     """
+    # This class is not manipulated by C++. So use python's identity check function is sufficient
+    same_as = object.__eq__
+
     def __init__(self, a, b):
         self.a = a
         self.b = b
@@ -181,6 +184,9 @@ class NotEqualOp(NodeGeneric, ExprOp):
     b : Expr
         Right operand.
     """
+    # This class is not manipulated by C++. So use python's identity check function is sufficient
+    same_as = object.__eq__
+
     def __init__(self, a, b):
         self.a = a
         self.b = b

--- a/tests/python/unittest/test_lang_basic.py
+++ b/tests/python/unittest/test_lang_basic.py
@@ -134,6 +134,14 @@ def test_bitwise():
     assert str(~x) == 'bitwise_not(x)'
 
 
+def test_equality():
+    a = tvm.var('a')
+    b = tvm.var('b')
+    c = (a == b)
+    assert not c
+    d = (c != c)
+    assert not d
+
 if __name__ == "__main__":
     test_cast()
     test_attr()
@@ -148,3 +156,4 @@ if __name__ == "__main__":
     test_any()
     test_all()
     test_bitwise()
+    test_equality()


### PR DESCRIPTION
use `object.__eq__`(default object identity comparison) as default
implementation of same_as. This should be OK since `EqualOp` and
`NotEqualOp` are pure Python object, `object.__eq__` is sufficient.