### PR TITLE
[SCHEDULE] Detect duplicate IterVar in reorder

### DIFF
--- a/src/schedule/schedule_lang.cc
+++ b/src/schedule/schedule_lang.cc
@@ -259,6 +259,7 @@ Stage& Stage::fuse(IterVar outer, IterVar inner, IterVar* p_target) {  // NOLINT
 }
 
 Stage& Stage::reorder(const Array<IterVar>& order) {  // NOLINT(*)
+  std::unordered_set<IterVar> seen_var;
   StageNode* self = operator->();
   for (IterVar iv : order) {
     CHECK(iv->iter_type == kDataPar ||
@@ -266,6 +267,10 @@ Stage& Stage::reorder(const Array<IterVar>& order) {  // NOLINT(*)
           iv->iter_type == kThreadIndex)
         << "Cannot reorder IterVar("
         << IterVarType2String(iv->iter_type) << ")";
+
+    CHECK_EQ(seen_var.count(iv), 0)
+        << "Same axis can not appear more than once " << iv;
+    seen_var.insert(iv);
   }
   ArrayNode* all_vars = self->all_iter_vars.CopyOnWrite();
   ArrayNode* leaf_vars = self->leaf_iter_vars.CopyOnWrite();

--- a/tests/python/unittest/test_lang_schedule.py
+++ b/tests/python/unittest/test_lang_schedule.py
@@ -43,6 +43,13 @@ def test_reorder():
     assert tuple(s[T].leaf_iter_vars) != order
     s[T].reorder(*order)
     assert tuple(s[T].leaf_iter_vars) == order
+    try:
+        # pass duplicate IterVar
+        # must raise an error
+        s[T].reorder(xi2, xi1, xi2)
+        assert False
+    except tvm.TVMError:
+        pass
 
 def test_split():
     m = tvm.var('m')


### PR DESCRIPTION
Test output:
````
➜  tvm git:(check-duplicate-cpp) ✗ python3 -m nose tests/python/unittest/test_lang_schedule.py
.[20:46:17] /Users/weichen/workspace/deep-learning/tvm/dmlc-core/include/dmlc/logging.h:308: [20:46:17] src/schedule/schedule_lang.cc:271: Check failed: seen_var.count(iv) == 0 (1 vs. 0) Same axis can not appear more than once iter_var(i.inner.inner, )

Stack trace returned 6 entries:
[bt] (0) 0   libtvm.dylib                        0x000000010f2d9ed8 _ZN4dmlc15LogMessageFatalD2Ev + 40
[bt] (1) 1   libtvm.dylib                        0x000000010f4afefe _ZN3tvm5Stage7reorderERKNS_5ArrayINS_7IterVarEvEE + 2606
[bt] (2) 2   libtvm.dylib                        0x000000010f300470 _ZNSt3__110__function6__funcIN3tvm4$_38ENS_9allocatorIS3_EEFvNS2_7runtime7TVMArgsEPNS6_11TVMRetValueEEEclEOS7_OS9_ + 112
[bt] (3) 3   libtvm.dylib                        0x000000010f62cccb TVMFuncCall + 75
[bt] (4) 4   _ctypes.cpython-36m-darwin.so       0x000000010ead343f ffi_call_unix64 + 79
[bt] (5) 5   ???                                 0x00007fff52353650 0x0 + 140734572607056

........
----------------------------------------------------------------------
Ran 9 tests in 0.027s
````