### PR TITLE
[ROCM] View llvm ir and gcn asm with module.get_source(...)

### DIFF
--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -202,7 +202,7 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
       << "Cannot emit target CGFT_AssemblyFile";
   passAsm.run(*mAsm);
   std::string assembly(dataAsm.begin(), dataAsm.end());
-  
+
   const auto* f = tvm::runtime::Registry::Get("tvm_callback_rocm_link");
   CHECK(f != nullptr) << "Require tvm_callback_rocm_link to exist, do import tvm.contrib.rocm";
 

--- a/src/runtime/rocm/rocm_module.h
+++ b/src/runtime/rocm/rocm_module.h
@@ -31,7 +31,8 @@ Module ROCMModuleCreate(
     std::string data,
     std::string fmt,
     std::unordered_map<std::string, FunctionInfo> fmap,
-    std::string rocm_source);
+    std::string rocm_source,
+    std::string assembly);
 }  // namespace runtime
 }  // namespace tvm
 #endif  // TVM_RUNTIME_ROCM_ROCM_MODULE_H_


### PR DESCRIPTION
Enables viewing generated LLVM IR or GCN assembly with:

```
dev_module = func.imported_modules[0]
print(dev_module.get_source("llvm"))
print(dev_module.get_source("asm"))
```
