### PR TITLE
[ROCM] remove fma dispatch

### DIFF
--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -29,6 +29,8 @@ namespace llvm {
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.exp")
 .set_body(DispatchExternOCML);
 
+// On AMD GPU, fma is slower than mac
+// removing fma dispatch allows backend to generate faster mac instruction 
 // TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.fma")
 // .set_body(DispatchExternOCML);
 

--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -30,7 +30,7 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.exp")
 .set_body(DispatchExternOCML);
 
 // On AMD GPU, fma is slower than mac
-// removing fma dispatch allows backend to generate faster mac instruction 
+// removing fma dispatch allows backend to generate faster mac instruction
 // TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.fma")
 // .set_body(DispatchExternOCML);
 

--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -29,8 +29,8 @@ namespace llvm {
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.exp")
 .set_body(DispatchExternOCML);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.fma")
-.set_body(DispatchExternOCML);
+// TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.fma")
+// .set_body(DispatchExternOCML);
 
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.log")
 .set_body(DispatchExternOCML);

--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -31,8 +31,8 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.exp")
 
 // On AMD GPU, fma is slower than mac
 // removing fma dispatch allows backend to generate faster mac instruction
-// TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.fma")
-// .set_body(DispatchExternOCML);
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.fma")
+.set_body(DispatchLLVMPureIntrin<::llvm::Intrinsic::fmuladd, 1>);
 
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.log")
 .set_body(DispatchExternOCML);


### PR DESCRIPTION
Turned out fma instruction was causing severe performance regression for gemm and resnet inference.
For gemm, it dropped to 1800 GFLOPs from 5200 GFLOPs. 

Removing fma instruction dispatch allows LLVM AMDGPU backend to generate mac instruction instead, which solved the performance regression problem.