### PR TITLE
[ROCM] add tanh dispatch

### DIFF
--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -43,6 +43,8 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.sqrt")
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.pow")
 .set_body(DispatchExternOCML);
 
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.rocm.tanh")
+.set_body(DispatchExternOCML);
 }  // namespace llvm
 }  // namespace codegen
 }  // namespace tvm


### PR DESCRIPTION
tanh support is required for running DCGAN and neural style, etc.
OCML has __ocml_tanh_f32 built in, so this is the only change needed.