### PR TITLE
remove minimum 32-bit restriction

### DIFF
--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -127,7 +127,7 @@ inline void TVMArrayFree_(TVMArray* arr) {
 inline void VerifyType(int dtype_code, int dtype_bits, int dtype_lanes) {
   CHECK_GE(dtype_lanes, 1);
   if (dtype_code == kDLFloat) {
-    CHECK_EQ(dtype_bits % 32, 0);
+    CHECK_EQ(dtype_bits % 8, 0);
   } else {
     CHECK_EQ(dtype_bits % 8, 0);
   }


### PR DESCRIPTION
Change minimum 32-bit restriction for floating point types to 8-bit.
This change is to enable reduced precision types that may use vector operations underneath the hood (cases where #lanes > 1 such as half4).