### PR TITLE
Fix long for windows in cuda

### DIFF
--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -81,9 +81,18 @@ void CodeGenCUDA::PrintType(Type t, std::ostream& os) {  // NOLINT(*)
       case 16: os << "short"; break;
       case 32: os << "int"; break;
       case 64: {
-        CHECK(sizeof(long) == 8)  // NOLINT(*)
-            << "CUDA not support int64 int in 32 bit system";
-        os << "long"; break;
+        if (sizeof(long) != 8) {
+          if (t.lanes() == 1) {
+            os << "long long"; break;
+          } else if (t.lanes() == 2) {
+            os << "longlong"; break;
+          } else {
+            // No longlong3, longlong4
+            LOG(FATAL) << "Cannot convert type " << t << " to CUDA type on a L32 platform";
+          }
+        } else {
+          os << "long"; break;
+        }
       }
       case 1: os << "int"; break;
       default: fail = true; break;

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -87,7 +87,7 @@ void CodeGenCUDA::PrintType(Type t, std::ostream& os) {  // NOLINT(*)
       case 16: os << "short"; break;
       case 32: os << "int"; break;
       case 64: {
-        if (sizeof(long) != 8) {
+        if (sizeof(long) != 8) { // NOLINT(*)
           if (t.lanes() == 1) {
             os << "long long"; break;
           } else if (t.lanes() == 2) {

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -77,7 +77,13 @@ void CodeGenCUDA::PrintType(Type t, std::ostream& os) {  // NOLINT(*)
       os << "int"; return;
     }
     switch (t.bits()) {
-      case 8: os << "char"; break;
+      case 8: {
+        if (!t.is_uint() && t.lanes() == 1) {
+          os << "signed char"; break;
+        } else {
+          os << "char"; break;
+        }
+      }
       case 16: os << "short"; break;
       case 32: os << "int"; break;
       case 64: {


### PR DESCRIPTION
I've noticed that #683 fixes use of long scalars, but the code will break on windows since sizeof(long) is 4 there.  However we can use long long in these cases so I did that.