### PR TITLE
Simplify expressions early on

### DIFF
--- a/src/arithmetic/int_set.cc
+++ b/src/arithmetic/int_set.cc
@@ -27,7 +27,7 @@ inline IntSet IntSet::cover_interval() const {
     for (size_t i = 0; i < s->extents.size(); ++i) {
       max = max + s->extents[i] * s->strides[i] - s->strides[i];
     }
-    return IntervalSet::make(s->base.min, max);
+    return IntervalSet::make(s->base.min, Simplify(max));
   }
   LOG(FATAL) << "cannot convert set " << (*this)->type_key() << " to interval";
   return IntSet::everything();

--- a/src/schedule/bound.cc
+++ b/src/schedule/bound.cc
@@ -8,6 +8,7 @@
 #include <tvm/operation.h>
 #include <unordered_map>
 #include <unordered_set>
+#include <tvm/ir_pass.h>
 #include "./graph.h"
 #include "./message_passing.h"
 #include "../runtime/thread_storage_scope.h"
@@ -208,6 +209,10 @@ Map<IterVar, Range> InferBound(const Schedule& sch) {
       CHECK(iv->dom.defined());
       ret[iv] = iv->dom;
     }
+  }
+  for (auto& p : ret) {
+    ret[p.first] = Range::make_by_min_extent(ir::Simplify(p.second->min),
+                                             ir::Simplify(p.second->extent));
   }
   return Map<IterVar, Range>(ret.begin(), ret.end());
 }

--- a/src/schedule/bound.cc
+++ b/src/schedule/bound.cc
@@ -6,9 +6,9 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/schedule_pass.h>
 #include <tvm/operation.h>
+#include <tvm/ir_pass.h>
 #include <unordered_map>
 #include <unordered_set>
-#include <tvm/ir_pass.h>
 #include "./graph.h"
 #include "./message_passing.h"
 #include "../runtime/thread_storage_scope.h"


### PR DESCRIPTION
This is a minor fix. It's to avoid (possibly) unsimplified expressions propagating through the whole program. I found these points (in which I have added simplification) the closest to the place the expressions are generated.