### PR TITLE
Make duplicated function name checker working

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,3 +36,4 @@ List of Contributors
 - [Jian Weng](https://github.com/were)
 - [Masahiro Masuda](https://github.com/masahi)
 - [Haolong Zhang](https://github.com/haolongzhangm)
+- [Cody Hao Yu](https://github.com/comaniac)

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -310,6 +310,7 @@ def build(sch,
             raise ValueError("sch have to be Schedule, LoweredFunc or list of LoweredFunc")
         if x.name in fname_set:
             raise ValueError("Duplicate function name %s" % x.name)
+        fname_set.add(x.name)
 
     target = _target.current_target() if target is None else target
     target = _target.create(target) if target else _target.create("llvm")


### PR DESCRIPTION
Add the traversed function name to the temporary set so that the duplicated function name could be caught.