### PR TITLE
Fix lib64 not found error when building with cuda for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,11 @@ RUNTIME_DEP = $(RUNTIME_OBJ)
 ifdef CUDA_PATH
 	NVCC=$(CUDA_PATH)/bin/nvcc
 	CFLAGS += -I$(CUDA_PATH)/include
-	LDFLAGS += -L$(CUDA_PATH)/lib64
+	ifeq ($(UNAME_S),Darwin)
+		LDFLAGS += -L$(CUDA_PATH)/lib
+	else
+		LDFLAGS += -L$(CUDA_PATH)/lib64
+	endif
 endif
 
 ifeq ($(USE_CUDA), 1)


### PR DESCRIPTION
When building TVM for macOS, I would like to enable CUDA if my computer has such a GPU available. OSX stores the cuda libraries in `$(CUDA_PATH)/lib`, not `$(CUDA_PATH)/lib64` as it is in linux based systems.