### PR TITLE
Disable OpenGL test temporary

### DIFF
--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -17,5 +17,7 @@ TVM_FFI=cython python -m nose -v tests/python/integration || exit -1
 TVM_FFI=ctypes python3 -m nose -v tests/python/integration || exit -1
 TVM_FFI=cython python -m nose -v tests/python/contrib || exit -1
 TVM_FFI=ctypes python3 -m nose -v tests/python/contrib || exit -1
-TVM_FFI=cython python -m nose -v tests/webgl || exit -1
-TVM_FFI=ctypes python3 -m nose -v tests/webgl || exit -1
+
+# Do not enabke OpenGL
+# TVM_FFI=cython python -m nose -v tests/webgl || exit -1
+# TVM_FFI=ctypes python3 -m nose -v tests/webgl || exit -1


### PR DESCRIPTION
cc @phisiart Seems that the current docker environment cannot run OpenGL (report X11 is display env is missing). This is because the test docker env may not have display connected. Let us find a solution to this problem then re-enable the test 