### PR TITLE
[Compilation Warning Fix] comparison between signed and unsigned integer expressions

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -386,7 +386,7 @@ void GraphRuntime::LoadDLTensor(dmlc::Stream* strm, DLTensor* dst) {
   for (int i = 0; i < dst->ndim; ++i) {
     size *= dst->shape[i];
   }
-  int64_t data_byte_size;
+  uint64_t data_byte_size;
   CHECK(strm->Read(&data_byte_size, sizeof(data_byte_size)))
       << "Invalid DLTensor file format";
   CHECK(data_byte_size == size)


### PR DESCRIPTION
The compilation warning is fixed. 
src/runtime/graph/graph_runtime.cc:392:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   CHECK(data_byte_size == size)
         ~~~~~~~~~~~~~~~^~~~
/mnt/D_DRIVE/work/nnvm_22_Jan/nnvm_latest/tvm/dmlc-core/include/dmlc/logging.h:109:9: note: in definition of macro ‘CHECK’
   if (!(x))                                                \
         ^