### PR TITLE
infrastructure for autotensorize 1

### DIFF
--- a/src/schedule/schedule_dataflow_rewrite.cc
+++ b/src/schedule/schedule_dataflow_rewrite.cc
@@ -104,7 +104,7 @@ Tensor Schedule::cache_read(const Tensor& tensor,
   ArrayNode* stages = (*this)->stages.CopyOnWrite();
   Stage op_stage = operator[](tensor->op);
   size_t pos = FindNodeRef(stages, op_stage);
-  Stage cache_stage = Stage(cache->op);
+  Stage cache_stage = Stage(cache->op, this);
   cache_stage.set_scope(scope);
   CHECK_LT(pos, stages->data.size());
   stages->data.insert(stages->data.begin() + pos + 1,
@@ -207,7 +207,7 @@ Tensor CacheWriteWithReLayout(Schedule sch,
   // create schedule for new cached stage.
   ArrayNode* stages = sch->stages.CopyOnWrite();
   size_t pos = FindNodeRef(stages, orig_stage);
-  Stage cache_stage = Stage(cache_op);
+  Stage cache_stage = Stage(cache_op, &sch);
   cache_stage.set_scope(scope);
   CHECK_LT(pos, stages->data.size());
   stages->data.insert(stages->data.begin() + pos,
@@ -386,8 +386,8 @@ void InjectInline(ScheduleNode* sch) {
   }
 }
 
-Schedule Schedule::normalize() {
-  Schedule sn = copy();
+Schedule Schedule::normalize(std::unordered_map<Stage, Stage, NodeHash, NodeEqual>* smap) {
+  Schedule sn = copy(smap);
   InjectInline(sn.operator->());
   RebaseNonZeroMinLoop(sn);
   return sn;
@@ -525,7 +525,7 @@ Array<Tensor> Schedule::rfactor(const Tensor& tensor,
   Operation factor_op(n);
   ArrayNode* stages = (*this)->stages.CopyOnWrite();
   size_t stage_pos = FindNodeRef(stages, reduce_stage);
-  Stage factor_stage = Stage(factor_op);
+  Stage factor_stage = Stage(factor_op, this);
   factor_stage->relations = rels;
   CHECK_LT(stage_pos, stages->data.size());
   stages->data.insert(stages->data.begin() + stage_pos,


### PR DESCRIPTION
Add a data member to the Stage class so that a Stage object knows what Schedule object it belongs to.
To do autotensorize, we need to check tensorization conditions at the time Python's tensorize() is called. To do that we first need to make a copy of the schedule and normalize it (in Stage::autotensorize()). To do this, a Stage object needs to know what Schedule object it belongs to. Finally, we check those conditions on the copied schedule and stage objects.
I have made quite a few changes for autotensorize but to keep it more organized and make it easier to understand and review, I'm going to submit them in pieces.