### PR TITLE
[PASS] enable small vars reuse big buffer

### DIFF
--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -374,6 +374,8 @@ def test_alloc_seq_type():
             C[j] = tvm.const(1, "int16")
             D = ib.allocate("int16", 200, name="D", scope="local.L0A")
             D[j] = B[j] + C[j]
+            E = ib.allocate("int16", 400, name="E", scope="local.L0A")
+            E[j] = tvm.const(1, "int16")
             A2 = ib.allocate("float32", 200, name="A2", scope="local.L0A")
             A2[j] = A[j]
 
@@ -383,7 +385,7 @@ def test_alloc_seq_type():
     def verify(n):
         if isinstance(n, tvm.stmt.Allocate):
             num_alloc[0] += 1
-            assert n.extents[0].value == 500
+            assert n.extents[0].value == 400
     tvm.ir_pass.PostOrderVisit(body, verify)
     assert num_alloc[0] == 1
 


### PR DESCRIPTION
enable B and C reuse A1 buffer, before this patch, B(200 int16) took all space of A1(200 float32) 
```
with ib.for_range(0, 10, name="j") as j:
            A = ib.allocate("float32", 200, name="A", scope="local.L0A")
            A1 = ib.allocate("float32", 200, name="A1", scope="local.L0A")
            A[j] = 1.2
            A1[j] = 1.3
            B = ib.allocate("int16", 200, name="B", scope="local.L0A")
            B[j] = tvm.const(1, "int16")
            C = ib.allocate("int16", 200, name="C", scope="local.L0A")
            C[j] = tvm.const(1, "int16")
            D = ib.allocate("int16", 200, name="D", scope="local.L0A")
            D[j] = B[j] + C[j]
            E = ib.allocate("int16", 400, name="E", scope="local.L0A")
            E[j] = tvm.const(1, "int16")
            A2 = ib.allocate("float32", 200, name="A2", scope="local.L0A")
            A2[j] = A[j]
```
also add a case for 
```
// then start looking at smaller buffers.
      for (auto it = mid; it != begin;) {
        --it;
        StorageEntry *e = it->second;
        if (e->attach_scope_ != attach_scope) continue;
        if (e->scope != scope) continue;
        if (e->elem_type != op->type.element_of()) continue;
        const_free_map_.erase(it);
        return e;
      }
```