### PR TITLE
Assert dont crash on null strides

### DIFF
--- a/src/pass/arg_binder.cc
+++ b/src/pass/arg_binder.cc
@@ -194,6 +194,9 @@ void ArgBinder::BindDLTensor(const Buffer& buffer,
   init_nest_.emplace_back(LetStmt::make(
       v_strides, TVMArrayGet(Handle(), handle, intrinsic::kArrStrides),
       nop));
+  Expr is_null = Call::make(
+    Bool(1), intrinsic::tvm_handle_is_null,
+    {v_strides}, Call::PureIntrinsic);
   if (buffer->strides.size() == 0) {
     // Assert the buffer is compact
     Type stype = buffer->DefaultIndexType();
@@ -215,13 +218,15 @@ void ArgBinder::BindDLTensor(const Buffer& buffer,
       Stmt check =
           AssertStmt::make(arith::ComputeReduce<ir::And>(conds, Expr()),
                            stride_err_msg.str(), Evaluate::make(0));
-      Expr is_null = Call::make(
-          Bool(1), intrinsic::tvm_handle_is_null,
-          {v_strides}, Call::PureIntrinsic);
       check = IfThenElse::make(Not::make(is_null), check, Stmt());
       init_nest_.emplace_back(Block::make(check, Evaluate::make(0)));
     }
   } else {
+    std::ostringstream stride_null_err_msg;
+    stride_err_msg << arg_name << ".strides:"
+                   << " expected non-null strides.";
+    asserts_.emplace_back(AssertStmt::make(Not::make(is_null), stride_err_msg.str(), nop));
+    init_nest.emplace_back( AssertStmt::make( 
     for (size_t k = 0; k < buffer->strides.size(); ++k) {
       std::ostringstream field_name;
       field_name << v_strides->name_hint << '[' << k << ']';

--- a/src/pass/arg_binder.cc
+++ b/src/pass/arg_binder.cc
@@ -223,10 +223,9 @@ void ArgBinder::BindDLTensor(const Buffer& buffer,
     }
   } else {
     std::ostringstream stride_null_err_msg;
-    stride_err_msg << arg_name << ".strides:"
-                   << " expected non-null strides.";
-    asserts_.emplace_back(AssertStmt::make(Not::make(is_null), stride_err_msg.str(), nop));
-    init_nest.emplace_back( AssertStmt::make( 
+    stride_null_err_msg << arg_name << ".strides: expected non-null strides.";
+    asserts_.emplace_back(AssertStmt::make(Not::make(is_null), stride_null_err_msg.str(), nop));
+
     for (size_t k = 0; k < buffer->strides.size(); ++k) {
       std::ostringstream field_name;
       field_name << v_strides->name_hint << '[' << k << ']';


### PR DESCRIPTION
Moved is_null check up into enclosing scope as it is used under all conditions on both sides of the if-statement.

Tested that checking for null strides does in fact work:
```clojure
   {:error-string "[16:36:57] src/codegen/llvm/llvm_module.cc:59: Check failed: ret == 0 (-1 vs. 0) Assert fail: !tvm_handle_is_null(arg0.strides), arg0.strides: expected non-null strides.\n\nStack trace returned 6 entries:\n[bt] (0) /home/chrisn/dev/tech/tvm-clj/java/native/linux/x86_64/libtvm.so(dmlc::StackTrace[abi:cxx11]()+0x53) [0x7f2382eb41e3]\n[bt] (1) /home/chrisn/dev/tech/tvm-clj/java/native/linux/x86_64/libtvm.so(tvm::codegen::LLVMModuleNode::GetFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<tvm::runtime::ModuleNode> const&)::{lambda(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)#2}::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x78f) [0x7f238311ec9f]\n[bt] (2) /home/chrisn/dev/tech/tvm-clj/java/native/linux/x86_64/libtvm.so(std::_Function_handler<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::codegen::LLVMModuleNode::GetFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<tvm::runtime::ModuleNode> const&)::{lambda(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)#2}>::_M_invoke(std::_Any_data const&, tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&)+0x17) [0x7f238311efb7]\n[bt] (3) /home/chrisn/dev/tech/tvm-clj/java/native/linux/x86_64/libtvm.so(TVMFuncCall+0x5e) [0x7f23832722be]\n[bt] (4) /home/chrisn/dev/tech/tvm-clj/java/native/linux/x86_64/libjniruntime.so(Java_tvm_1clj_tvm_runtime_TVMFuncCall__Ltvm_1clj_tvm_runtime_00024TVMFunctionHandle_2Ltvm_1clj_tvm_runtime_00024TVMValue_2_3IILtvm_1clj_tvm_runtime_00024TVMValue_2_3I+0x120) [0x7f2365b9a700]\n[bt] (5) [0x7f23f5017774]\n\n",
    :fn-name ""}
```