### PR TITLE
Simplify enclave lifecycle management

### DIFF
--- a/apps/sgx/app.cc
+++ b/apps/sgx/app.cc
@@ -119,8 +119,7 @@ int SGX_CDECL main(int argc, char *argv[]) {
   if (sgx_status != SGX_SUCCESS) {
     print_error_message(sgx_status);
   }
-  tvm_ecall_shutdown(tvm_sgx_eid);
-  tvm::runtime::sgx::Shutdown();
+
   sgx_destroy_enclave(tvm_sgx_eid);
 
   if (addone_status == 1) {

--- a/apps/sgx/enclave.cc
+++ b/apps/sgx/enclave.cc
@@ -6,8 +6,6 @@
 #include <iostream>
 #endif
 
-extern void Shutdown();
-
 /* This function mirrors the one in howto_deploy except without the iostream */
 int Verify(tvm::runtime::Module mod, std::string fname) {
   // Get the function from the module.

--- a/sgx/runtime_t.cc
+++ b/sgx/runtime_t.cc
@@ -15,9 +15,3 @@
 #include "threading_backend.cc"
 #endif
 #include "../../src/runtime/thread_pool.cc"
-
-extern "C" {
-void tvm_ecall_shutdown() {
-  tvm::runtime::ThreadPool::Global()->Shutdown();
-}
-}

--- a/sgx/runtime_u.cc
+++ b/sgx/runtime_u.cc
@@ -14,7 +14,8 @@ namespace sgx {
 static std::unique_ptr<tvm::runtime::threading::ThreadGroup> sgx_thread_group;
 
 extern "C" {
-void tvm_ocall_thread_pool_launch(int num_tasks, void* cb) {
+
+void tvm_ocall_thread_group_launch(int num_tasks, void* cb) {
   std::function<void(int)> runner = [cb](int _worker_id) {
     sgx_status_t sgx_status = SGX_ERROR_UNEXPECTED;
     sgx_status = tvm_ecall_run_worker(tvm_sgx_eid, cb);
@@ -23,10 +24,11 @@ void tvm_ocall_thread_pool_launch(int num_tasks, void* cb) {
   sgx_thread_group.reset(new tvm::runtime::threading::ThreadGroup(
         num_tasks, runner, false /* include_main_thread */));
 }
+
+void tvm_ocall_thread_group_join() {
+  sgx_thread_group->Join();
 }
 
-void Shutdown() {
-  sgx_thread_group->Join();
 }
 
 }  // namespace sgx

--- a/sgx/tvm.edl
+++ b/sgx/tvm.edl
@@ -5,11 +5,11 @@ enclave {
         public void tvm_ecall_run_module([user_check] const void* tvm_args,
                                          [user_check] void* tvm_ret_value);
         public void tvm_ecall_run_worker([user_check] const void* cb);
-        public void tvm_ecall_shutdown();
     };
 
     untrusted {
-        void tvm_ocall_thread_pool_launch(int num_workers, [user_check] void* cb);
+        void tvm_ocall_thread_group_launch(int num_workers, [user_check] void* cb);
+        void tvm_ocall_thread_group_join();
     };
 };
 


### PR DESCRIPTION
This PR obviates the need for explicit enclave destruction steps (i.e. `ecall_shutdown` and `Shutdown()`). This will it easier to construct wrap enclaves as TVM Modules (which should be ready later today).

(turns out the issue before was that the trusted queues were being destructed rather than just closed while threads were still in them)