### PR TITLE
Move BuildConfig context stack to C++

### DIFF
--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <tuple>
 #include "./runtime/packed_func.h"
 #include "./schedule_pass.h"
 #include "./lowered_func.h"

--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -197,7 +197,7 @@ class BuildConfigNode : public Node {
   bool partition_const_loop = false;
 
   /*! \brief Whether to dump the IR of each pass (only when building from python) */
-  std::vector<std::tuple<int, PackedFunc>> add_lower_pass;
+  std::vector< std::pair<int, PackedFunc> > add_lower_pass;
 
   /*! \brief Whether to dump the IR of each pass (only when building from python) */
   bool dump_pass_ir = false;
@@ -232,9 +232,8 @@ class BuildConfig : public ::tvm::NodeRef {
     return static_cast<const BuildConfigNode*>(node_.get());
   }
 
-  inline void set_add_lower_pass(const std::vector<std::tuple<int, PackedFunc>>& add_lower_pass) {
-    auto node = static_cast<BuildConfigNode*>(node_.get());
-    node->add_lower_pass = add_lower_pass;
+  BuildConfigNode* operator->() {
+    return static_cast<BuildConfigNode*>(node_.get());
   }
 
   /*!
@@ -254,7 +253,7 @@ class BuildConfig : public ::tvm::NodeRef {
    * configuration if a BuildConfig scope has not been entered.
    * \return The configuration that is the current context.
    */
-  EXPORT static tvm::BuildConfig current_build_config();
+  EXPORT static tvm::BuildConfig Current();
 
   using ContainerType = BuildConfigNode;
 };

--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -8,7 +8,7 @@
 
 #include <string>
 #include <vector>
-#include <tuple>
+#include <utility>
 #include "./runtime/packed_func.h"
 #include "./schedule_pass.h"
 #include "./lowered_func.h"

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -8,8 +8,8 @@ import warnings
 import types
 
 from ._ffi.node import NodeBase, register_node
-from ._ffi.base import _RUNTIME_ONLY
 from . import api
+from . import _api_internal
 from . import tensor
 from . import schedule
 from . import expr
@@ -46,7 +46,8 @@ class DumpIR(object):
             retv = func(*args, **kwargs)
             if not isinstance(retv, (_stmt.Stmt, container.LoweredFunc, container.Array)):
                 return retv
-            pname = str(self._pass_id) + "_" + func.func_name + "_ir.cc"
+            fname = func.func_name if hasattr(func, 'func_name') else func.__name__
+            pname = str(self._pass_id) + "_" + fname + "_ir.cc"
             with open(pname, "a") as f:
                 out = retv.body if isinstance(retv, container.LoweredFunc) else retv
                 f.write(str(out))
@@ -70,20 +71,20 @@ class DumpIR(object):
             self._recover_list.append(recover)
             vset[k] = self.decorate(v) if isinstance(v, types.FunctionType) else v
 
-    def decorate_custompass(self):
-        """ decorate add_lower_pass pass in BuildConfig"""
-        cfg = BuildConfig.current
-        self._old_custom_pass = cfg.add_lower_pass
-        custom_pass = cfg.add_lower_pass if cfg.add_lower_pass else []
-        pass_list = [(x[0], self.decorate(x[1])) for x in custom_pass]
-        BuildConfig.current.add_lower_pass = pass_list
+    def decorate_custompass(self, custom_pass):
+        """decorate given list of custom passes, and return decorated passes"""
+        custom_pass = custom_pass if custom_pass else []
+        pass_list = []
+        for idx, x in enumerate(custom_pass):
+            x[1].__name__ = "custom{}_phase{}".format(idx, x[0])
+            pass_list += [(x[0], self.decorate(x[1]))]
+        return pass_list
 
     def enter(self):
         """only decorate outermost nest"""
         if DumpIR.scope_level > 0:
             return
         self.decorate_irpass()
-        self.decorate_custompass()
         self._pass_id = 0
         DumpIR.scope_level += 1
 
@@ -95,7 +96,6 @@ class DumpIR(object):
         for f in self._recover_list:
             f()
         schedule.ScheduleOps = self._old_sgpass
-        BuildConfig.current.add_lower_pass = self._old_custom_pass
         DumpIR.scope_level -= 1
 
 @register_node
@@ -113,7 +113,6 @@ class BuildConfig(NodeBase):
     is constructed. See _node_defaults for the fields.
     """
 
-    current = None
     _node_defaults = {
         "auto_unroll_max_step": 0,
         "auto_unroll_max_depth": 8,
@@ -124,8 +123,10 @@ class BuildConfig(NodeBase):
         "offset_factor": 0,
         "data_alignment": -1,
         "restricted_func": True,
-        "double_buffer_split_loop": 1
+        "double_buffer_split_loop": 1,
+        "dump_pass_ir": False
     }
+    _dump_ir = DumpIR()
 
     # pylint: disable=no-member
     def __init__(self, handle):
@@ -138,30 +139,37 @@ class BuildConfig(NodeBase):
         """
         super(BuildConfig, self).__init__(handle)
         self.handle = handle
-        self._old_scope = None
-        self._dump_ir = DumpIR()
-        self.dump_pass_ir = False
-        self.add_lower_pass = None
+
+    @property
+    def add_lower_pass(self):
+        size = _api_internal._BuildConfigGetAddLowerPassSize(self)
+        result = []
+        for i in range(size):
+            phase = _api_internal._BuildConfigGetAddLowerPassItemPhase(self, i)
+            func = _api_internal._BuildConfigGetAddLowerPassItemFunc(self, i)
+            result += [(phase, func)]
+        return result
 
     def __enter__(self):
         # pylint: disable=protected-access
-        self._old_scope = BuildConfig.current
-        BuildConfig.current = self
-        if self.dump_pass_ir is True:
-            self._dump_ir.enter()
+        _api_internal._EnterBuildConfigScope(self)
+        if self.dump_pass_ir:
+            BuildConfig._dump_ir.enter()
         return self
 
     def __exit__(self, ptype, value, trace):
-        assert self._old_scope
-        if self.dump_pass_ir is True:
-            self._dump_ir.exit()
-        BuildConfig.current = self._old_scope
+        if self.dump_pass_ir:
+            BuildConfig._dump_ir.exit()
+        _api_internal._ExitBuildConfigScope()
 
     def __setattr__(self, name, value):
         if name in BuildConfig._node_defaults:
             raise AttributeError(
                 "'%s' object cannot set attribute '%s'" % (str(type(self)), name))
         return super(BuildConfig, self).__setattr__(name, value)
+
+def current_build_config():
+    return _api_internal._GetCurrentBuildConfig()
 
 def build_config(**kwargs):
     """Configure the build behavior by setting config variables.
@@ -221,14 +229,13 @@ def build_config(**kwargs):
                  for k, v in BuildConfig._node_defaults.items()}
     config = make.node("BuildConfig", **node_args)
 
-    for k in kwargs:
-        if not k in node_args:
-            setattr(config, k, kwargs[k])
-    return config
+    if "add_lower_pass" in kwargs:
+        add_lower_pass_args = []
+        for x in kwargs["add_lower_pass"]:
+            add_lower_pass_args += [x[0], x[1]]
+        _api_internal._BuildConfigSetAddLowerPass(config, *add_lower_pass_args)
 
-if not _RUNTIME_ONLY:
-    # BuildConfig is not available in tvm_runtime
-    BuildConfig.current = build_config()
+    return config
 
 def get_binds(args, binds=None):
     """Internal function to get binds and arg_list given arguments.
@@ -252,7 +259,7 @@ def get_binds(args, binds=None):
         The list of symbolic buffers of arguments.
     """
     binds = {} if binds is None else binds.copy()
-    cfg = BuildConfig.current
+    cfg = current_build_config()
     arg_list = []
     for x in args:
         if isinstance(x, tensor.Tensor):
@@ -309,8 +316,10 @@ def lower(sch,
        Then the Stmt before make api is returned.
     """
     binds, arg_list = get_binds(args, binds)
-    cfg = BuildConfig.current
+    cfg = current_build_config()
     add_lower_pass = cfg.add_lower_pass if cfg.add_lower_pass else []
+    if cfg.dump_pass_ir:
+        add_lower_pass = BuildConfig._dump_ir.decorate_custompass(add_lower_pass)
     lower_phase0 = [x[1] for x in add_lower_pass if x[0] == 0]
     lower_phase1 = [x[1] for x in add_lower_pass if x[0] == 1]
     lower_phase2 = [x[1] for x in add_lower_pass if x[0] == 2]
@@ -434,7 +443,7 @@ def build(sch,
                 "Direct host side access to device memory is detected in %s. "
                 "Did you forget to bind?" % func.name)
         if func.func_type == container.LoweredFunc.MixedFunc:
-            if BuildConfig.current.detect_global_barrier:
+            if current_build_config().detect_global_barrier:
                 func = ir_pass.ThreadSync(func, "global")
             func = ir_pass.ThreadSync(func, "shared")
             warp_size = target.thread_warp_size

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -142,11 +142,11 @@ class BuildConfig(NodeBase):
 
     @property
     def add_lower_pass(self):
-        size = _api_internal._BuildConfigGetAddLowerPassSize(self)
+        size = _api_internal._BuildConfigGetAddLowerPassInfo(self)
         result = []
         for i in range(size):
-            phase = _api_internal._BuildConfigGetAddLowerPassItemPhase(self, i)
-            func = _api_internal._BuildConfigGetAddLowerPassItemFunc(self, i)
+            phase = _api_internal._BuildConfigGetAddLowerPassInfo(self, i, True)
+            func = _api_internal._BuildConfigGetAddLowerPassInfo(self, i, False)
             result += [(phase, func)]
         return result
 

--- a/python/tvm/tensor_intrin.py
+++ b/python/tvm/tensor_intrin.py
@@ -6,7 +6,7 @@ from . import expr as _expr
 from . import stmt as _stmt
 from . import make as _make
 from . import tensor as _tensor
-from .build_module import BuildConfig
+from .build_module import current_build_config
 from ._ffi.node import NodeBase, register_node
 
 @register_node
@@ -74,7 +74,7 @@ def decl_tensor_intrin(op,
         if not isinstance(t.op, _tensor.PlaceholderOp):
             raise ValueError("Donot yet support composition op")
 
-    cfg = BuildConfig.current
+    cfg = current_build_config()
     for t in tensors:
         buf = (binds[t] if t in binds else
                _api.decl_buffer(t.shape, t.dtype, t.op.name,

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <mutex>
 #include <stack>
+#include <utility>
 
 namespace tvm {
 

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <mutex>
 #include <stack>
-#include <utility>
 
 namespace tvm {
 

--- a/tests/python/unittest/test_pass_unroll.py
+++ b/tests/python/unittest/test_pass_unroll.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
     file_list = os.listdir('./')
     cc_file = end_with('.cc')
     cc_file = filter(cc_file, file_list)
+    cc_file = [f for f in cc_file]
     assert len(cc_file) == 3
     for i in cc_file:
         os.remove(i)


### PR DESCRIPTION
The problem that this PR addresses is with porting NNVM's build function to C++. The NNVM pass `GraphFuseCompile` makes callbacks to global functions `nnvm.compiler.lower` and `nnvm.compiler.build_target` in order to invoke the TVM compiler. Both of these functions rely on being able to access the BuildConfig context, which is currently stored in python, and not available to C++.

This PR attempts to solve that by moving the context stack into C++. This requires also moving the remaining two pieces of BuildConfig state (`dump_pass_ir` and `add_lower_pass`) into the C++ node so that these aren't lost in a round trip call to get the current BuildConfig.
