### PR TITLE
[RUNTIME] better parallel launcher and task distribution

### DIFF
--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -273,10 +273,12 @@ class ThreadPool {
     launcher->Init(flambda, cdata, num_task, need_sync != 0);
     SpscTaskQueue::Task tsk;
     tsk.launcher = launcher;
+    // if worker0 is taken by the master, queues_[0] is abandoned
     for (int i = exclude_worker0_; i < num_task; ++i) {
       tsk.task_id = i;
       queues_[i]->Push(tsk);
     }
+    // use the master thread to run task 0
     if (exclude_worker0_) {
       TVMParallelGroupEnv* penv = &(tsk.launcher->env);
       if ((*tsk.launcher->flambda)(0, penv, cdata) == 0) {
@@ -312,6 +314,7 @@ class ThreadPool {
     }
   }
   int num_workers_;
+  // if excluding worker 0 and using master to run task 0
   bool exclude_worker0_{true};
   std::vector<std::unique_ptr<SpscTaskQueue> > queues_;
   std::unique_ptr<tvm::runtime::threading::ThreadGroup> threads_;

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -372,8 +372,8 @@ class ThreadPool {
     memset((cpusetp), 0, sizeof(cpu_set_t))
 #endif
 #endif
-    for (int i=0; i < num_workers_; ++i) {
 #if defined(__linux__) || defined(__ANDROID__)
+    for (int i=0; i < num_workers_; ++i) {
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
       CPU_SET(i, &cpuset);

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -78,11 +78,11 @@ class ThreadGroup::Impl {
 #endif
     }
     if (exclude_worker0) {  // bind the master thread to core 0
-    cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
-    CPU_SET(0, &cpuset);
-    pthread_setaffinity_np(pthread_self(),
-      sizeof(cpu_set_t), &cpuset);
+      cpu_set_t cpuset;
+      CPU_ZERO(&cpuset);
+      CPU_SET(0, &cpuset);
+      pthread_setaffinity_np(pthread_self(),
+        sizeof(cpu_set_t), &cpuset);
     }
 #endif
   }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -61,8 +61,8 @@ class ThreadGroup::Impl {
     memset((cpusetp), 0, sizeof(cpu_set_t))
 #endif
 #endif
-    for (unsigned i=0; i < threads_.size(); ++i) {
 #if defined(__linux__) || defined(__ANDROID__)
+    for (unsigned i=0; i < threads_.size(); ++i) {
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
       CPU_SET(i, &cpuset);
@@ -72,8 +72,14 @@ class ThreadGroup::Impl {
       pthread_setaffinity_np(threads_[i].native_handle(),
           sizeof(cpu_set_t), &cpuset);
 #endif
-#endif
     }
+    // bind the master thread to core num_workers_-1
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(num_workers_-1, &cpuset);
+    pthread_setaffinity_np(pthread_self(),
+      sizeof(cpu_set_t), &cpuset);
+#endif
   }
 
   int num_workers_;


### PR DESCRIPTION
This PR works on two issues to improve the multi-threaded runtime performance on CPUs. 

1. Use atomic variables to coordinate the threads in `ParallelLauncher`.
2. Make `exclude_worker0` true as default, so that task 0 is run by master.
3. Bind master thread to core 0 if `exclude_worker0 == true`. The master thread is not bound when `exclude_worker0 == false`.

The overall performance boost on 18-core Intel Skylake is ~20%.