### PR TITLE
Fix the issue #1036

### DIFF
--- a/apps/howto_deploy/tvm_runtime_pack.cc
+++ b/apps/howto_deploy/tvm_runtime_pack.cc
@@ -56,7 +56,7 @@
 
 // Uncomment the following lines to enable CUDA
 // #include "../../src/runtime/cuda/cuda_device_api.cc"
-// #include "../../src/runtime/cuda/cuda_runtime.cc"
+// #include "../../src/runtime/cuda/cuda_module.cc"
 
 // Uncomment the following lines to enable OpenCL
 // #include "../../src/runtime/opencl/opencl_device_api.cc"


### PR DESCRIPTION
No file named "cuda__runtime.cc". Update "cuda__runtime.cc" to "cuda_module.cc" to fix the issue #1036. After fixing, it can build packed runtime with CUDA enabled successfully.