### PR TITLE
fix Android build w/ threading_backend

### DIFF
--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -21,7 +21,7 @@
 #include "../src/runtime/rpc/rpc_module.cc"
 #include "../src/runtime/rpc/rpc_socket_impl.cc"
 #include "../src/runtime/thread_pool.cc"
-
+#include "../src/runtime/threading_backend.cc"
 #include "../src/runtime/graph/graph_runtime.cc"
 
 #ifdef TVM_OPENCL_RUNTIME

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -81,8 +81,13 @@ class ThreadGroup::Impl {
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
       CPU_SET(0, &cpuset);
+#if defined(__ANDROID__)
+      sched_setaffinity(0,
+        sizeof(cpu_set_t), &cpuset);
+#else
       pthread_setaffinity_np(pthread_self(),
         sizeof(cpu_set_t), &cpuset);
+#endif
     }
 #endif
   }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -82,7 +82,7 @@ class ThreadGroup::Impl {
       CPU_ZERO(&cpuset);
       CPU_SET(0, &cpuset);
 #if defined(__ANDROID__)
-      sched_setaffinity(0,
+      sched_setaffinity(pthread_self(),
         sizeof(cpu_set_t), &cpuset);
 #else
       pthread_setaffinity_np(pthread_self(),


### PR DESCRIPTION
These are changes I need to build the Android `apk` on my end.

I also needed to change a line in `Application.mk` to 
```
APP_STL := c++_static
```
to fix an error about `std::to_string`, but not sure if that is a required fix so it is omitted for now.