### PR TITLE
Add phisiart to code owner of webgl module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,13 +5,17 @@
 *        @dmlc/tvm-committers
 
 # LLVM backends
-src/llvm/*          @aatluri
+src/codegen/llvm/*          @aatluri
 
 # ROCM runtime
 src/runtime/rocm/*    @aatluri
 
 # JVM language
 jvm/*   @yzhliu
+
+# WebGL backends
+src/runtime/opengl/*    @phisiart
+src/codegen/*opengl*    @phisiart
 
 # TOPI
 topi/python/topi/*  @Laurawly @Huyuwei

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,6 +48,7 @@ and are qualified to lead development and review changes of the owned module.
 - [Leyuan Wang](https://github.com/Laurawly) TOPI
 - [Yuwei Hu](https://github.com/Huyuwei) TOPI
 - [Yizhi Liu](https://github.com/yzhliu) JVM package
+- [Zhixun Tan](https://github.com/phisiart) OpenGL/WebGL backend
 
 
 List of Contributors


### PR DESCRIPTION
This PR adds @phisiart to the code owner of OpenGL/WebGL module. zhixun did all the scaffolding of  WebGL backend which allows us to [compile deep learning model to webgl](http://www.tvmlang.org/2018/03/12/webgl.html) without writing a single line of javascript.

