### PR TITLE
support string option when creating cuda/rocm/... target

### DIFF
--- a/python/tvm/target.py
+++ b/python/tvm/target.py
@@ -349,10 +349,10 @@ def cuda(options=None):
 
     Parameters
     ----------
-    options : list of str
+    options : str or list of str
         Additional options
     """
-    options = options if options else []
+    options = _merge_opts([], options)
     return _api_internal._TargetCreate("cuda", *options)
 
 
@@ -361,10 +361,10 @@ def rocm(options=None):
 
     Parameters
     ----------
-    options : list of str
+    options : str or list of str
         Additional options
     """
-    options = options if options else []
+    options = _merge_opts([], options)
     return _api_internal._TargetCreate("rocm", *options)
 
 
@@ -373,7 +373,7 @@ def rasp(options=None):
 
     Parameters
     ----------
-    options : list of str
+    options : str or list of str
         Additional options
     """
     opts = ["-device=rasp",
@@ -389,7 +389,7 @@ def mali(options=None):
 
     Parameters
     ----------
-    options : list of str
+    options : str or list of str
         Additional options
     """
     opts = ["-device=mali"]
@@ -402,10 +402,10 @@ def opengl(options=None):
 
     Parameters
     ----------
-    options : list of str
+    options : str or list of str
         Additional options
     """
-    options = options if options else []
+    options = _merge_opts([], options)
     return _api_internal._TargetCreate("opengl", *options)
 
 

--- a/tests/python/unittest/test_lang_target.py
+++ b/tests/python/unittest/test_lang_target.py
@@ -43,6 +43,7 @@ def test_target_string_parse():
     assert target.options == ['-libs=cublas,cudnn']
     assert target.keys == ['cuda', 'gpu']
     assert target.libs == ['cublas', 'cudnn']
+    assert str(target) == str(tvm.target.cuda("-libs=cublas,cudnn"))
 
 if __name__ == "__main__":
     test_target_dispatch()


### PR DESCRIPTION
The new target patch #892 can only takes a list of strings as argument, so it does not support usages like `tvm.target.cuda("-model=titanx")` .
This PR fixes it.
