### PR TITLE
[WIP] Add conv2d gradients

### DIFF
--- a/topi/include/topi/nn.h
+++ b/topi/include/topi/nn.h
@@ -321,23 +321,23 @@ inline tvm::Tensor conv2d_nchw_grad_weight(const tvm::Tensor& O,
   CHECK_EQ(4, O->shape.size());
   CHECK_EQ(4, I->shape.size());
 
-  auto b = tvm::reduce_axis(tvm::Range{0, I->shape[0]}, "b");
-  auto h = tvm::reduce_axis(tvm::Range{0, I->shape[2]}, "h");
-  auto w = tvm::reduce_axis(tvm::Range{0, I->shape[3]}, "w");
+  auto b = tvm::reduce_axis(tvm::Range{0, O->shape[0]}, "b");
+  auto h = tvm::reduce_axis(tvm::Range{0, O->shape[2]}, "h");
+  auto w = tvm::reduce_axis(tvm::Range{0, O->shape[3]}, "w");
   auto T = (pad_h == 0 && pad_w == 0)
                ? I
                : pad(I, {tvm::Expr(0), tvm::Expr(0), pad_h, pad_w});
   Expr dh = make_const(UInt(32), stride_h);
   Expr dw = make_const(UInt(32), stride_w);
-  auto l = [&](tvm::Var i, tvm::Var o, tvm::Var kh, tvm::Var kw) {
+  auto l = [&](tvm::Var o, tvm::Var i, tvm::Var kh, tvm::Var kw) {
     return tvm::sum(
         T(b, i, dh * h + kh, dw * w + kw) * O(b, o, h, w),
         {b, h, w});
   };
 
   tvm::Array<tvm::Expr> output_shape{
-    I->shape[1],
     O->shape[1],
+    I->shape[1],
     make_const(Int(32), kernel_h),
     make_const(Int(32), kernel_w)
   };

--- a/topi/include/topi/nn.h
+++ b/topi/include/topi/nn.h
@@ -156,7 +156,7 @@ inline tvm::Tensor pad(const tvm::Tensor& t,
                        tvm::Array<tvm::Expr> pad_after = tvm::Array<tvm::Expr>(),
                        Expr pad_value = Expr(),
                        std::string name = "tensor",
-                       std::string tag = kElementWise) {
+                       std::string tag = std::string(kElementWise) + ",pad") {
   if (pad_after.size() < pad_before.size()) {
     for (size_t i = pad_after.size(); i < pad_before.size(); ++i) {
       pad_after.push_back(pad_before[i]);

--- a/topi/include/topi/nn.h
+++ b/topi/include/topi/nn.h
@@ -288,6 +288,57 @@ inline tvm::Tensor conv2d_nchw(const tvm::Tensor& I,
 }
 
 /*!
+ * \brief Creates an operation that computes the gradient w.r.t. the weight of
+ * a NCHW-layout 2-D convolution.
+ *
+ * \param O The 4-D output gradient tensor
+ * \param I The 4-D input tensor
+ * \param W The 4-D weight tensor
+ * \param pad_h A static constant padding amount applied to the height of the
+ * image, before and after (symmetric padding)
+ * \param pad_w A static constant padding amount applied to the width of the
+ * image, before and after (symmetric padding)
+ * \param stride_h A static constant striding amount applied to the height of
+ * the image, before and after (symmetric padding)
+ * \param stride_w A static constant strindingamount applied to the width of
+ * the image, before and after (symmetric padding)
+ * \param name The name of the operation
+ * \param tag The tag to mark the operation
+ *
+ * \return A Tensor whose op member is the 2-D convolution operation (NCHW
+ * layout)
+ */
+inline tvm::Tensor conv2d_nchw_grad_weight(const tvm::Tensor& O,
+                                           const tvm::Tensor& I,
+                                           const tvm::Tensor& W,
+                                           int pad_h = 0,
+                                           int pad_w = 0,
+                                           int stride_h = 1,
+                                           int stride_w = 1,
+                                           std::string name = "tensor",
+                                           std::string tag = kConv2dNCHW) {
+  CHECK_EQ(4, O->shape.size());
+  CHECK_EQ(4, I->shape.size());
+  CHECK_EQ(4, W->shape.size());
+
+  auto b = tvm::reduce_axis(tvm::Range{0, I->shape[0]}, "b");
+  auto h = tvm::reduce_axis(tvm::Range{0, I->shape[2]}, "h");
+  auto w = tvm::reduce_axis(tvm::Range{0, I->shape[3]}, "w");
+  auto T = (pad_h == 0 && pad_w == 0)
+               ? I
+               : pad(I, {tvm::Expr(0), tvm::Expr(0), pad_h, pad_w});
+  Expr dh = make_const(UInt(64), stride_h);
+  Expr dw = make_const(UInt(64), stride_w);
+  auto l = [&](tvm::Var i, tvm::Var o, tvm::Var kh, tvm::Var kw) {
+    return tvm::sum(
+        // T(b, i, stride_h * h + kh, stride_w * w + kw) * O(b, o, h, w),
+        T(b, i, dh * h + kh, dw * w + kw) * O(b, o, h, w),
+        {b, h, w});
+  };
+  return tvm::compute(W->shape, l, name, tag);
+}
+
+/*!
  * \brief Creates an operation for 2-D convolution layer with an HWCN-layout
  *
  * \param I The 4-D input tensor

--- a/topi/include/topi/tags.h
+++ b/topi/include/topi/tags.h
@@ -17,6 +17,7 @@ constexpr auto kCommReduceIdx = "comm_reduce_idx";
 constexpr auto kBroadcast = "broadcast";
 constexpr auto kMatMult = "matmult";
 constexpr auto kConv2dNCHW = "conv2d_nchw";
+constexpr auto kConv2dNCHWdW = "conv2d_grad_weight_nchw";
 constexpr auto kConv2dHWCN = "conv2d_hwcn";
 constexpr auto kDepthwiseConv2dNCHW = "depthwise_conv2d_nchw";
 constexpr auto kDepthwiseConv2dNHWC = "depthwise_conv2d_nhwc";

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -36,7 +36,7 @@ def schedule_conv2d_nchw(outs):
 
 
 @tvm.target.generic_func
-def schedule_conv2d_grad_weight_nchw(outs):
+def schedule_conv2d_grad_weight_nchw(outs): # pylint: disable=invalid-name
     """Schedule for conv2d_nchw_grad_weight
 
     Parameters

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -36,6 +36,24 @@ def schedule_conv2d_nchw(outs):
 
 
 @tvm.target.generic_func
+def schedule_conv2d_grad_weight_nchw(outs):
+    """Schedule for conv2d_nchw_grad_weight
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of conv2d_nchw_grad_weight
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
+@tvm.target.generic_func
 def schedule_conv2d_nhwc(outs):
     """Schedule for conv2d_nhwc
 

--- a/topi/python/topi/x86/conv2d.py
+++ b/topi/python/topi/x86/conv2d.py
@@ -150,7 +150,7 @@ def schedule_conv2d_grad_weight_nchw(outs):
     dw = outs[0]
     data = dw.op.input_tensors[0]
 
-    if not isinstance(data, tvm.tensor.PlaceholderOp) and 'pad' in data.op.tag:
+    if not isinstance(data.op, tvm.tensor.PlaceholderOp) and 'pad' in data.op.tag:
         _schedule_pad(s, data)
 
     n, c, kh, kw = _get_axes_nchw(dw, 'nchw')

--- a/topi/python/topi/x86/conv2d.py
+++ b/topi/python/topi/x86/conv2d.py
@@ -83,7 +83,6 @@ def _declaration_conv(data, kernel, stride, padding, layout, out_dtype):
 
 def _traverse_conv2d(op, conv_tag, default_schedule):
     """Traverse operators from computation graph"""
-    print('traversing', op.tag)
     # inline all one-to-one-mapping operators except the last stage (output)
     if tag.is_broadcast(op.tag):
         if op not in s.outputs:


### PR DESCRIPTION
This PR enables efficient `conv2d_nchw` gradients on x86. Specifically, it
* adds an x86 schedule for `conv2d_transpose` which nets a 10x boost in performance
* adds the `conv2d_grad_weight_nchw` operator with a custom schedule for x86

Some notes:
* the method of specifying TVM tags should be made 1)  composable and 2) consistent across C++ and Python

WIP until:
- [ ] streamlined functions for all layouts via nchw converters
- [ ] add docs and other pylint necessities