### PR TITLE
minor fix for type in cudnn.py and typo 

### DIFF
--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -180,7 +180,7 @@ def build_config(**kwargs):
         Threshold of number of steps in the loop to be automatically unrolled.
         This takes inner loop count into consideration.
 
-    auto_unroll_max_depth: int, default=4
+    auto_unroll_max_depth: int, default=8
         The maximum nested level of loops that can be automatically unrolled.
 
     unroll_explicit: bool, default=True
@@ -214,7 +214,7 @@ def build_config(**kwargs):
         It it is bigger than one, the logic will do a split with factor equals the integer
         and unroll the inner loop. This allows the buffer fetching won't contain condition.
 
-    add_lower_pass: list of tuiple (phase, function(Stmt->Stmt)), default=None
+    add_lower_pass: list of tuple (phase, function(Stmt->Stmt)), default=None
         phase contains an integer on which optimization pass we apply the pass.
         Additional lowering passes to be applied before make_api.
 

--- a/python/tvm/contrib/cudnn.py
+++ b/python/tvm/contrib/cudnn.py
@@ -278,10 +278,10 @@ def conv2d_find_algo(tensor_format,
                 w_shape[1].value,
                 w_shape[2].value,
                 w_shape[3].value,
-                y_shape[0],
-                y_shape[1],
-                y_shape[2],
-                y_shape[3])
+                int(y_shape[0]),
+                int(y_shape[1]),
+                int(y_shape[2]),
+                int(y_shape[3]))
 
 
 def conv2d_forward(x,


### PR DESCRIPTION
the involved arguments in cudnn.py cause error when cython is used as FFI.