### PR TITLE
Add dilate_filter scheduling to conv2d_nchw

### DIFF
--- a/topi/python/topi/cuda/conv2d_nchw.py
+++ b/topi/python/topi/cuda/conv2d_nchw.py
@@ -495,6 +495,8 @@ def schedule_conv2d_small_batch(outs):
         if 'conv2d_nchw' in OP.tag:
             temp = OP.input_tensors[0]
             Filter = OP.input_tensors[1]
+            if Filter.name == "DilatedInput":
+                s[Filter].compute_inline()
             Output = OP.output(0)
             schedule(temp, Filter, Output)
 


### PR DESCRIPTION
This PR modifies conv2d schedule to handle conv2d with `dilation` on cuda. Could you review this and give me advice?  @Huyuwei 

Related github issue: 
[[OP] Support dilation in conv2d](https://github.com/dmlc/nnvm/issues/402)