### PR TITLE
Expose tvm.ndarray.empty in doc.

### DIFF
--- a/docs/api/python/ndarray.rst
+++ b/docs/api/python/ndarray.rst
@@ -14,5 +14,6 @@ tvm.ndarray
 .. autofunction:: tvm.opencl
 .. autofunction:: tvm.metal
 .. autofunction:: tvm.ndarray.array
+.. autofunction:: tvm.ndarray.empty
 
 .. autofunction:: tvm.register_extension


### PR DESCRIPTION
Expose tvm.ndarray.empty which has already been implemented, just not yet documented.