### PR TITLE
[MAINTAINER] Add Nick Hynes to CodeOwner of SGX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,10 @@ src/codegen/llvm/*          @aatluri
 # ROCM runtime
 src/runtime/rocm/*    @aatluri
 
+# SGX support
+src/runtime/sgx/*       @nhynes
+apps/sgx/*              @nhynes
+
 # JVM language
 jvm/*   @yzhliu
 
@@ -19,3 +23,5 @@ src/codegen/*opengl*    @phisiart
 
 # TOPI
 topi/python/topi/*  @Laurawly @Huyuwei
+
+

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@ and are qualified to lead development and review changes of the owned module.
 - [Yuwei Hu](https://github.com/Huyuwei) TOPI
 - [Yizhi Liu](https://github.com/yzhliu) JVM package
 - [Zhixun Tan](https://github.com/phisiart) OpenGL/WebGL backend
+- [Nick Hynes](https://github.com/nhynes) SGX and secured computing
 
 
 List of Contributors


### PR DESCRIPTION
This PR add @nhynes to code owner of SGX runtime. Nick has been very active to bring secured computing to the TVM stack, notably the support of SGX runtime and other improvements to high level nnvm and topi. He also makes good design decision, and holds a high standard for high quality code to the project.
