### PR TITLE
fix relu tests

### DIFF
--- a/topi/tests/python/test_topi_relu.py
+++ b/topi/tests/python/test_topi_relu.py
@@ -9,7 +9,7 @@ def verify_relu(m, n):
     A = tvm.placeholder((m, n), name='A')
     B = topi.nn.relu(A)
 
-    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
+    a_np = np.random.uniform(low=-1.0, high=1.0, size=get_const_tuple(A.shape)).astype(A.dtype)
     b_np = a_np * (a_np > 0)
 
     def check_device(device):

--- a/topi/tests/python_cpp/test_topi_relu.py
+++ b/topi/tests/python_cpp/test_topi_relu.py
@@ -10,7 +10,7 @@ def verify_relu(m, n, dtype):
     B = topi.cpp.nn.relu(A)
     assert B.dtype == dtype
 
-    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
+    a_np = np.random.uniform(low=-1.0, high=1.0, size=get_const_tuple(A.shape)).astype(A.dtype)
     b_np = a_np * (a_np > 0)
 
     def check_device(device):


### PR DESCRIPTION
np.random.uniform generates "[0, 1)" samples by default, so it's not suitable for ReLU test inputs.
This PR fixes the problem.