### PR TITLE
register loadbinary_hip

### DIFF
--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -229,6 +229,12 @@ TVM_REGISTER_GLOBAL("module.loadbinary_hsaco")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
     *rv = ROCMModuleLoadBinary(args[0]);
   });
+
+
+TVM_REGISTER_GLOBAL("module.loadbinary_hip")
+.set_body([](TVMArgs args, TVMRetValue* rv) {
+    *rv = ROCMModuleLoadBinary(args[0]);
+  });
 }  // namespace runtime
 }  // namespace tvm
 #endif  // TVM_ROCM_RUNTIME


### PR DESCRIPTION
currently not fully tested on my end w/ rocm backend, but matches behavior of running without save/load module