### PR TITLE
[llvm] fixed issue with llvm 5 vs 6 codegen_amdgpu.cc

### DIFF
--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -200,8 +200,13 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   dest_ll.SetUnbuffered();
   destAsm.SetUnbuffered();
   module->print(dest_ll, nullptr);
+#if TVM_LLVM_VERSION <= 60
   std::unique_ptr<llvm::Module> mAsm = llvm::CloneModule(module.get());
   std::unique_ptr<llvm::Module> mObj = llvm::CloneModule(module.get());
+#else
+  std::unique_ptr<llvm::Module> mAsm = llvm::CloneModule(*module.get());
+  std::unique_ptr<llvm::Module> mObj = llvm::CloneModule(*module.get());
+#endif
   llvm::legacy::PassManager pass;
 
   CHECK(tm->addPassesToEmitFile(


### PR DESCRIPTION
I got this error when trying to compile with LLVM7 on a raspberry pi. There seems to be missing compile guards here as the LLVM API has changed slightly. Here is the error. Changes are the added compile guards to the file. 

```
g++ -std=c++11 -Wall -O2 -Iinclude -I/home/pi/tvm/dlpack/include -I/home/pi/tvm/dmlc-core/include -IHalideIR/src -Itopi/include -fPIC -DTVM_CUDA_RUNTIME=0 -DTVM_ROCM_RUNTIME=0 -DTVM_OPENCL_RUNTIME=0 -DTVM_VULKAN_RUNTIME=0 -DTVM_OPENGL_RUNTIME=0 -DTVM_METAL_RUNTIME=0 -DTVM_SGX_RUNTIME=0 -fno-rtti -DDMLC_ENABLE_RTTI=0 -DDMLC_USE_FOPEN64=0 -I/home/pi/llvm/include -I/home/pi/llvm/build/include -DTVM_LLVM_VERSION=70 -MM -MT build/llvm70/codegen/llvm/codegen_amdgpu.o src/codegen/llvm/codegen_amdgpu.cc >build/llvm70/codegen/llvm/codegen_amdgpu.d
g++ -c -std=c++11 -Wall -O2 -Iinclude -I/home/pi/tvm/dlpack/include -I/home/pi/tvm/dmlc-core/include -IHalideIR/src -Itopi/include -fPIC -DTVM_CUDA_RUNTIME=0 -DTVM_ROCM_RUNTIME=0 -DTVM_OPENCL_RUNTIME=0 -DTVM_VULKAN_RUNTIME=0 -DTVM_OPENGL_RUNTIME=0 -DTVM_METAL_RUNTIME=0 -DTVM_SGX_RUNTIME=0 -fno-rtti -DDMLC_ENABLE_RTTI=0 -DDMLC_USE_FOPEN64=0 -I/home/pi/llvm/include -I/home/pi/llvm/build/include -DTVM_LLVM_VERSION=70 -c src/codegen/llvm/codegen_amdgpu.cc -o build/llvm70/codegen/llvm/codegen_amdgpu.o
src/codegen/llvm/codegen_amdgpu.cc: In function ‘tvm::runtime::Module tvm::codegen::BuildAMDGPU(tvm::Array<tvm::LoweredFunc>, std::string)’:
src/codegen/llvm/codegen_amdgpu.cc:203:70: error: no matching function for call to ‘CloneModule(std::unique_ptr<llvm::Module>::pointer)’
   std::unique_ptr<llvm::Module> mAsm = llvm::CloneModule(module.get());
                                                                      ^
src/codegen/llvm/codegen_amdgpu.cc:203:70: note: candidates are:
In file included from src/codegen/llvm/././llvm_common.h:31:0,
                 from src/codegen/llvm/./codegen_llvm.h:18,
                 from src/codegen/llvm/codegen_amdgpu.cc:11:
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:52:25: note: std::unique_ptr<llvm::Module> llvm::CloneModule(const llvm::Module&)
 std::unique_ptr<Module> CloneModule(const Module &M);
                         ^
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:52:25: note:   no known conversion for argument 1 from ‘std::unique_ptr<llvm::Module>::pointer {aka llvm::Module*}’ to ‘const llvm::Module&’
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:53:25: note: std::unique_ptr<llvm::Module> llvm::CloneModule(const llvm::Module&, llvm::ValueToValueMapTy&)
 std::unique_ptr<Module> CloneModule(const Module &M, ValueToValueMapTy &VMap);
                         ^
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:53:25: note:   candidate expects 2 arguments, 1 provided
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:60:1: note: std::unique_ptr<llvm::Module> llvm::CloneModule(const llvm::Module&, llvm::ValueToValueMapTy&, llvm::function_ref<bool(const llvm::GlobalValue*)>)
 CloneModule(const Module &M, ValueToValueMapTy &VMap,
 ^
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:60:1: note:   candidate expects 3 arguments, 1 provided
src/codegen/llvm/codegen_amdgpu.cc:204:70: error: no matching function for call to ‘CloneModule(std::unique_ptr<llvm::Module>::pointer)’
   std::unique_ptr<llvm::Module> mObj = llvm::CloneModule(module.get());
                                                                      ^
src/codegen/llvm/codegen_amdgpu.cc:204:70: note: candidates are:
In file included from src/codegen/llvm/././llvm_common.h:31:0,
                 from src/codegen/llvm/./codegen_llvm.h:18,
                 from src/codegen/llvm/codegen_amdgpu.cc:11:
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:52:25: note: std::unique_ptr<llvm::Module> llvm::CloneModule(const llvm::Module&)
 std::unique_ptr<Module> CloneModule(const Module &M);
                         ^
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:52:25: note:   no known conversion for argument 1 from ‘std::unique_ptr<llvm::Module>::pointer {aka llvm::Module*}’ to ‘const llvm::Module&’
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:53:25: note: std::unique_ptr<llvm::Module> llvm::CloneModule(const llvm::Module&, llvm::ValueToValueMapTy&)
 std::unique_ptr<Module> CloneModule(const Module &M, ValueToValueMapTy &VMap);
                         ^
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:53:25: note:   candidate expects 2 arguments, 1 provided
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:60:1: note: std::unique_ptr<llvm::Module> llvm::CloneModule(const llvm::Module&, llvm::ValueToValueMapTy&, llvm::function_ref<bool(const llvm::GlobalValue*)>)
 CloneModule(const Module &M, ValueToValueMapTy &VMap,
 ^
/home/pi/llvm/include/llvm/Transforms/Utils/Cloning.h:60:1: note:   candidate expects 3 arguments, 1 provided
Makefile:265: recipe for target 'build/llvm70/codegen/llvm/codegen_amdgpu.o' failed
make: *** [build/llvm70/codegen/llvm/codegen_amdgpu.o] Error 1
```


