### PR TITLE
fix wrong type declaration of float64 "log" in intrin_math.py

### DIFF
--- a/tutorials/language/intrin_math.py
+++ b/tutorials/language/intrin_math.py
@@ -116,7 +116,7 @@ def my_cuda_mylog_rule(op):
     if op.dtype == "float32":
         return tvm.call_pure_extern("float32", "logf", op.args[0])
     elif op.dtype == "float64":
-        return tvm.call_pure_extern("float32", "log", op.args[0])
+        return tvm.call_pure_extern("float64", "log", op.args[0])
     else:
         return op
 tvm.register_intrin_rule("cuda", "mylog", my_cuda_mylog_rule, override=True)


### PR DESCRIPTION
`log` function in CUDA is declared to return `float32` in `intrin_math.py`.
But I think it returns `float64`.

c.f. https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html#group__CUDA__MATH__DOUBLE_1g28ce8e15ef5149c271eba95663becba2