### PR TITLE
Equality check issue in nnvm is fixed 

### DIFF
--- a/topi/include/topi/detail/constant_utils.h
+++ b/topi/include/topi/detail/constant_utils.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "tvm/tvm.h"
+#include "tvm/ir_pass.h"
 
 namespace topi {
 namespace detail {

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -15,7 +15,6 @@
 #include "topi/detail/ravel_unravel.h"
 #include "topi/detail/constant_utils.h"
 #include "tvm/tvm.h"
-#include "tvm/ir_pass.h"
 
 namespace topi {
 using namespace tvm;


### PR DESCRIPTION
NNVM build is giving error as below. It is fixed with this PR.

```
In file included from tvm/topi/include/topi/nn.h:13:0,
                 from src/top/nn/nn.cc:19:
tvm/topi/include/topi/detail/constant_utils.h: In function ‘bool topi::detail::EqualCheck(HalideIR::Expr, HalideIR::Expr)’:
tvm/topi/include/topi/detail/constant_utils.h:78:26: error: ‘Equal’ is not a member of ‘tvm::ir’
   bool result = tvm::ir::Equal(lhs, rhs);
                          ^~~~~
tvm/topi/include/topi/detail/constant_utils.h:81:23: error: ‘Equal’ is not a member of ‘tvm::ir’
     result = tvm::ir::Equal(tvm::ir::CanonicalSimplify(lhs-rhs), zero);
                       ^~~~~
tvm/topi/include/topi/detail/constant_utils.h:81:38: error: ‘CanonicalSimplify’ is not a member of ‘tvm::ir’
     result = tvm::ir::Equal(tvm::ir::CanonicalSimplify(lhs-rhs), zero);

```