### PR TITLE
axis bounds checking in split

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,3 +63,4 @@ List of Contributors
 - [Cody Hao Yu](https://github.com/comaniac)
 - [Chris Nuernberger](https://github.com/cnuernber)
 - [Tatsuya Nishiyama](https://github.com/nishi-t)
+- [Kazutaka Morita](https://github.com/kazum)

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -310,6 +310,8 @@ inline Array<Tensor> split(const Tensor& x,
   if (axis < 0) {
     axis += static_cast<int>(x->shape.size());
   }
+  CHECK_LT(axis, x->shape.size()) << "axis out of bounds";
+
   auto src_axis_size = static_cast<int>(GetConstInt(x->shape[axis]));
 
   auto split_indices_val = GetConstIntValues(split_indices, "split_indices");


### PR DESCRIPTION
This PR avoids a segmentation fault of the following code:
```
import nnvm
import nnvm.symbol as sym

data = sym.Variable(name="data")
x = sym.split(data, indices_or_sections=(1,))
g = nnvm.graph.create(x)

nnvm.compiler.build(g, target="cuda")
```
