### PR TITLE
Fix build break on Windows.

### DIFF
--- a/include/tvm/ir_pass.h
+++ b/include/tvm/ir_pass.h
@@ -53,8 +53,8 @@ Stmt CanonicalSimplify(Stmt stmt,
  * \param vrange The range information about the variable.
  * \return Canonicalized expression.
  */
-Expr CanonicalSimplify(Expr expr,
-                       Map<Var, Range> vrange = Map<Var, Range>());
+EXPORT Expr CanonicalSimplify(Expr expr,
+                              Map<Var, Range> vrange = Map<Var, Range>());
 
 /*!
  * \brief Deep compare lhs and rhs


### PR DESCRIPTION
The CanonicalSimplify function was used but not exported.