### PR TITLE
Gitignore updated as NNVM untracked files not detected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,6 @@ build_*
 Win32
 *.dir
 perf
-nnvm
 *.wasm
 .emscripten
 


### PR DESCRIPTION
Issue: Untracked files in NNVM is not detected