### PR TITLE
[NNVM]CommonSubExpression Pass added

### DIFF
--- a/nnvm/python/nnvm/compiler/build_module.py
+++ b/nnvm/python/nnvm/compiler/build_module.py
@@ -15,8 +15,9 @@ OPT_PASS_LEVEL = {
     "SimplifyInference": 0,
     "PrecomputePrune": 2,
     "OpFusion": 1,
-    "FoldScaleAxis": 3,
-    "AlterOpLayout": 3,
+    "FoldScaleAxis": 4,
+    "AlterOpLayout": 4,
+    "CommonSubExpression": 3,
 }
 
 # List of optimization pass and level when switch on
@@ -270,6 +271,9 @@ def build(graph, target=None, shape=None, dtype="float32",
     # Apply optimization
     with target:
         graph = optimize(graph, shape, dtype, layout)
+    # Apply Common Sub Expression elimination
+    if params and cfg.pass_enabled("CommonSubExpression"):
+        graph = graph.apply("CommonSubExpression")
     # Precompute prune
     if params and cfg.pass_enabled("PrecomputePrune"):
         graph, params = precompute_prune(graph, params)

--- a/nnvm/src/compiler/common_sub_expression.cc
+++ b/nnvm/src/compiler/common_sub_expression.cc
@@ -1,0 +1,63 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file common_sub_expression.cc
+ * \brief take common expressions out and replace with one.
+ *
+ */
+#include <nnvm/graph.h>
+#include <nnvm/pass.h>
+
+namespace nnvm {
+namespace compiler {
+
+nnvm::Graph CommonSubExpression(nnvm::Graph src) {
+  std::vector<NodeEntry> commonNodeList;
+  std::unordered_map<std::string, int> unique_expressn;
+  std::string expressn = "";
+  std::function<std::string(const NodeEntry& node, std::string)>find_cummulative_expression
+    = [&find_cummulative_expression, &commonNodeList, &unique_expressn]
+    (const NodeEntry& node, std::string expressn)->std::string {
+    std::string tempExpressn = "";
+    // If varibale, just get the attribute name
+    if (node.node->is_variable()) {
+      tempExpressn += node.node->attrs.name;
+    } else {
+      for (auto& e : node.node->inputs) {
+        tempExpressn = find_cummulative_expression(e, tempExpressn);
+        if (unique_expressn.count(tempExpressn)) {
+          // Replace current one with already commoned node
+          e = commonNodeList[unique_expressn.at(tempExpressn)];
+          // Replace already commoned expression with its global index
+          tempExpressn = std::to_string(unique_expressn.at(tempExpressn));
+        }
+        expressn += tempExpressn;
+        tempExpressn = "";
+      }
+
+      // Append all the params name & value also in the expressn
+      for (auto kv : node.node->attrs.dict) {
+        expressn = kv.first + kv.second + expressn;
+      }
+      tempExpressn = node.node->op()->name + expressn;
+    }
+    return tempExpressn;
+  };
+
+  DFSVisit(src.outputs, [&](const nnvm::NodePtr& n) {
+    // If variable then, there is nothing to take common
+    if (!n->is_variable()) {
+      // If non-variable, then form logical expression
+      expressn = "";
+      expressn = find_cummulative_expression(nnvm::NodeEntry{n, 0, 0}, expressn);
+      commonNodeList.push_back(nnvm::NodeEntry{n, 0, 0});
+      unique_expressn.emplace(expressn, commonNodeList.size() - 1);
+    }
+  });
+
+  return src;
+}
+
+NNVM_REGISTER_PASS(CommonSubExpression)
+.set_body(CommonSubExpression);
+}  // namespace compiler
+}  // namespace nnvm

--- a/nnvm/tests/python/compiler/test_common_sub_expression.py
+++ b/nnvm/tests/python/compiler/test_common_sub_expression.py
@@ -1,0 +1,126 @@
+import nnvm
+import numpy as np
+import tvm
+import topi
+from tvm.contrib import graph_runtime
+from nnvm import symbol as sym
+from nnvm.compiler import graph_util, graph_attr
+from nnvm.testing import ctx_list
+
+def test_ewise_injective():
+    def final_expression(x, y, n):
+        y1 = sym.sqrt(y)
+        p = sym.elemwise_add(x, y1)
+        q = sym.elemwise_add(n, y1)
+        r = sym.elemwise_add(q, y1)
+        x1 = sym.sqrt(x)
+        s = sym.elemwise_add(q, x1)
+        t = sym.elemwise_add(r, s)
+        u = sym.tanh(t)
+        v = sym.elemwise_add(p, u)
+        w = sym.elemwise_add(r, v)
+        i = sym.tanh(s)
+        j = sym.elemwise_add(w, i)
+        k = sym.elemwise_add(j, y1)
+        l = sym.elemwise_add(p, k)
+        return l
+
+
+    x = sym.Variable("x")
+    y = sym.Variable("y")
+    n = sym.Variable("n")
+    z = sym.elemwise_add(x, sym.sqrt(y))
+    i = sym.elemwise_add(n, sym.sqrt(y))
+    p = sym.elemwise_add(i, sym.sqrt(y))
+    q = sym.elemwise_add(i, sym.sqrt(x))
+    r = sym.elemwise_add(p, q)
+    s = sym.tanh(r)
+    t = sym.elemwise_add(z, s)
+    a = sym.elemwise_add(n, sym.sqrt(y))
+    b = sym.elemwise_add(a, sym.sqrt(y))
+    c = sym.elemwise_add(i, sym.sqrt(x))
+    d = sym.elemwise_add(b, t)
+    e = sym.tanh(c)
+    f = sym.elemwise_add(d, e)
+    g = sym.elemwise_add(f, sym.sqrt(y))
+    k = sym.elemwise_add(z, g)
+    dshape = (4,)
+    shape_dict = {"x": dshape}
+    dtype = "float32"
+    target = "llvm"
+
+    g = nnvm.graph.create(k)
+    g2 = nnvm.graph.create(final_expression(x, y, n))
+    graph_attr.set_shape_inputs(g, shape_dict)
+    g1 = g.apply("InferShape").apply("SimplifyInference").apply("CommonSubExpression")
+    # assert graph equals as expected
+    graph_util.check_graph_equal(g1, g2)
+
+    for target, ctx in ctx_list():
+        x_np = np.array([1, 4, 9, 16]).astype("float32")
+        y_np = np.array([4, 4, 4, 4]).astype("float32")
+        n_np = np.array([9, 9, 9, 9]).astype("float32")
+        params = {"y": y_np, "n": n_np}
+        with nnvm.compiler.build_config(opt_level=3):
+            graph, lib, params = nnvm.compiler.build(k, target, shape_dict, params=params)
+        m = graph_runtime.create(graph, lib, ctx)
+        params["x"] = x_np
+        m["load_params"](nnvm.compiler.save_param_dict(params))
+        m.run()
+        out = m.get_output(0, tvm.nd.empty(dshape))
+        np.testing.assert_allclose(
+            out.asnumpy(),  np.array([23, 29, 39, 53]).astype("float32"),
+            atol=1e-5, rtol=1e-5)
+
+def test_ops_with_diffparams():
+    def final_expression(x, y):
+        y1 = sym.sqrt(y)
+        p = sym.elemwise_add(x, y1)
+        q = sym.leaky_relu(p, alpha = 0.3)
+        r = sym.leaky_relu(p, alpha = 0.2)
+        x1 = sym.sqrt(x)
+        s = sym.elemwise_add(r, x1)
+        t = sym.elemwise_add(s, p)
+        v = sym.elemwise_add(q, t)
+        return v
+
+
+    x = sym.Variable("x")
+    y = sym.Variable("y")
+    s = sym.elemwise_add(x , sym.sqrt(y))
+    z = sym.leaky_relu(s, alpha = 0.2)
+    t = sym.elemwise_add(z , sym.sqrt(x))
+    u = sym.elemwise_add(t , s)
+    v = sym.elemwise_add(x , sym.sqrt(y))
+    w = sym.leaky_relu(v, alpha = 0.3)
+    k = sym.elemwise_add(w , u)
+    dshape = (4,)
+    shape_dict = {"x": dshape}
+    dtype = "float32"
+    target = "llvm"
+
+    g = nnvm.graph.create(k)
+    g2 = nnvm.graph.create(final_expression(x, y))
+    graph_attr.set_shape_inputs(g, shape_dict)
+    g1 = g.apply("InferShape").apply("SimplifyInference").apply("CommonSubExpression")
+    # assert graph equals as expected
+    graph_util.check_graph_equal(g1, g2)
+
+    for target, ctx in ctx_list():
+        x_np = np.array([1, 4, 9, 16]).astype("float32")
+        y_np = np.array([4, 4, 4, 4]).astype("float32")
+        params = {"y": y_np}
+        with nnvm.compiler.build_config(opt_level=3):
+            graph, lib, params = nnvm.compiler.build(k, target, shape_dict, params=params)
+        m = graph_runtime.create(graph, lib, ctx)
+        params["x"] = x_np
+        m["load_params"](nnvm.compiler.save_param_dict(params))
+        m.run()
+        out = m.get_output(0, tvm.nd.empty(dshape))
+        np.testing.assert_allclose(
+            out.asnumpy(),  np.array([10, 20, 36, 58]).astype("float32"),
+            atol=1e-5, rtol=1e-5)
+
+if __name__ == "__main__":
+    test_ewise_injective()
+    test_ops_with_diffparams()


### PR DESCRIPTION
CommonSubExpression Pass added, Along with duplicate constants issue fixed in PrecomputePrune.

Common Sub Expression will basically take out common expression and define only once,
for example:
If the Graph has operation like:
a = sqrt(y)
b = sqrt(x)
c = elementwise_add(a, b)
d = sqrt(x)
e = tanh(d)

Then after CommonSubExpression Pass applied the Graph will become as below:
a = sqrt(y)
b = sqrt(x)
c = elementwise_add(a, b)
e = tanh(b) ## --> The common expression is gone

~/A.T.