### PR TITLE
Fix compilation failure with latest LLVM

### DIFF
--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -209,16 +209,28 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
 #endif
   llvm::legacy::PassManager pass;
 
+#if TVM_LLVM_VERSION <= 60
+  CHECK(tm->addPassesToEmitFile(
+            pass, destObj, llvm::TargetMachine::CGFT_ObjectFile) == 0)
+            << "Cannot emit target CGFT_ObjectFile";
+#else
   CHECK(tm->addPassesToEmitFile(
             pass, destObj, nullptr, llvm::TargetMachine::CGFT_ObjectFile) == 0)
             << "Cannot emit target CGFT_ObjectFile";
+#endif
   pass.run(*mObj);
   std::string obj(dataObj.begin(), dataObj.end());
 
   llvm::legacy::PassManager passAsm;
+#if TVM_LLVM_VERSION <= 60
+  CHECK(tm->addPassesToEmitFile(passAsm, destAsm,
+                                llvm::TargetMachine::CGFT_AssemblyFile) == 0)
+      << "Cannot emit target CGFT_AssemblyFile";
+#else
   CHECK(tm->addPassesToEmitFile(passAsm, destAsm, nullptr,
                                 llvm::TargetMachine::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_AssemblyFile";
+#endif
   passAsm.run(*mAsm);
   std::string assembly(dataAsm.begin(), dataAsm.end());
 

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -210,13 +210,13 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   llvm::legacy::PassManager pass;
 
   CHECK(tm->addPassesToEmitFile(
-            pass, destObj, llvm::TargetMachine::CGFT_ObjectFile) == 0)
+            pass, destObj, nullptr, llvm::TargetMachine::CGFT_ObjectFile) == 0)
             << "Cannot emit target CGFT_ObjectFile";
   pass.run(*mObj);
   std::string obj(dataObj.begin(), dataObj.end());
 
   llvm::legacy::PassManager passAsm;
-  CHECK(tm->addPassesToEmitFile(passAsm, destAsm,
+  CHECK(tm->addPassesToEmitFile(passAsm, destAsm, nullptr,
                                 llvm::TargetMachine::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_AssemblyFile";
   passAsm.run(*mAsm);

--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -195,7 +195,7 @@ runtime::Module BuildNVPTX(Array<LoweredFunc> funcs, std::string target) {
   // emit ptx
   llvm::legacy::PassManager pass;
   CHECK(tm->addPassesToEmitFile(
-      pass, dest_ptx, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
+      pass, dest_ptx, nullptr, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
   pass.run(*module);
   std::string ptx(data_ptx.begin(), data_ptx.end());

--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -194,9 +194,15 @@ runtime::Module BuildNVPTX(Array<LoweredFunc> funcs, std::string target) {
   std::string ll(data_ll.begin(), data_ll.end());
   // emit ptx
   llvm::legacy::PassManager pass;
+#if TVM_LLVM_VERSION <= 60
+  CHECK(tm->addPassesToEmitFile(
+      pass, dest_ptx, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
+      << "Cannot emit target CGFT_ObjectFile";
+#else
   CHECK(tm->addPassesToEmitFile(
       pass, dest_ptx, nullptr, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
       << "Cannot emit target CGFT_ObjectFile";
+#endif
   pass.run(*module);
   std::string ptx(data_ptx.begin(), data_ptx.end());
   return CUDAModuleCreate(ptx, "ptx", ExtractFuncInfo(funcs), ll);

--- a/src/codegen/llvm/llvm_module.cc
+++ b/src/codegen/llvm/llvm_module.cc
@@ -70,7 +70,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
       llvm::legacy::PassManager pass;
       CHECK(tm_);
       CHECK(tm_->addPassesToEmitFile(
-          pass, dest, llvm::TargetMachine::CGFT_ObjectFile) == 0)
+          pass, dest, nullptr, llvm::TargetMachine::CGFT_ObjectFile) == 0)
           << "Cannot emit target CGFT_ObjectFile";
       pass.run(*m);
     } else if (fmt == "s" || fmt == "asm") {
@@ -82,7 +82,7 @@ class LLVMModuleNode final : public runtime::ModuleNode {
       llvm::legacy::PassManager pass;
       CHECK(tm_);
       CHECK(tm_->addPassesToEmitFile(
-          pass, dest, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
+          pass, dest, nullptr, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
           << "Cannot emit target CGFT_AssemblyFile";
       pass.run(*m);
     } else if (fmt == "ll") {

--- a/src/codegen/llvm/llvm_module.cc
+++ b/src/codegen/llvm/llvm_module.cc
@@ -69,9 +69,15 @@ class LLVMModuleNode final : public runtime::ModuleNode {
 #endif
       llvm::legacy::PassManager pass;
       CHECK(tm_);
+#if TVM_LLVM_VERSION <= 60
+      CHECK(tm_->addPassesToEmitFile(
+          pass, dest, llvm::TargetMachine::CGFT_ObjectFile) == 0)
+          << "Cannot emit target CGFT_ObjectFile";
+#else
       CHECK(tm_->addPassesToEmitFile(
           pass, dest, nullptr, llvm::TargetMachine::CGFT_ObjectFile) == 0)
           << "Cannot emit target CGFT_ObjectFile";
+#endif
       pass.run(*m);
     } else if (fmt == "s" || fmt == "asm") {
 #if TVM_LLVM_VERSION <= 60
@@ -81,9 +87,15 @@ class LLVMModuleNode final : public runtime::ModuleNode {
 #endif
       llvm::legacy::PassManager pass;
       CHECK(tm_);
+#if TVM_LLVM_VERSION <= 60
+      CHECK(tm_->addPassesToEmitFile(
+          pass, dest, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
+          << "Cannot emit target CGFT_AssemblyFile";
+#else
       CHECK(tm_->addPassesToEmitFile(
           pass, dest, nullptr, llvm::TargetMachine::CGFT_AssemblyFile) == 0)
           << "Cannot emit target CGFT_AssemblyFile";
+#endif
       pass.run(*m);
     } else if (fmt == "ll") {
       mptr_->print(dest, nullptr);


### PR DESCRIPTION
LLVM recently changes API by adding one additional operand in `addPassesToEmitFile` (in this commit https://github.com/llvm-mirror/llvm/commit/9ffe073e98243cd8c3425c3ebf1d3337c4863247#diff-0f98aa9773c8beb761218f39bd8d4b2a ).
The new operand is used to generate DWARF debug information in a separate .dwo file. If we do not need .dwo file, we can just pass `nullptr`.

This PR passes `nullptr` for this new operand to avoid compilation error with the latest LLVM.