### PR TITLE
[NNVM][TOPI] Add gradients for broadcast_* ops

### DIFF
--- a/nnvm/include/nnvm/tuple.h
+++ b/nnvm/include/nnvm/tuple.h
@@ -56,7 +56,7 @@ class Tuple {
    * \brief constructor from vector
    * \param init the vector
    */
-  inline Tuple(std::vector<ValueType> init) {
+  inline Tuple(std::vector<ValueType> init) {  // NOLINT(runtime/explicit)
     this->assign(init.begin(), init.end());
   }
   /*!
@@ -64,7 +64,7 @@ class Tuple {
    * \param src the source shape
    */
 
-  inline Tuple(Tuple<ValueType>&& src) { // NOLINT(*)
+  inline Tuple(Tuple<ValueType>&& src) {   // NOLINT(runtime/explicit)
     this->swap(src);
   }
   /*!

--- a/nnvm/include/nnvm/tuple.h
+++ b/nnvm/include/nnvm/tuple.h
@@ -53,6 +53,13 @@ class Tuple {
     this->assign(init.begin(), init.end());
   }
   /*!
+   * \brief constructor from vector
+   * \param init the vector
+   */
+  inline Tuple(std::vector<ValueType> init) {
+    this->assign(init.begin(), init.end());
+  }
+  /*!
    * \brief move constructor from Tuple
    * \param src the source shape
    */

--- a/nnvm/python/nnvm/top/reduction.py
+++ b/nnvm/python/nnvm/top/reduction.py
@@ -37,3 +37,7 @@ reg.register_schedule("max", _fschedule_reduce)
 # min
 reg.register_pattern("min", OpPattern.COMM_REDUCE)
 reg.register_schedule("min", _fschedule_reduce)
+
+# collapse sum
+reg.register_pattern("collapse_sum", OpPattern.COMM_REDUCE)
+reg.register_schedule("collapse_sum", _fschedule_reduce)

--- a/nnvm/src/top/tensor/reduce.cc
+++ b/nnvm/src/top/tensor/reduce.cc
@@ -12,9 +12,10 @@
 #include <nnvm/top/tensor.h>
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
+#include "topi/detail/constant_utils.h"
+#include "topi/elemwise.h"
 #include "topi/reduction.h"
 #include "topi/transform.h"
-#include "topi/detail/constant_utils.h"
 
 namespace nnvm {
 namespace top {
@@ -168,6 +169,7 @@ Example::
     const ReduceParam& param = nnvm::get<ReduceParam>(attrs.parsed);
     TShape r_axes = GetReduceAxes(inputs[0]->shape.size(),
                                   param.axis, param.exclude);
+    if (!r_axes.ndim()) return Array<Tensor> { topi::identity(inputs[0]) };
     auto axis = ShapeToArray(r_axes);
     return Array<Tensor>{
       topi::sum(inputs[0], axis, param.keepdims) };

--- a/nnvm/src/top/tensor/reduce.cc
+++ b/nnvm/src/top/tensor/reduce.cc
@@ -267,17 +267,18 @@ NNVM_REGISTER_COLLAPSE_OP(sum)
     std::vector<dim_t> r_axes;
     bool keepdims = false;
     std::vector<dim_t> squeeze_axes;
-    for (int i = ishape.size() - 1, j = oshape.size() - 1; i >= 0; --i) {
-      if (j < 0 || ishape[i] != oshape[j]) {
-        r_axes.push_back(i);
-        if (j < 0) {
-          squeeze_axes.push_back(i);
-        } else {
-          keepdims |= oshape[j] == 1;
-          j -= oshape[j] == 1;
-        }
-      } else {
-        --j;
+    for (int i_ax = ishape.size() - 1,
+             o_ax = oshape.size() - 1; i_ax >= 0; --i_ax) {
+      if (o_ax >= 0 && ishape[i_ax] == oshape[o_ax]) {
+        --o_ax;
+        continue;
+      }
+      r_axes.push_back(i_ax);
+      if (o_ax < 0) {  // squeeze o_ax if was added during expansion
+        squeeze_axes.push_back(i_ax);
+      } else if (oshape[o_ax] == 1) {
+        keepdims = true;
+        --o_ax;
       }
     }
 

--- a/nnvm/src/top/tensor/reduce.cc
+++ b/nnvm/src/top/tensor/reduce.cc
@@ -3,13 +3,13 @@
  * \file reduce.cc
  * \brief reduce operator.
  */
-#include <numeric>
 #include <nnvm/op.h>
 #include <nnvm/node.h>
 #include <nnvm/op_attr_types.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <nnvm/compiler/util.h>
 #include <nnvm/top/tensor.h>
+#include <numeric>
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
 #include "topi/detail/constant_utils.h"

--- a/nnvm/src/top/tensor/transform.cc
+++ b/nnvm/src/top/tensor/transform.cc
@@ -242,8 +242,7 @@ will return a new array with shape ``(2,1,1,1,1,1,3,4)``.
                   const std::vector<NodeEntry>& ograds){
     const ExpandDimsParam& param = nnvm::get<ExpandDimsParam>(n->attrs.parsed);
     return std::vector<NodeEntry> {
-      MakeNode("sum", n->attrs.name + "_grad", {ograds[0]},
-               {{"axis", std::to_string(param.axis)}})
+      MakeNode("collapse_sum", n->attrs.name, {ograds[0], n->inputs[0]})
     };
 })
 .set_support_level(1);

--- a/nnvm/src/top/tensor/transform.cc
+++ b/nnvm/src/top/tensor/transform.cc
@@ -240,9 +240,8 @@ will return a new array with shape ``(2,1,1,1,1,1,3,4)``.
 .set_attr<FGradient>(
   "FGradient", [](const NodePtr& n,
                   const std::vector<NodeEntry>& ograds){
-    const ExpandDimsParam& param = nnvm::get<ExpandDimsParam>(n->attrs.parsed);
     return std::vector<NodeEntry> {
-      MakeNode("collapse_sum", n->attrs.name, {ograds[0], n->inputs[0]})
+      MakeNode("collapse_sum", n->attrs.name + "_grad", {ograds[0], n->inputs[0]})
     };
 })
 .set_support_level(1);

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -117,10 +117,10 @@ def test_collapse():
     verify_collapse((2, 3, 4), (3, 4), lambda x: x.sum(0))
     verify_collapse((2, 3, 4), (1, 3, 4), lambda x: x.sum(0, keepdims=True))
     verify_collapse((2, 3, 4), (1, 1, 4), lambda x: x.sum((0, 1), keepdims=True))
-    verify_collapse((2, 3, 4), (2, 3, 4), lambda x: x)
     verify_collapse((2, 3, 4), (2, 1, 4), lambda x: x.sum(1, keepdims=True))
     verify_collapse((2, 3, 4), (2, 1, 1), lambda x: x.sum((1, 2), keepdims=True))
     verify_collapse((2, 3, 4), (2, 3, 1), lambda x: x.sum(2, keepdims=True))
+    verify_collapse((2, 3, 4), (2, 3, 4), lambda x: x)
 
 
 def verify_flip(ishape, axis):

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -106,6 +106,7 @@ def test_reduce():
     verify_reduce((2, 3, 4), np.max, sym.max, axis=1, keepdims=True)
     verify_reduce((4, 4, 3), np.min, sym.min, keepdims=True)
     verify_reduce((4, 4, 3), np.sum, sym.sum, axis=(0, 2))
+    verify_reduce((4, 4, 3), np.sum, sym.sum)
 
 
 def test_collapse():

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -95,7 +95,7 @@ def verify_collapse(dshape, target_shape):
         m.get_output(0, tvm.nd.empty(target_shape))
 
 
-def test_tranpose():
+def test_transpose():
     verify_transpose((2, 3, 4), (0, 2, 1))
     verify_transpose((2, 3, 4), None)
 
@@ -538,7 +538,7 @@ if __name__ == "__main__":
     test_broadcast()
     test_reduce()
     test_collapse()
-    test_tranpose()
+    test_transpose()
     test_clip()
     test_greater()
     test_less()

--- a/nnvm/tests/python/unittest/test_graph_gradient.py
+++ b/nnvm/tests/python/unittest/test_graph_gradient.py
@@ -164,7 +164,7 @@ def _run_op_grad(op):
         outs.append(mod.get_output(
             i,tvm.nd.array(np.zeros(s, dtype='float32'))).asnumpy())
 
-    return (arrs['a'], arrs['b'], arrs['g'], *outs)
+    return [arrs['a'], arrs['b'], arrs['g']] + outs
 
 def test_broadcast_grads():
     # add

--- a/nnvm/tests/python/unittest/test_graph_gradient.py
+++ b/nnvm/tests/python/unittest/test_graph_gradient.py
@@ -1,5 +1,9 @@
+import nnvm
 import nnvm.symbol as sym
 from nnvm.compiler import graph_util
+import numpy as np
+import tvm
+from tvm.contrib import graph_runtime
 
 def test_cnn_gradients():
     # input data
@@ -130,7 +134,61 @@ def test_multi_loss_graph_gradients():
     # test reverse infer type for label
     assert grad_g.apply('InferType').json_attr('dtype_num_unknown_nodes') == 0
 
+def _run_op_grad(op):
+    ishapes = {
+        'a': (4,),
+        'b': (5, 4),
+        'g': (5, 4),
+    }
+    arrs = {}
+    syms = {}
+    params = {}
+    for n, s in ishapes.items():
+        syms[n] = sym.Variable(n, shape=s, dtype='float32')
+        arrs[n] = np.random.randn(*s).astype('float32')
+        params[n] = tvm.nd.array(arrs[n])
+
+    op = getattr(sym, 'broadcast_' + op)(syms['a'], syms['b'])
+    gop = graph_util.get_gradient_graph(op, [syms['a'], syms['b']], syms['g'])
+    net = nnvm.graph.create(gop)
+    with nnvm.compiler.build_config(opt_level=-1):
+        graph, lib, params = nnvm.compiler.build(net, 'llvm', params=params)
+
+    mod = graph_runtime.create(graph, lib, tvm.cpu(0))
+    mod.set_input(**params)
+    mod.run()
+
+    oshapes = ((4,), (5, 4))
+    outs = []
+    for i, s in enumerate(oshapes):
+        outs.append(mod.get_output(
+            i,tvm.nd.array(np.zeros(s, dtype='float32'))).asnumpy())
+
+    return (arrs['a'], arrs['b'], arrs['g'], *outs)
+
+def test_broadcast_grads():
+    # add
+    a, b, g, da, db = _run_op_grad('add')
+    assert np.allclose(da, g.sum(0))
+    assert np.allclose(db, g)
+
+    # sub
+    a, b, g, da, db = _run_op_grad('sub')
+    assert np.allclose(da, g.sum(0))
+    assert np.allclose(db, -g)
+
+    # mul
+    a, b, g, da, db = _run_op_grad('mul')
+    assert np.allclose(da, (g * b).sum(0))
+    assert np.allclose(db, g * a)
+
+    # div
+    a, b, g, da, db = _run_op_grad('div')
+    assert np.allclose(da, (g / b).sum(0))
+    assert np.allclose(db, g * a / (2*b**2))
+
 
 if __name__ == "__main__":
     test_cnn_gradients()
     test_multi_loss_graph_gradients()
+    test_broadcast_grads()

--- a/topi/include/topi/reduction.h
+++ b/topi/include/topi/reduction.h
@@ -121,7 +121,6 @@ inline Tensor DoCommReduce(const Tensor& data,
     Array<Var> eval_indices;
     int arg_counter = 0;
     int red_counter = 0;
-    int keep_counter = 0;
 
     for (size_t i = 0; i < data->shape.size(); ++i) {
       bool squeeze_i = std::find(squeeze_axes.begin(), squeeze_axes.end(), i) != squeeze_axes.end();
@@ -130,15 +129,11 @@ inline Tensor DoCommReduce(const Tensor& data,
         eval_range.push_back(r_axes[red_counter]);
         eval_indices.push_back(r_axes[red_counter]->var);
         red_counter++;
-        keep_counter += squeeze_i;
+        arg_counter += !squeeze_i;
         continue;
       }
-      if (squeeze_i) {
-        eval_range.push_back(indices[arg_counter]);
-        arg_counter++;
-      } else {
-        eval_range.push_back(indices[keep_counter]);
-      }
+      eval_range.push_back(indices[arg_counter]);
+      arg_counter++;
     }
 
     return func(data(eval_range), r_axes);

--- a/topi/include/topi/reduction.h
+++ b/topi/include/topi/reduction.h
@@ -94,6 +94,9 @@ inline Array<Expr> MakeReduceTargetShape(const std::vector<int>& real_axis,
         target_shape.push_back(data->shape[i]);
       }
     }
+    if (target_shape.size() == 0) {
+      target_shape.push_back(1);
+    }
   }
   return target_shape;
 }

--- a/topi/include/topi/reduction.h
+++ b/topi/include/topi/reduction.h
@@ -325,7 +325,7 @@ inline Tensor collapse_sum(const Tensor& data, Array<Expr> target_shape) {
     }
   }
 
-  if (reduce_axes.size() == 0) return topi::identity(data);
+  if (reduce_axes.size() == 0) return topi::identity(data, "tensor", kCommReduce);
 
   std::reverse(reduce_axes.begin(), reduce_axes.end());
   std::reverse(squeeze_axes.begin(), squeeze_axes.end());

--- a/topi/python/topi/cuda/reduction.py
+++ b/topi/python/topi/cuda/reduction.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import as _abs
 import tvm
 from .. import tag
 from .. import generic
+from .injective import _schedule_injective
 
 def _schedule_reduce(op, sch, is_idx_reduce=False):
     if is_idx_reduce:
@@ -11,7 +12,9 @@ def _schedule_reduce(op, sch, is_idx_reduce=False):
     else:
         data_in = op.input_tensors[0]
         data_out = op.output(0)
-    assert len(sch[data_out].op.reduce_axis) > 0, "reduce_axis must be bigger than zero!"
+
+    if not sch[data_out].op.reduce_axis:
+        return _schedule_injective(op, sch)
 
     if len(sch[data_out].op.axis) > 0:
         all_reduce = False

--- a/topi/tests/python_cpp/test_topi_reduce.py
+++ b/topi/tests/python_cpp/test_topi_reduce.py
@@ -73,6 +73,7 @@ def verify_reduce_map_ele(in_shape, axis, keepdims, type="sum"):
             out_npy = _my_npy_argmin(in_npy_map, axis=axis, keepdims=keepdims)
         else:
             raise NotImplementedError
+        out_npy = np.atleast_1d(out_npy)
         data_tvm = tvm.nd.array(in_npy, ctx=ctx)
         out_tvm = tvm.nd.empty(shape=out_npy.shape, ctx=ctx, dtype=out_dtype)
         for _ in range(1):


### PR DESCRIPTION
This PR
* adds gradient operators for `broadcast_*` ops by adding a `collapse_sum` op
* fixes a bug in reduce ops which didn't correctly apply excluded reduce axes
* fixes a bug in `MakeReduceTargetShape` which prevents reduction to scalar