### PR TITLE
[NNVM][FRONTEND][ONNX] Fix the gemm conversion in onnx frontend

### DIFF
--- a/nnvm/python/nnvm/frontend/onnx.py
+++ b/nnvm/python/nnvm/frontend/onnx.py
@@ -186,6 +186,7 @@ class Gemm(OnnxOpConverter):
             inputs[0] = _sym.transpose(inputs[0], axes=(1, 0))
         if not transB:
             inputs[1] = _sym.transpose(inputs[1], axes=(1, 0))
+        inputs[0] = _sym.flatten(inputs[0])
         return _sym.dense(
             alpha * inputs[0], inputs[1], beta * inputs[2], units=channels)
 


### PR DESCRIPTION
This PR addressed #1231 
I think that the problem caused by passing 4 dimensions no flatten data to `dense` operator. I locally confirmed that `vgg19` is compiled successfully. Please review.