### PR TITLE
support custom IP address from rpc server to tracker (PUT)

### DIFF
--- a/python/tvm/contrib/rpc/server.py
+++ b/python/tvm/contrib/rpc/server.py
@@ -71,7 +71,6 @@ def _parse_server_opt(opts):
             ret["timeout"] = float(kv[9:])
     return ret
 
-print("load listen loop func")
 def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
     """Lisenting loop of the server master."""
     def _accept_conn(listen_sock, tracker_conn, ping_period=2):
@@ -92,7 +91,6 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
         # Report resource to tracker
         if tracker_conn:
             matchkey = base.random_key(rpc_key + ":")
-            print("SEND JSON PUT (FIRST)")
             if custom_addr is not None:
                 base.sendjson(tracker_conn,
                               [TrackerCode.PUT, rpc_key, (port, matchkey), custom_addr])
@@ -161,7 +159,6 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
             # step 1: setup tracker and report to tracker
             if tracker_addr and tracker_conn is None:
                 tracker_conn = base.connect_with_retry(tracker_addr)
-                print("ABOUT TO SEND:", struct.pack("<i", base.RPC_TRACKER_MAGIC))
                 tracker_conn.sendall(struct.pack("<i", base.RPC_TRACKER_MAGIC))
                 magic = struct.unpack("<i", base.recvall(tracker_conn, 4))[0]
                 if magic != base.RPC_TRACKER_MAGIC:

--- a/python/tvm/contrib/rpc/server.py
+++ b/python/tvm/contrib/rpc/server.py
@@ -95,7 +95,7 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
                 base.sendjson(tracker_conn,
                               [TrackerCode.PUT, rpc_key, (port, matchkey), custom_addr])
             else:
-                 base.sendjson(tracker_conn,
+                base.sendjson(tracker_conn,
                               [TrackerCode.PUT, rpc_key, (port, matchkey)])
             assert base.recvjson(tracker_conn) == TrackerCode.SUCCESS
         else:
@@ -112,7 +112,7 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
                     pending_keys = base.recvjson(tracker_conn)
                     old_keyset.add(matchkey)
                     # if match key not in pending key set
-                    # it means the key is aqquired by a client but not used.
+                    # it means the key is acquired by a client but not used.
                     if matchkey not in pending_keys:
                         unmatch_period_count += 1
                     else:
@@ -124,9 +124,9 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
                         if custom_addr is not None:
                             base.sendjson(tracker_conn,
                                           [TrackerCode.PUT, rpc_key, (port, matchkey),
-                                          custom_addr])
+                                           custom_addr])
                         else:
-                             base.sendjson(tracker_conn,
+                            base.sendjson(tracker_conn,
                                           [TrackerCode.PUT, rpc_key, (port, matchkey)])
                         assert base.recvjson(tracker_conn) == TrackerCode.SUCCESS
                         unmatch_period_count = 0

--- a/python/tvm/contrib/rpc/server.py
+++ b/python/tvm/contrib/rpc/server.py
@@ -91,12 +91,8 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
         # Report resource to tracker
         if tracker_conn:
             matchkey = base.random_key(rpc_key + ":")
-            if custom_addr is not None:
-                base.sendjson(tracker_conn,
-                              [TrackerCode.PUT, rpc_key, (port, matchkey), custom_addr])
-            else:
-                base.sendjson(tracker_conn,
-                              [TrackerCode.PUT, rpc_key, (port, matchkey)])
+            base.sendjson(tracker_conn,
+                          [TrackerCode.PUT, rpc_key, (port, matchkey), custom_addr])
             assert base.recvjson(tracker_conn) == TrackerCode.SUCCESS
         else:
             matchkey = rpc_key
@@ -121,13 +117,9 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
                     if unmatch_period_count * ping_period > unmatch_timeout + ping_period:
                         logging.info("RPCServer: no incoming connections, regenerate key ...")
                         matchkey = base.random_key(rpc_key + ":", old_keyset)
-                        if custom_addr is not None:
-                            base.sendjson(tracker_conn,
-                                          [TrackerCode.PUT, rpc_key, (port, matchkey),
-                                           custom_addr])
-                        else:
-                            base.sendjson(tracker_conn,
-                                          [TrackerCode.PUT, rpc_key, (port, matchkey)])
+                        base.sendjson(tracker_conn,
+                                      [TrackerCode.PUT, rpc_key, (port, matchkey),
+                                       custom_addr])
                         assert base.recvjson(tracker_conn) == TrackerCode.SUCCESS
                         unmatch_period_count = 0
                     continue

--- a/python/tvm/contrib/rpc/tracker.py
+++ b/python/tvm/contrib/rpc/tracker.py
@@ -194,11 +194,10 @@ class TCPEventHandler(tornado_util.TCPHandler):
             key = args[1]
             port, matchkey = args[2]
             self.pending_matchkeys.add(matchkey)
+            self._tracker.put(key, (self, self._addr[0], port, matchkey))
             # got custom address (from rpc server)
             if args[3] is not None:
                 self._tracker.put(key, (self, args[3], port, matchkey))
-            else:
-                self._tracker.put(key, (self, self._addr[0], port, matchkey))
             self.ret_value(TrackerCode.SUCCESS)
         elif code == TrackerCode.REQUEST:
             key = args[1]

--- a/python/tvm/contrib/rpc/tracker.py
+++ b/python/tvm/contrib/rpc/tracker.py
@@ -195,7 +195,7 @@ class TCPEventHandler(tornado_util.TCPHandler):
             port, matchkey = args[2]
             self.pending_matchkeys.add(matchkey)
             # got custom address (from rpc server)
-            if len(args) > 3:
+            if str(args[3]) != 'None':
                 self._tracker.put(key, (self, args[3], port, matchkey))
             else:
                 self._tracker.put(key, (self, self._addr[0], port, matchkey))

--- a/python/tvm/contrib/rpc/tracker.py
+++ b/python/tvm/contrib/rpc/tracker.py
@@ -194,7 +194,11 @@ class TCPEventHandler(tornado_util.TCPHandler):
             key = args[1]
             port, matchkey = args[2]
             self.pending_matchkeys.add(matchkey)
-            self._tracker.put(key, (self, self._addr[0], port, matchkey))
+            # got custom address (from rpc server)
+            if len(args) > 3:
+                self._tracker.put(key, (self, args[3], port, matchkey))
+            else:
+                self._tracker.put(key, (self, self._addr[0], port, matchkey))
             self.ret_value(TrackerCode.SUCCESS)
         elif code == TrackerCode.REQUEST:
             key = args[1]

--- a/python/tvm/contrib/rpc/tracker.py
+++ b/python/tvm/contrib/rpc/tracker.py
@@ -194,10 +194,11 @@ class TCPEventHandler(tornado_util.TCPHandler):
             key = args[1]
             port, matchkey = args[2]
             self.pending_matchkeys.add(matchkey)
-            self._tracker.put(key, (self, self._addr[0], port, matchkey))
             # got custom address (from rpc server)
             if args[3] is not None:
                 self._tracker.put(key, (self, args[3], port, matchkey))
+            else:
+                self._tracker.put(key, (self, self._addr[0], port, matchkey))
             self.ret_value(TrackerCode.SUCCESS)
         elif code == TrackerCode.REQUEST:
             key = args[1]

--- a/python/tvm/contrib/rpc/tracker.py
+++ b/python/tvm/contrib/rpc/tracker.py
@@ -195,7 +195,7 @@ class TCPEventHandler(tornado_util.TCPHandler):
             port, matchkey = args[2]
             self.pending_matchkeys.add(matchkey)
             # got custom address (from rpc server)
-            if str(args[3]) != 'None':
+            if args[3] is not None:
                 self._tracker.put(key, (self, args[3], port, matchkey))
             else:
                 self._tracker.put(key, (self, self._addr[0], port, matchkey))

--- a/python/tvm/exec/rpc_server.py
+++ b/python/tvm/exec/rpc_server.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
                          is able to avoid potential fork problems with Metal, OpenCL \
                          and ROCM compilers.")
     parser.add_argument('--custom-addr', type=str,
-                        help="Custom IP Address to Report to RPC Tracker") 
+                        help="Custom IP Address to Report to RPC Tracker")
 
     parser.set_defaults(fork=True)
     args = parser.parse_args()

--- a/python/tvm/exec/rpc_server.py
+++ b/python/tvm/exec/rpc_server.py
@@ -10,7 +10,7 @@ from ..contrib import rpc
 
 
 def main(args):
-    """Main funciton"""
+    """Main function"""
 
     if args.tracker:
         url, port = args.tracker.split(":")
@@ -27,7 +27,8 @@ def main(args):
                         args.port_end,
                         key=args.key,
                         tracker_addr=tracker_addr,
-                        load_library=args.load_library)
+                        load_library=args.load_library,
+                        custom_addr=args.custom_addr)
     server.proc.join()
 
 
@@ -49,6 +50,7 @@ if __name__ == "__main__":
                         help="Use spawn mode to avoid fork. This option \
                          is able to avoid potential fork problems with Metal, OpenCL \
                          and ROCM compilers.")
+    parser.add_argument('--custom-addr', type=str) 
     parser.set_defaults(fork=True)
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)

--- a/python/tvm/exec/rpc_server.py
+++ b/python/tvm/exec/rpc_server.py
@@ -8,7 +8,6 @@ import sys
 import logging
 from ..contrib import rpc
 
-
 def main(args):
     """Main function"""
 
@@ -50,7 +49,9 @@ if __name__ == "__main__":
                         help="Use spawn mode to avoid fork. This option \
                          is able to avoid potential fork problems with Metal, OpenCL \
                          and ROCM compilers.")
-    parser.add_argument('--custom-addr', type=str) 
+    parser.add_argument('--custom-addr', type=str,
+                        help="Custom IP Address to Report to RPC Tracker") 
+
     parser.set_defaults(fork=True)
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Currently the tracker uses the IP address of the connection when a new rpc server registers.
In the case of a network topology where the tracker is behind a NAT/firewall, the registering RPC server's connection will appear to come from another device from within the NAT (e.g., if we use an ssh tunnel).
This PR allows the registering RPC server to specify a custom IP at `PUT` time so RPC requests to the tracker can receive the actual address of the server.