### PR TITLE
Add -Bsymbolic-functions to linker option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ UNAME_S := $(shell uname -s)
 
 # The flags
 LLVM_CFLAGS= -fno-rtti -DDMLC_ENABLE_RTTI=0 -DDMLC_USE_FOPEN64=0
-LDFLAGS = -pthread -lm -ldl
+LDFLAGS = -pthread -lm -ldl -Wl,-Bsymbolic-functions
 INCLUDE_FLAGS = -Iinclude -I$(DLPACK_PATH)/include -I$(DMLC_CORE_PATH)/include -IHalideIR/src -Itopi/include
 CFLAGS = -std=c++11 -Wall -O2 $(INCLUDE_FLAGS) -fPIC
 PKG_LDFLAGS =


### PR DESCRIPTION
The value of `extension_class_info<tvm::Target>::code` is 0 in libtvm.so and 28 in libtvm_topi.so.  This can result in different implementations with the same function symbol between libtvm.so and libtvm_topi.so.

Actualy, we cannot pass python_cpp tests when we use `-O0` compiler option.
```
$ grep CFLAGS config.mk
ADD_CFLAGS = -O0

$ nm -C lib/libtvm.so | grep 'tvm::runtime::TVMArgValue::operator tvm::Target'
0000000000ce4054 W tvm::runtime::TVMArgValue::operator tvm::Target<tvm::Target, void>() const

$ nm -C lib/libtvm_topi.so | grep 'tvm::runtime::TVMArgValue::operator tvm::Target'
00000000001525b2 W tvm::runtime::TVMArgValue::operator tvm::Target<tvm::Target, void>() const

$ python -m nose -vs
topi/tests/python_cpp/test_topi_clip.py test_topi_clip.test_clip ... ERROR

======================================================================
ERROR: test_topi_clip.test_clip
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kazutaka/nnvm/.venv/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/var/tmp/tvm/topi/tests/python_cpp/test_topi_clip.py", line 38, in test_clip
    verify_clip(1024, -127, 127, 'int8')
  File "/var/tmp/tvm/topi/tests/python_cpp/test_topi_clip.py", line 35, in verify_clip
    check_device(device)
  File "/var/tmp/tvm/topi/tests/python_cpp/test_topi_clip.py", line 26, in check_device
    s = topi.cpp.generic.default_schedule(target, [B], False)
  File "/var/tmp/tvm/python/tvm/_ffi/function.py", line 280, in my_api_func
    return flocal(*args)
  File "/var/tmp/tvm/python/tvm/_ffi/_ctypes/function.py", line 183, in __call__
    ctypes.byref(ret_val), ctypes.byref(ret_tcode)))
  File "/var/tmp/tvm/python/tvm/_ffi/base.py", line 66, in check_call
    raise TVMError(py_str(_LIB.TVMGetLastError()))
TVMError: [12:42:38] include/tvm/././runtime/./packed_func.h:638: unknown type_code=28

Stack trace returned 10 entries:
[bt] (0) /var/tmp/tvm/lib/libtvm.so(dmlc::StackTrace[abi:cxx11]()+0x54) [0x7fb281431f7f]
[bt] (1) /var/tmp/tvm/lib/libtvm.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x2a) [0x7fb281432266]
[bt] (2) /var/tmp/tvm/lib/libtvm.so(tvm::runtime::TypeCode2Str(int)+0x140) [0x7fb281518e6a]
[bt] (3) /var/tmp/tvm/lib/libtvm.so(tvm::Target tvm::runtime::TVMArgValue::AsNodeRef<tvm::Target>() const+0xa6) [0x7fb281723e50]
[bt] (4) /var/tmp/tvm/lib/libtvm.so(tvm::runtime::detail::TVMValueCast<tvm::Target, tvm::runtime::TVMArgValue, false>::Apply(tvm::runtime::TVMArgValue const*)+0x32) [0x7fb281720\
87b]
[bt] (5) /var/tmp/tvm/lib/libtvm.so(tvm::runtime::TVMArgValue::operator tvm::Target<tvm::Target, void>() const+0x32) [0x7fb28171e086]
[bt] (6) /var/tmp/tvm/lib/libtvm_topi.so(+0xf3651) [0x7fb27c58e651]
[bt] (7) /var/tmp/tvm/lib/libtvm_topi.so(+0xfd502) [0x7fb27c598502]
[bt] (8) /var/tmp/tvm/lib/libtvm.so(std::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+\
0x5a) [0x7fb28151a20c]
[bt] (9) /var/tmp/tvm/lib/libtvm.so(tvm::runtime::PackedFunc::CallPacked(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const+0x30) [0x7fb28171b03c]
```

To solve this problem, this PR adds -Bsymbolic-functions linker option to use the local function definition within the shared library.
