### PR TITLE
Fix warning 

### DIFF
--- a/nnvm/include/nnvm/layout.h
+++ b/nnvm/include/nnvm/layout.h
@@ -348,7 +348,7 @@ class Layout {
     return false;
   }
 
-  inline const LayoutDim operator[](size_t i) const {
+  inline LayoutDim operator[](size_t i) const {
     return layout_simplified_[i];
   }
 


### PR DESCRIPTION
Fix compilation warning: 
```
nnvm/include/nnvm/./layout.h(351): warning: type qualifier on return type is meaningless
```