### PR TITLE
Fix the building error in android_deploy

### DIFF
--- a/apps/android_deploy/README.md
+++ b/apps/android_deploy/README.md
@@ -99,7 +99,7 @@ If everything goes well, you will find compile tools in `/opt/android-toolchain-
 
 ### Place compiled model on Android application assets folder
 
-Follow instruction to get compiled version model for android target [here.](https://tvm.ai/deploy/android.html)
+Follow instruction to get compiled version model for android target [here.](http://docs.tvm.ai/deploy/android.html)
 
 Copied these compiled model deploy_lib.so, deploy_graph.json and deploy_param.params to apps/android_deploy/app/src/main/assets/ and modify TVM flavor changes on [java](https://github.com/dmlc/tvm/blob/master/apps/android_deploy/app/src/main/java/ml/dmlc/tvm/android/demo/MainActivity.java#L81)
 

--- a/apps/android_deploy/app/src/main/jni/Application.mk
+++ b/apps/android_deploy/app/src/main/jni/Application.mk
@@ -8,7 +8,7 @@ endif
 
 include $(config)
 
-APP_STL := gnustl_static
+APP_STL := c++_static
 
 APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++11 -Oz -frtti
 ifeq ($(USE_OPENCL), 1)                                                                                                                                             

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -69,14 +69,14 @@ class ParallelLauncher {
       tvm::runtime::threading::Yield();
     }
     if (!has_error_.load()) return 0;
-    std::string err("");
+    std::stringstream err;
     for (size_t i = 0; i < par_errors_.size(); ++i) {
       if (par_errors_[i].length() != 0) {
-        err += "Task " + std::to_string(i) + " error: " + par_errors_[i] + '\n';
+        err << "Task " << i << " error: " << par_errors_[i] << std::endl;
         par_errors_[i].clear();
       }
     }
-    TVMAPISetLastError(err.c_str());
+    TVMAPISetLastError(err.str().c_str());
     return -1;
   }
   // Signal that one job has finished.

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -69,14 +69,16 @@ class ParallelLauncher {
       tvm::runtime::threading::Yield();
     }
     if (!has_error_.load()) return 0;
-    std::stringstream err;
+    // the following is intended to use string due to
+    // security issue raised in SGX backend
+    std::string err("");
     for (size_t i = 0; i < par_errors_.size(); ++i) {
       if (par_errors_[i].length() != 0) {
-        err << "Task " << i << " error: " << par_errors_[i] << std::endl;
+        err += "Task " + std::to_string(i) + " error: " + par_errors_[i] + '\n';
         par_errors_[i].clear();
       }
     }
-    TVMAPISetLastError(err.str().c_str());
+    TVMAPISetLastError(err.c_str());
     return -1;
   }
   // Signal that one job has finished.


### PR DESCRIPTION
Fix the following error while doing `gradle build` and the document url in README.

```
/Users/tatsuya/work/tvm/apps/android_deploy/app/src/main/jni/../../../../../../include/../src/runtime/thread_pool.cc:76:31: error: no member named 'to_string' in namespace 'std'
        err += "Task " + std::to_string(i) + " error: " + par_errors_[i] + '\n';
```
Please review. @tqchen @PariksheetPinjari909 