### PR TITLE
[MAINTAINER] Adds Pariksheet Pinjari as reviewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 - [Nick Hynes](https://github.com/nhynes) SGX and secured computing
 
 ## Reviewers
+- [Pariksheet Pinjari](https://github.com/PariksheetPinjari909)
 - [Eddie Yan](https://github.com/eqy)
 - [Lianmin Zheng](https://github.com/merrymercy)
 


### PR DESCRIPTION
This PR adds @PariksheetPinjari909 as a reviewer of TVM as per http://docs.tvm.ai/contribute/community.html.

Pariksheet has been actively contributing to TVM stack. His contributed to various operator support in topi and nnvm as well as android deployment support.  
- [Pariksheet's contributions](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3APariksheetPinjari909++is%3Amerged%09). 
- [Code reviews involving Pariksheet](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3APariksheetPinjari909+) 
