### PR TITLE
fix missing std::to_string during Android build, android rpc test script

### DIFF
--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -8,7 +8,7 @@ endif
 
 include $(config)
 
-APP_STL := gnustl_static
+APP_STL := c++_static
 
 APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++11 -Oz -frtti
 ifeq ($(USE_OPENCL), 1)                                                                                                                                             

--- a/apps/android_rpc/tests/android_rpc_test.py
+++ b/apps/android_rpc/tests/android_rpc_test.py
@@ -6,7 +6,7 @@ And configure the proxy host field as commented.
 
 import tvm
 import os
-from tvm.contrib import rpc, util, ndk, rpc_proxy
+from tvm.contrib import rpc, util, ndk
 import numpy as np
 
 # Set to be address of tvm proxy.


### PR DESCRIPTION
currently the Android build breaks on my end with:
```
/sampa/home/eqy/tvm/apps/android_rpc/app/src/main/jni/../../../../../../include/../src/runtime/thread_pool.cc:77:31: error: no member named 'to_string' in namespace 'std'
err += "Task " + std::to_string(i) + " error: " + par_errors_[i] + '\n';
```

switching the `APP_STL` seems to fix:
https://stackoverflow.com/a/27563132

also remove broken import in android rpc test
