### PR TITLE
Use CMake for make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,4 +110,4 @@ jvminstall:
 
 # clean rule
 clean:
-	$(RM) -rf build lib bin *~ */*~ */*/*~ */*/*/*~ */*.o */*/*.o */*/*/*.o */*.d */*/*.d */*/*/*.d
+	@mkdir -p build && cd build && cmake .. && $(MAKE) clean


### PR DESCRIPTION
The current Makefile removes build/config.cmake with make clean.  Let's use CMake for make clean, too.