### PR TITLE
[MAINTAINER] add zhreshold as Reviewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 - [Masahiro Masuda](https://github.com/masahi)
 - [Pariksheet Pinjari](https://github.com/PariksheetPinjari909)
 - [Eddie Yan](https://github.com/eqy)
+- [Joshua Z. Zhang](https://github.com/zhreshold)
 - [Lianmin Zheng](https://github.com/merrymercy)
 
 ## List of Contributors


### PR DESCRIPTION
This PR adds @zhreshold as a reviewer of TVM. Joshua contributes to the first ONNX importer of the graph compiler. Recently he has been actively helping to review the PRs related to vision package and help to bring detector pipelines to the stack.

- [Contribution history of Joshua](https://github.com/dmlc/nnvm/pulls?q=is%3Apr+author%3Azhreshold+is%3Aclosed)
- [Recent code reviews Joshua involves in](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Azhreshold)