### PR TITLE
Check common subdirs for vulkan/spirv headers

### DIFF
--- a/cmake/util/FindVulkan.cmake
+++ b/cmake/util/FindVulkan.cmake
@@ -46,5 +46,10 @@ macro(find_vulkan use_vulkan)
     get_filename_component(VULKAN_LIBRARY_PATH ${Vulkan_LIBRARY} DIRECTORY)
     find_library(Vulkan_SPIRV_TOOLS_LIBRARY SPIRV-Tools
       ${VULKAN_LIBRARY_PATH}/spirv-tools)
+
+    find_path(_libspirv libspirv.h HINTS ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan spirv-tools)
+    find_path(_spirv spirv.hpp HINTS ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan spirv/unified1)
+    find_path(_glsl_std GLSL.std.450.h HINTS ${Vulkan_INCLUDE_DIRS} PATH_SUFFIXES vulkan spirv/unified1)
+    list(APPEND Vulkan_INCLUDE_DIRS ${_libspirv} ${_spirv} ${_glsl_std})
   endif(Vulkan_FOUND)
 endmacro(find_vulkan)

--- a/src/codegen/spirv/build_vulkan.cc
+++ b/src/codegen/spirv/build_vulkan.cc
@@ -4,7 +4,7 @@
  * \brief Build SPIRV block
  */
 // Use libspirv for parsing and validating code.
-#include <vulkan/libspirv.h>
+#include <libspirv.h>
 #include <dmlc/memory_io.h>
 #include <tvm/ir_pass.h>
 

--- a/src/codegen/spirv/intrin_rule_spirv.cc
+++ b/src/codegen/spirv/intrin_rule_spirv.cc
@@ -4,7 +4,7 @@
  */
 #include <tvm/packed_func_ext.h>
 #include <tvm/ir.h>
-#include <vulkan/GLSL.std.450.h>
+#include <GLSL.std.450.h>
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/spirv/ir_builder.h
+++ b/src/codegen/spirv/ir_builder.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <map>
 
-#include <vulkan/spirv.hpp>
+#include <spirv.hpp>
 
 namespace tvm {
 namespace codegen {


### PR DESCRIPTION
The Vulkan SDK currently places all headers in a vulkan subdirectory.
However, upstream tools use and reference other subdirectories.

This change does not assumes headers are in a particular subdirectory
and instead searches commonly known subdirectories and adds the
appropriate ones to the include path.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from others in the community.
