### PR TITLE
[BUILD] Fix reflection build for gcc-8

### DIFF
--- a/src/lang/reflection.cc
+++ b/src/lang/reflection.cc
@@ -375,41 +375,43 @@ class NodeAttrSetter : public AttrVisitor {
   std::string type_key;
   std::unordered_map<std::string, runtime::TVMArgValue> attrs;
 
-  template<typename T>
-  void SetValue(const char* key, T* value) {
+  void Visit(const char* key, double* value) final {
+    *value = GetAttr(key).operator double();
+  }
+  void Visit(const char* key, int64_t* value) final {
+    *value = GetAttr(key).operator int64_t();
+  }
+  void Visit(const char* key, uint64_t* value) final {
+    *value = GetAttr(key).operator uint64_t();
+  }
+  void Visit(const char* key, int* value) final {
+    *value = GetAttr(key).operator int();
+  }
+  void Visit(const char* key, bool* value) final {
+    *value = GetAttr(key).operator bool();
+  }
+  void Visit(const char* key, std::string* value) final {
+    *value = GetAttr(key).operator std::string();
+  }
+  void Visit(const char* key, void** value) final {
+    *value = GetAttr(key).operator void*();
+  }
+  void Visit(const char* key, Type* value) final {
+    *value = GetAttr(key).operator Type();
+  }
+  void Visit(const char* key, NodeRef* value) final {
+    *value = GetAttr(key).operator NodeRef();
+  }
+
+ private:
+  runtime::TVMArgValue GetAttr(const char* key) {
     auto it = attrs.find(key);
     if (it == attrs.end()) {
       LOG(FATAL) << type_key << ": require field " << key;
     }
-    *value = it->second.operator T();
+    runtime::TVMArgValue v = it->second;
     attrs.erase(it);
-  }
-  void Visit(const char* key, double* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, int64_t* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, uint64_t* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, int* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, bool* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, std::string* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, void** value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, Type* value) final {
-    SetValue(key, value);
-  }
-  void Visit(const char* key, NodeRef* value) final {
-    SetValue(key, value);
+    return v;
   }
 };
 

--- a/src/pass/unroll_loop.cc
+++ b/src/pass/unroll_loop.cc
@@ -29,14 +29,14 @@ class LoopUnroller : public IRMutator {
 
   Stmt Mutate_(const AttrStmt* op, const Stmt& stmt) final {
     if (op->attr_key == "pragma_auto_unroll_max_step") {
-      int value;
+      int value = 0;
       CHECK(arith::GetConstInt(op->value, &value));
       std::swap(value, auto_max_step_);
       Stmt ret = this->Mutate(op->body);
       std::swap(value, auto_max_step_);
       return ret;
     } else if (op->attr_key == "pragma_unroll_explicit") {
-      int value;
+      int value = 0;
       CHECK(arith::GetConstInt(op->value, &value));
       bool explicit_unroll = value;
       std::swap(explicit_unroll, explicit_unroll_);


### PR DESCRIPTION
https://discuss.tvm.ai/t/tvm-with-gcc-8-1-build-errors/286

The error was due to gcc-8 have some problem redirecting to the right operator T (where T is double, or int) inside the inside a template function. This PR introduces a workaround of that

## Minimum Example to Demonstrate the Problem
```c++
#include <type_traits>

class MyClass {
 public:
  operator double() const {
    return 1;
  }
  template<typename T>
  operator T() const {
    static_assert(std::is_class<T>::value, "problem");
    return T();
  }
};

template<typename T>
void SetValue(const MyClass& obj, T* value) {
  *value = obj.operator T();
}

int main() {
  MyClass obj;
  // works fine                                                                                                                              
  obj.operator double();
  double x;
  // error;                                                                                                                                  
  SetValue(obj, &x);
}
```