### PR TITLE
Import hybrid module in __init__.py

### DIFF
--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -16,6 +16,7 @@ from . import node
 from . import ir_builder
 from . import target
 from . import generic
+from . import hybrid
 
 from . import ndarray as nd
 from .ndarray import context, cpu, gpu, opencl, cl, vulkan, metal, mtl

--- a/python/tvm/hybrid/parser.py
+++ b/python/tvm/hybrid/parser.py
@@ -35,7 +35,7 @@ class HybridParser(ast.NodeVisitor):
         ast.Add   : operator.add,
         ast.Sub   : operator.sub,
         ast.Mult  : operator.mul,
-        ast.Div   : _expr.Div,
+        ast.Div   : operator.div if sys.version_info[0] == 2 else operator.truediv,
         ast.Mod   : operator.mod,
         ast.BitOr : operator.or_,
         ast.BitAnd: operator.and_,

--- a/python/tvm/hybrid/parser.py
+++ b/python/tvm/hybrid/parser.py
@@ -35,7 +35,7 @@ class HybridParser(ast.NodeVisitor):
         ast.Add   : operator.add,
         ast.Sub   : operator.sub,
         ast.Mult  : operator.mul,
-        ast.Div   : _make.Div,
+        ast.Div   : _expr.Div,
         ast.Mod   : operator.mod,
         ast.BitOr : operator.or_,
         ast.BitAnd: operator.and_,


### PR DESCRIPTION
Sorry I forgot this. Because in tests I did `from tvm.hybrid import script` which worked well.
However I found it cannot do `@tvm.hybrid.script`.