### PR TITLE
Add querying OpenCL device infomation

### DIFF
--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -260,7 +260,6 @@ Target rocm(const std::vector<std::string>& options) {
 }
 
 Target opencl(const std::vector<std::string>& options) {
-  std::cout << "Creating opencl target" << std::endl;
   return CreateTarget("opencl", options);
 }
 


### PR DESCRIPTION
Hi, this pull request allows TVM to have the correct warp size and thread count when using OpenCL. 
This PR is not compatible with some parts of #1290. But I believe this is a better approach that it provides accurate information about the device on all devices.