### PR TITLE
Windows - VS2015 Compile error - 'conversion from 'double' to 'float' requires a narrowing conversion'

### DIFF
--- a/nnvm/include/nnvm/top/nn.h
+++ b/nnvm/include/nnvm/top/nn.h
@@ -349,7 +349,7 @@ struct MultiBoxTransformLocParam : public dmlc::Parameter<MultiBoxTransformLocPa
       .describe("Clip out-of-boundary boxes.");
     DMLC_DECLARE_FIELD(threshold).set_default(0.01)
     .describe("Threshold to be a positive prediction.");
-    DMLC_DECLARE_FIELD(variances).set_default(Tuple<float>{0.1, 0.1, 0.2, 0.2})
+    DMLC_DECLARE_FIELD(variances).set_default(Tuple<float>({0.1f, 0.1f, 0.2f, 0.2f}))
     .describe("Variances to be decoded from box regression output.");
   }
 };


### PR DESCRIPTION
Compiling of TVM fails in Windows 10 - VS 2015 environment .
Reason : conversion error from float to double .  This seems to be a compiler bug and we have to explicitly add "f" suffix to float values during uniform intialization .
ref: https://stackoverflow.com/a/47913325/3814804

Build Error Log :
```

5>C:\TVM\v0_3_a1\tvm\nnvm\include\nnvm/top/nn.h(350): warning C4305: 'argument': truncation from 'double' to 'const float' (compiling source file C:\TVM\v0_3_a1\tvm\nnvm\src\top\vision\yolo2\reorg.cc)
5>C:\TVM\v0_3_a1\tvm\nnvm\include\nnvm/top/nn.h(352): error C2398: Element '1': conversion from 'double' to 'float' requires a narrowing conversion (compiling source file C:\TVM\v0_3_a1\tvm\nnvm\src\top\vision\yolo2\reorg.cc)
5>C:\TVM\v0_3_a1\tvm\nnvm\include\nnvm/top/nn.h(352): error C2398: Element '2': conversion from 'double' to 'float' requires a narrowing conversion (compiling source file C:\TVM\v0_3_a1\tvm\nnvm\src\top\vision\yolo2\reorg.cc)
5>C:\TVM\v0_3_a1\tvm\nnvm\include\nnvm/top/nn.h(352): error C2398: Element '3': conversion from 'double' to 'float' requires a narrowing conversion (compiling source file C:\TVM\v0_3_a1\tvm\nnvm\src\top\vision\yolo2\reorg.cc)
5>C:\TVM\v0_3_a1\tvm\nnvm\include\nnvm/top/nn.h(352): error C2398: Element '4': conversion from 'double' to 'float' requires a narrowing conversion (compiling source file C:\TVM\v0_3_a1\tvm\nnvm\src\top\vision\yolo2\reorg.cc)
5>C:\TVM\v0_3_a1\tvm\nnvm\include\nnvm/top/nn.h(352): warning C4305: 'initializing': truncation from 'double' to 'float' (compiling source file C:\TVM\v0_3_a1\tvm\nnvm\src\top\vision\yolo2\reorg.cc)
7>------ Build started: Project: ALL_BUILD, Configuration: Release x64 ------
7>  Building Custom Rule C:/TVM/v0_3_a1/tvm/CMakeLists.txt
7>  CMake does not need to re-run because C:/TVM/v0_3_a1/tvm/build/CMakeFiles/generate.stamp is up-to-date.
8>------ Skipped Build: Project: INSTALL, Configuration: Release x64 ------
8>Project not selected to build for this solution configuration 
========== Build: 5 succeeded, 1 failed, 0 up-to-date, 2 skipped ==========

```

Note: i have added the suffix'f' only on L352 as it was breaking the Build.
Awaiting for  feedback .
Thanks
