### PR TITLE
[RUNTIME] keep opencl runtime deps free from node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.2)
 project(tvm C CXX)
 
 # Utility functions

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -4,9 +4,6 @@
  */
 #include <tvm/runtime/registry.h>
 #include <dmlc/thread_local.h>
-#include <tvm/container.h>
-#include <tvm/ir.h>
-#include <tvm/packed_func_ext.h>
 #include "./opencl_common.h"
 
 namespace tvm {


### PR DESCRIPTION
The runtime cannot depend on the node system which will introduce additional symbols https://github.com/dmlc/tvm/issues/1344