### PR TITLE
TVM run on Nexus Oreo version reported JNI crash while accessing tvmArrayGetShape

### DIFF
--- a/jvm/native/src/main/native/ml_dmlc_tvm_native_c_api.cc
+++ b/jvm/native/src/main/native/ml_dmlc_tvm_native_c_api.cc
@@ -384,7 +384,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_tvm_LibInfo_tvmArrayGetShape(
   jmethodID arrayAppend = env->GetMethodID(arrayClass, "add", "(Ljava/lang/Object;)Z");
   for (int i = 0; i < ndim; ++i) {
     jobject data = env->NewObject(longClass, newLong, static_cast<jlong>(shape[i]));
-    env->CallObjectMethod(jshape, arrayAppend, data);
+    env->CallBooleanMethod(jshape, arrayAppend, data);
     env->DeleteLocalRef(data);
   }
   env->DeleteLocalRef(longClass);


### PR DESCRIPTION
This fix is solve below crash reported on Nexus phone running on android oreo version.

Error Log
`zygote64: java_vm_ext.cc:534] JNI DETECTED ERROR IN APPLICATION: the return type of CallObjectMethodV does not match boolean java.util.List.add(java.lang.Object)`

Solve the [stack issue 406](https://discuss.tvm.ai/t/issues-on-ndarray-copyfrom-data-ndarray-asfloatarray/406)