### PR TITLE
[DARKNET FRONTEND]Batchnorm added as part of Dense op for running rnn model for next wo…

### DIFF
--- a/nnvm/python/nnvm/frontend/darknet.py
+++ b/nnvm/python/nnvm/frontend/darknet.py
@@ -122,7 +122,7 @@ def _darknet_avgpooling(inputs, attrs):
 
 def _darknet_batch_norm(inputs, attrs):
     """Process the batchnormalization operation."""
-    op_name, new_attrs = '_darknet_batch_norm', {}
+    op_name, new_attrs = 'darknet_batch_norm', {}
     new_attrs['axis'] = attrs.get('axis', 1)
     new_attrs['epsilon'] = attrs.get('eps', 0.000001)
     new_attrs['center'] = True

--- a/nnvm/python/nnvm/frontend/darknet.py
+++ b/nnvm/python/nnvm/frontend/darknet.py
@@ -122,7 +122,7 @@ def _darknet_avgpooling(inputs, attrs):
 
 def _darknet_batch_norm(inputs, attrs):
     """Process the batchnormalization operation."""
-    op_name, new_attrs = 'batch_norm', {}
+    op_name, new_attrs = '_darknet_batch_norm', {}
     new_attrs['axis'] = attrs.get('axis', 1)
     new_attrs['epsilon'] = attrs.get('eps', 0.000001)
     new_attrs['center'] = True
@@ -234,7 +234,9 @@ def _darknet_dense(inputs, attrs):
     sym = _darknet_get_nnvm_op(op_name)(*inputs, **new_attrs)
     out_name[0] = sym.list_output_names()[0].replace('_output', '')
     if 'use_batchNorm' in attrs:
-        sym, _ = _darknet_batch_norm(*sym, attrs)
+        op_name, new_attrs = 'batch_norm', {}
+        new_attrs['epsilon'] = 0.000001
+        sym = _darknet_get_nnvm_op(op_name)(*sym, **new_attrs)
         out_name[1] = sym.list_output_names()[0].replace('_output', '')
     if 'activation' in attrs:
         new_attrs = {}

--- a/nnvm/tests/python/frontend/darknet/test_forward.py
+++ b/nnvm/tests/python/frontend/darknet/test_forward.py
@@ -169,6 +169,19 @@ def test_forward_dense():
     test_forward(net)
     LIB.free_network(net)
 
+def test_forward_dense_batchnorm():
+    '''test fully connected layer with batchnorm'''
+    net = LIB.make_network(1)
+    layer = LIB.make_connected_layer(1, 75, 5, 1, 1, 0)
+    for i in range(5):
+        layer.rolling_mean[i] = np.random.rand(1)
+        layer.rolling_variance[i] = np.random.rand(1)
+    net.layers[0] = layer
+    net.w = net.h = 5
+    LIB.resize_network(net, 5, 5)
+    test_forward(net)
+    LIB.free_network(net)
+
 def test_forward_maxpooling():
     '''test maxpooling layer'''
     net = LIB.make_network(1)
@@ -264,6 +277,7 @@ if __name__ == '__main__':
     test_forward_batch_norm()
     test_forward_shortcut()
     test_forward_dense()
+    test_forward_dense_batchnorm()
     test_forward_reorg()
     test_forward_region()
     test_forward_elu()

--- a/nnvm/tests/python/frontend/darknet/test_forward.py
+++ b/nnvm/tests/python/frontend/darknet/test_forward.py
@@ -172,13 +172,14 @@ def test_forward_dense():
 def test_forward_dense_batchnorm():
     '''test fully connected layer with batchnorm'''
     net = LIB.make_network(1)
-    layer = LIB.make_connected_layer(1, 75, 5, 1, 1, 0)
+    layer = LIB.make_connected_layer(1, 12, 2, 1, 1, 0)
     for i in range(5):
         layer.rolling_mean[i] = np.random.rand(1)
         layer.rolling_variance[i] = np.random.rand(1)
+        layer.scales[i] = np.random.rand(1)
     net.layers[0] = layer
-    net.w = net.h = 5
-    LIB.resize_network(net, 5, 5)
+    net.w = net.h = 2
+    LIB.resize_network(net, 2, 2)
     test_forward(net)
     LIB.free_network(net)
 


### PR DESCRIPTION
Batchnorm added as part of Dense op for running rnn model for a word prediction model.
This rnn model have batch norm as part of the dense layer, this scenario is not handled in current darknet frontend.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from others in the community.
