### PR TITLE
[NNVM][Keras] allow only tensorflow backend

### DIFF
--- a/nnvm/python/nnvm/frontend/keras.py
+++ b/nnvm/python/nnvm/frontend/keras.py
@@ -489,6 +489,8 @@ def from_keras(model):
         raise ImportError('Keras must be installed')
 
     assert isinstance(model, keras.engine.training.Model)
+    if keras.backend.backend() != 'tensorflow':
+        raise ValueError("Keras frontend currently supports tensorflow backend only.")
     if keras.backend.image_data_format() != 'channels_last':
         raise ValueError("Keras frontend currently supports data_format = channels_last only.")
     _check_unsupported_layers(model)

--- a/nnvm/tests/python/frontend/keras/test_forward.py
+++ b/nnvm/tests/python/frontend/keras/test_forward.py
@@ -14,6 +14,9 @@ set_session(tf.Session(config=config))
 
 
 def verify_keras_frontend(keras_model):
+    # Keras frontend currently supports tensorflow backend only.
+    assert(keras.backend.backend() == 'tensorflow')
+
     in_shapes = []
     for layer in keras_model._input_layers:
         in_shapes.append(tuple(dim.value if dim.value is not None else 1 for dim in layer.input.shape))


### PR DESCRIPTION
The Keras frontend only supports the tensorflow backend at the moment.

c.f. https://discuss.tvm.ai/t/compile-keras-model-issue-report-and-solution-included/256