### PR TITLE
[TVM] Fixed SPIR-V codegen incorrectly not declaring the interface for the entry point

### DIFF
--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -35,7 +35,7 @@ std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const LoweredFunc& f) {
       pod_args.push_back(arg);
     }
   }
-  spirv::Value func_ptr = builder_->DeclareKenrelFunction(f->name);
+  spirv::Value func_ptr = builder_->DeclareKernelFunction(f->name, true, true);
   builder_->StartFunction(func_ptr);
 
   // All the POD arguments are passed in through PushConstant

--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -35,7 +35,7 @@ std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const LoweredFunc& f) {
       pod_args.push_back(arg);
     }
   }
-  spirv::Value func_ptr = builder_->DeclareKernelFunction(f->name, true, true);
+  spirv::Value func_ptr = builder_->NewFunction();
   builder_->StartFunction(func_ptr);
 
   // All the POD arguments are passed in through PushConstant
@@ -55,6 +55,8 @@ std::vector<uint32_t> CodeGenSPIRV::BuildFunction(const LoweredFunc& f) {
   builder_->SetLocalSize(func_ptr, workgroup_size_);
   builder_->MakeInst(spv::OpReturn);
   builder_->MakeInst(spv::OpFunctionEnd);
+
+  builder_->CommitKernelFunction(func_ptr, f->name);
 
   return builder_->Finalize();
 }

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -226,10 +226,10 @@ Value IRBuilder::DeclareKernelFunction(const std::string& name,
                                        bool uses_workgroup_id,
                                        bool uses_local_id) {
   if (uses_workgroup_id) {
-    GetWorkgroupID(0); // Ensure workgroup_id_ is valid
+    GetWorkgroupID(0);  // Ensure workgroup_id_ is valid
   }
   if (uses_local_id) {
-    GetLocalID(0); // Ensure local_id_ is valid
+    GetLocalID(0);  // Ensure local_id_ is valid
   }
 
   Value val = NewValue(t_void_func_, kFunction);

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -222,11 +222,26 @@ Value IRBuilder::GetPushConstant(
   return this->MakeValue(spv::OpLoad, v_type, ptr);
 }
 
-Value IRBuilder::DeclareKenrelFunction(const std::string& name) {
+Value IRBuilder::DeclareKernelFunction(const std::string& name,
+                                       bool uses_workgroup_id,
+                                       bool uses_local_id) {
+  if (uses_workgroup_id) {
+    GetWorkgroupID(0); // Ensure workgroup_id_ is valid
+  }
+  if (uses_local_id) {
+    GetLocalID(0); // Ensure local_id_ is valid
+  }
+
   Value val = NewValue(t_void_func_, kFunction);
   ib_.Begin(spv::OpEntryPoint)
-      .AddSeq(spv::ExecutionModelGLCompute, val, name)
-      .Commit(&entry_);
+    .AddSeq(spv::ExecutionModelGLCompute, val, name);
+  if (uses_workgroup_id) {
+    ib_.Add(workgroup_id_);
+  }
+  if (uses_local_id) {
+    ib_.Add(local_id_);
+  }
+  ib_.Commit(&entry_);
   return val;
 }
 

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -227,13 +227,6 @@ Value IRBuilder::NewFunction() {
 }
 
 void IRBuilder::CommitKernelFunction(const Value& func_id, const std::string& name) {
-  //if (uses_workgroup_id) {
-  //  GetWorkgroupID(0);  // Ensure workgroup_id_ is valid
-  //}
-  //if (uses_local_id) {
-  //  GetLocalID(0);  // Ensure local_id_ is valid
-  //}
-
   ib_.Begin(spv::OpEntryPoint)
     .AddSeq(spv::ExecutionModelGLCompute, func_id, name);
   if (workgroup_id_.id != 0) {

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -222,27 +222,27 @@ Value IRBuilder::GetPushConstant(
   return this->MakeValue(spv::OpLoad, v_type, ptr);
 }
 
-Value IRBuilder::DeclareKernelFunction(const std::string& name,
-                                       bool uses_workgroup_id,
-                                       bool uses_local_id) {
-  if (uses_workgroup_id) {
-    GetWorkgroupID(0);  // Ensure workgroup_id_ is valid
-  }
-  if (uses_local_id) {
-    GetLocalID(0);  // Ensure local_id_ is valid
-  }
+Value IRBuilder::NewFunction() {
+  return NewValue(t_void_func_, kFunction);
+}
 
-  Value val = NewValue(t_void_func_, kFunction);
+void IRBuilder::CommitKernelFunction(const Value& func_id, const std::string& name) {
+  //if (uses_workgroup_id) {
+  //  GetWorkgroupID(0);  // Ensure workgroup_id_ is valid
+  //}
+  //if (uses_local_id) {
+  //  GetLocalID(0);  // Ensure local_id_ is valid
+  //}
+
   ib_.Begin(spv::OpEntryPoint)
-    .AddSeq(spv::ExecutionModelGLCompute, val, name);
-  if (uses_workgroup_id) {
+    .AddSeq(spv::ExecutionModelGLCompute, func_id, name);
+  if (workgroup_id_.id != 0) {
     ib_.Add(workgroup_id_);
   }
-  if (uses_local_id) {
+  if (local_id_.id != 0) {
     ib_.Add(local_id_);
   }
   ib_.Commit(&entry_);
-  return val;
 }
 
 void IRBuilder::StartFunction(const Value& func) {

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -226,9 +226,10 @@ Value IRBuilder::NewFunction() {
   return NewValue(t_void_func_, kFunction);
 }
 
-void IRBuilder::CommitKernelFunction(const Value& func_id, const std::string& name) {
+void IRBuilder::CommitKernelFunction(const Value& func, const std::string& name) {
+  CHECK_EQ(func.flag, kFunction);
   ib_.Begin(spv::OpEntryPoint)
-    .AddSeq(spv::ExecutionModelGLCompute, func_id, name);
+    .AddSeq(spv::ExecutionModelGLCompute, func, name);
   if (workgroup_id_.id != 0) {
     ib_.Add(workgroup_id_);
   }

--- a/src/codegen/spirv/ir_builder.h
+++ b/src/codegen/spirv/ir_builder.h
@@ -493,10 +493,10 @@ class IRBuilder {
    * \brief Declare the entry point for a kernel function. This should be
    * invoked after building the function so the builder is aware of which
    * variables to declare as part of the function's interface.
-   * \param func_id The id of the previously declared function.
+   * \param func The previously declared function.
    * \param name Name of the entry point.
    */
-  void CommitKernelFunction(const Value& func_id, const std::string& name);
+  void CommitKernelFunction(const Value& func, const std::string& name);
   /*!
    * \brief Start function scope.
    * \param func function to be started.

--- a/src/codegen/spirv/ir_builder.h
+++ b/src/codegen/spirv/ir_builder.h
@@ -485,15 +485,18 @@ class IRBuilder {
    */
   Value GetPushConstant(Value ptr_push_const, const SType& v_type, uint32_t index);
   /*!
-   * \brief Declare a kernel function
-   * \param name Name of the entry point.
-   * \param uses_workgroup_id Whether the function will use the workgroup id
-   * \param uses_local_id Whether the function will use the local invocation id
+   * \brief Declare a new function
    * \return The created function ID.
    */
-  Value DeclareKernelFunction(const std::string& name,
-                              bool uses_workgroup_id = false,
-                              bool uses_local_id = false);
+  Value NewFunction();
+  /*!
+   * \brief Declare the entry point for a kernel function. This should be
+   * invoked after building the function so the builder is aware of which
+   * variables to declare as part of the function's interface.
+   * \param func_id The id of the previously declared function.
+   * \param name Name of the entry point.
+   */
+  void CommitKernelFunction(const Value& func_id, const std::string& name);
   /*!
    * \brief Start function scope.
    * \param func function to be started.

--- a/src/codegen/spirv/ir_builder.h
+++ b/src/codegen/spirv/ir_builder.h
@@ -487,9 +487,13 @@ class IRBuilder {
   /*!
    * \brief Declare a kernel function
    * \param name Name of the entry point.
+   * \param uses_workgroup_id Whether the function will use the workgroup id
+   * \param uses_local_id Whether the function will use the local invocation id
    * \return The created function ID.
    */
-  Value DeclareKernelFunction(const std::string& name, bool uses_workgroup_id = false, bool uses_local_id = false);
+  Value DeclareKernelFunction(const std::string& name,
+                              bool uses_workgroup_id = false,
+                              bool uses_local_id = false);
   /*!
    * \brief Start function scope.
    * \param func function to be started.

--- a/src/codegen/spirv/ir_builder.h
+++ b/src/codegen/spirv/ir_builder.h
@@ -489,7 +489,7 @@ class IRBuilder {
    * \param name Name of the entry point.
    * \return The created function ID.
    */
-  Value DeclareKenrelFunction(const std::string& name);
+  Value DeclareKernelFunction(const std::string& name, bool uses_workgroup_id = false, bool uses_local_id = false);
   /*!
    * \brief Start function scope.
    * \param func function to be started.


### PR DESCRIPTION
The SPIR-V codegen was not generating code compliant with the spec, which was manifesting in all of the vulkan unit tests failing on Windows 10 with a GTX 960 GPU. Specifically, whenever a vulkan kernel was invoked, it would only ever succeed in updating the first element of the input tensor.

This turned out to be due to the codegen not generating the `interface` list of `OpEntryPoint`. For the code that TVM generates, the `interface` list should contain both the workgroup id and the local invocation id. See https://www.khronos.org/registry/spir-v/specs/1.0/SPIRV.html#OpEntryPoint for details.

SPIRV-Tools has recently been updated to detect this situation (see https://github.com/KhronosGroup/SPIRV-Tools/pull/1589), so one way to verify that TVM is generating correct code is to take the output of `get_source`, use `spirv-as` to generate a binary SPIR-V file, and then run a recent release of `spirv-val` on the binary file.

The fix in this PR does solve the problem, but I'm not sure if it's the best way of addressing this, so I'm definitely open to suggestions on how this could be done better (99% of this PR was tracking down the bug in the first place!)