### PR TITLE
[RUNTIME] Support setting CPU affinity

### DIFF
--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -47,7 +47,7 @@ class ThreadGroup {
   /*!
    * \brief configure the CPU id affinity
    *
-   * \param mode The preferred CPU type (0 = default, 1 = big, -1 = little).
+   * \param mode The preferred CPU type (1 = big, -1 = little).
    * \param nthreads The number of threads to use (0 = use all).
    * \param exclude_worker0 Whether to use the main thread as a worker.
    *        If  `true`, worker0 will not be launched in a new thread and
@@ -56,7 +56,7 @@ class ThreadGroup {
    *
    * \return The number of workers to use.
    */
-  int Config(int mode, int nthreads, bool exclude_worker0);
+  int Configure(int mode, int nthreads, bool exclude_worker0);
 
  private:
   Impl* impl_;

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -44,6 +44,11 @@ class ThreadGroup {
     */
   void Join();
 
+  enum AffinityMode : int {
+    kBig = 1,
+    kLittle = -1,
+  };
+
   /*!
    * \brief configure the CPU id affinity
    *
@@ -56,7 +61,7 @@ class ThreadGroup {
    *
    * \return The number of workers to use.
    */
-  int Configure(int mode, int nthreads, bool exclude_worker0);
+  int Configure(AffinityMode Mode, int nthreads, bool exclude_worker0);
 
  private:
   Impl* impl_;

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -44,25 +44,19 @@ class ThreadGroup {
     */
   void Join();
 
-   /*!
-    * \brief Set CPU affinity of workers
-    *
-    * \param exclude_worker0 Whether to use the main thread as a worker. (same
-      as constructor)
-    * \param reverse Whether to traverse the affinity ordering in reverse.
-      to.
-    */
-  void SetAffinity(bool exclude_worker0, bool reverse = false);
-
   /*!
    * \brief configure the CPU id affinity
    *
    * \param mode The preferred CPU type (0 = default, 1 = big, -1 = little).
    * \param nthreads The number of threads to use (0 = use all).
+   * \param exclude_worker0 Whether to use the main thread as a worker.
+   *        If  `true`, worker0 will not be launched in a new thread and
+   *        `worker_callback` will only be called for values >= 1. This
+   *        allows use of the main thread as a worker.
    *
    * \return The number of workers to use.
    */
-  unsigned int ConfigThreadGroup(int mode, int nthreads);
+  unsigned int ConfigThreadGroup(int mode, int nthreads, bool exclude_worker0);
 
  private:
   Impl* impl_;

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -52,7 +52,7 @@ class ThreadGroup {
     * \param it Optional pointer to an affinity order of CPU ids to bind threads
     * to.
     */
-  void SetAffinity(bool exclude_worker0, std::vector<unsigned int> *order = NULL, bool reverse = false);
+  void SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order = NULL, bool reverse = false);
 
  private:
   Impl* impl_;
@@ -77,7 +77,7 @@ int MaxConcurrency();
  *
  * \return the number of workers to use
  */
-unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> &sorted_order);
+unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> *sorted_order);
 
 }  // namespace threading
 }  // namespace runtime

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -61,7 +61,7 @@ class ThreadGroup {
    *
    * \return The number of workers to use.
    */
-  int Configure(AffinityMode Mode, int nthreads, bool exclude_worker0);
+  int Configure(AffinityMode mode, int nthreads, bool exclude_worker0);
 
  private:
   Impl* impl_;

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -48,9 +48,11 @@ class ThreadGroup {
     * \brief Set CPU affinity of workers
     *
     * \param exclude_worker0 Whether to use the main thread as a worker. (same
-    * as constructor)
-    * \param it Optional pointer to an affinity order of CPU ids to bind threads
-    * to.
+      as constructor)
+    * \param order Optional pointer to an affinity order of CPU ids to bind
+      threads.
+    * \param reverse Whether to traverse the affinity ordering in reverse.
+      to.
     */
   void SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order = NULL,
                    bool reverse = false);

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -33,19 +33,26 @@ class ThreadGroup {
     *        If  `true`, worker0 will not be launched in a new thread and
     *        `worker_callback` will only be called for values >= 1. This
     *        allows use of the main thread as a worker.
-    * \param affinity_order If specified, an ordering of CPU ids when setting
-    *        thread affinity.
     */
   ThreadGroup(int num_workers,
               std::function<void(int)> worker_callback,
-              bool exclude_worker0 = false,
-              std::vector<unsigned int> *affinity_order = NULL);
+              bool exclude_worker0 = false);
   ~ThreadGroup();
 
    /*!
     * \brief Blocks until all non-main threads in the pool finish.
     */
   void Join();
+
+   /*!
+    * \brief Set CPU affinity of workers
+    *
+    * \param exclude_worker0 Whether to use the main thread as a worker. (same
+    * as constructor)
+    * \param it Optional pointer to an affinity order of CPU ids to bind threads
+    * to.
+    */
+  void SetAffinity(bool exclude_worker0, std::vector<unsigned int> *order = NULL, bool reverse = false);
 
  private:
   Impl* impl_;
@@ -60,6 +67,17 @@ void Yield();
  * \return the maximum number of effective workers for this system.
  */
 int MaxConcurrency();
+
+/*!
+ * \brief configure the CPU id affinity
+ *
+ * \param mode the preferred CPU type (0 = default, 1 = big, -1 = little)
+ * \param nthreads the number of threads to use (0 = use all)
+ * \param sorted_order reference to the CPU id affinity list
+ *
+ * \return the number of workers to use
+ */
+unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> &sorted_order);
 
 }  // namespace threading
 }  // namespace runtime

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -33,10 +33,13 @@ class ThreadGroup {
     *        If  `true`, worker0 will not be launched in a new thread and
     *        `worker_callback` will only be called for values >= 1. This
     *        allows use of the main thread as a worker.
+    * \param affinity_order If specified, an ordering of CPU ids when setting
+    *        thread affinity.
     */
   ThreadGroup(int num_workers,
               std::function<void(int)> worker_callback,
-              bool exclude_worker0 = false);
+              bool exclude_worker0 = false,
+              std::vector<unsigned int> *affinity_order = NULL);
   ~ThreadGroup();
 
    /*!

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -52,7 +52,8 @@ class ThreadGroup {
     * \param it Optional pointer to an affinity order of CPU ids to bind threads
     * to.
     */
-  void SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order = NULL, bool reverse = false);
+  void SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order = NULL,
+                   bool reverse = false);
 
  private:
   Impl* impl_;

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -49,13 +49,37 @@ class ThreadGroup {
     *
     * \param exclude_worker0 Whether to use the main thread as a worker. (same
       as constructor)
-    * \param order Optional pointer to an affinity order of CPU ids to bind
-      threads.
     * \param reverse Whether to traverse the affinity ordering in reverse.
       to.
     */
-  void SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order = NULL,
-                   bool reverse = false);
+  void SetAffinity(bool exclude_worker0, bool reverse = false);
+
+  /*!
+   * \brief Set the affinity order of a ThreadGroup.
+   *
+   * \param order The affinity order to use.
+   * \param max_count The number of CPUs with the max frequency (big).
+   * \param min_count The number of CPUs with the min frequency (LITTLE).
+   */
+  void SetAffinityOrder(std::vector<unsigned int> order, int max_count, int min_count);
+
+  /*!
+   * \brief Check whether the affinity order of a ThreadGroup has been
+   * initialized.
+   *
+   * \brief Whether the affinity order has been initialized.
+   *
+   */
+  bool AffinityOrderSet();
+
+  /*!
+   * \brief Get the number of CPU ids of the preferred type
+   *
+   * \param reverse Whether to use the min_count instead.
+   *
+   * \return The count of the specified CPU id type.
+   */
+  int GetPrefCount(bool reverse);
 
  private:
   Impl* impl_;
@@ -74,13 +98,14 @@ int MaxConcurrency();
 /*!
  * \brief configure the CPU id affinity
  *
- * \param mode the preferred CPU type (0 = default, 1 = big, -1 = little)
- * \param nthreads the number of threads to use (0 = use all)
- * \param sorted_order reference to the CPU id affinity list
+ * \param mode The preferred CPU type (0 = default, 1 = big, -1 = little).
+ * \param nthreads The number of threads to use (0 = use all).
+ * \param thread_group Pointer to the ThreadGroup being configured.
  *
  * \return the number of workers to use
  */
-unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> *sorted_order);
+unsigned int ConfigThreadGroup(int mode, int nthreads, ThreadGroup *thread_group);
+
 
 }  // namespace threading
 }  // namespace runtime

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -55,31 +55,14 @@ class ThreadGroup {
   void SetAffinity(bool exclude_worker0, bool reverse = false);
 
   /*!
-   * \brief Set the affinity order of a ThreadGroup.
+   * \brief configure the CPU id affinity
    *
-   * \param order The affinity order to use.
-   * \param max_count The number of CPUs with the max frequency (big).
-   * \param min_count The number of CPUs with the min frequency (LITTLE).
+   * \param mode The preferred CPU type (0 = default, 1 = big, -1 = little).
+   * \param nthreads The number of threads to use (0 = use all).
+   *
+   * \return The number of workers to use.
    */
-  void SetAffinityOrder(std::vector<unsigned int> order, int max_count, int min_count);
-
-  /*!
-   * \brief Check whether the affinity order of a ThreadGroup has been
-   * initialized.
-   *
-   * \brief Whether the affinity order has been initialized.
-   *
-   */
-  bool AffinityOrderSet();
-
-  /*!
-   * \brief Get the number of CPU ids of the preferred type
-   *
-   * \param reverse Whether to use the min_count instead.
-   *
-   * \return The count of the specified CPU id type.
-   */
-  int GetPrefCount(bool reverse);
+  unsigned int ConfigThreadGroup(int mode, int nthreads);
 
  private:
   Impl* impl_;
@@ -94,17 +77,6 @@ void Yield();
  * \return the maximum number of effective workers for this system.
  */
 int MaxConcurrency();
-
-/*!
- * \brief configure the CPU id affinity
- *
- * \param mode The preferred CPU type (0 = default, 1 = big, -1 = little).
- * \param nthreads The number of threads to use (0 = use all).
- * \param thread_group Pointer to the ThreadGroup being configured.
- *
- * \return the number of workers to use
- */
-unsigned int ConfigThreadGroup(int mode, int nthreads, ThreadGroup *thread_group);
 
 
 }  // namespace threading

--- a/include/tvm/runtime/threading_backend.h
+++ b/include/tvm/runtime/threading_backend.h
@@ -56,7 +56,7 @@ class ThreadGroup {
    *
    * \return The number of workers to use.
    */
-  unsigned int ConfigThreadGroup(int mode, int nthreads, bool exclude_worker0);
+  int Config(int mode, int nthreads, bool exclude_worker0);
 
  private:
   Impl* impl_;

--- a/src/runtime/sgx/trusted/threading_backend.cc
+++ b/src/runtime/sgx/trusted/threading_backend.cc
@@ -53,7 +53,7 @@ ThreadGroup::ThreadGroup(int num_workers,
                          bool exclude_worker0)
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 void ThreadGroup::Join() {}
-unsigned int ThreadGroup::ConfigThreadGroup(int mode, int nthreads, bool exclude_worker0) {
+unsigned int ThreadGroup::Configure(int mode, int nthreads, bool exclude_worker0) {
   unsigned int max_conc = (unsigned int) MaxConcurrency();
   if (!nthreads || ntheads > MaxConcurrency()) {
     return max_conc;

--- a/src/runtime/sgx/trusted/threading_backend.cc
+++ b/src/runtime/sgx/trusted/threading_backend.cc
@@ -53,6 +53,13 @@ ThreadGroup::ThreadGroup(int num_workers,
                          bool exclude_worker0)
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 void ThreadGroup::Join() {}
+unsigned int ThreadGroup::ConfigThreadGroup(int mode, int nthreads, bool exclude_worker0) {
+  unsigned int max_conc = (unsigned int) MaxConcurrency();
+  if (!nthreads || ntheads > MaxConcurrency()) {
+    return max_conc;
+  }
+  return nthreads;
+}
 ThreadGroup::~ThreadGroup() { delete impl_; }
 
 void Yield() {}

--- a/src/runtime/sgx/trusted/threading_backend.cc
+++ b/src/runtime/sgx/trusted/threading_backend.cc
@@ -54,7 +54,7 @@ ThreadGroup::ThreadGroup(int num_workers,
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 void ThreadGroup::Join() {}
 int ThreadGroup::Configure(int mode, int nthreads, bool exclude_worker0) {
-  unsigned int max_conc = (unsigned int) MaxConcurrency();
+  int max_conc = MaxConcurrency();
   if (!nthreads || ntheads > MaxConcurrency()) {
     return max_conc;
   }

--- a/src/runtime/sgx/trusted/threading_backend.cc
+++ b/src/runtime/sgx/trusted/threading_backend.cc
@@ -53,9 +53,9 @@ ThreadGroup::ThreadGroup(int num_workers,
                          bool exclude_worker0)
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 void ThreadGroup::Join() {}
-int ThreadGroup::Configure(int mode, int nthreads, bool exclude_worker0) {
+int ThreadGroup::Configure(AffinityMode mode, int nthreads, bool exclude_worker0) {
   int max_conc = MaxConcurrency();
-  if (!nthreads || ntheads > MaxConcurrency()) {
+  if (!nthreads || ntheads > max_conc) {
     return max_conc;
   }
   return nthreads;

--- a/src/runtime/sgx/trusted/threading_backend.cc
+++ b/src/runtime/sgx/trusted/threading_backend.cc
@@ -53,7 +53,7 @@ ThreadGroup::ThreadGroup(int num_workers,
                          bool exclude_worker0)
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 void ThreadGroup::Join() {}
-unsigned int ThreadGroup::Configure(int mode, int nthreads, bool exclude_worker0) {
+int ThreadGroup::Configure(int mode, int nthreads, bool exclude_worker0) {
   unsigned int max_conc = (unsigned int) MaxConcurrency();
   if (!nthreads || ntheads > MaxConcurrency()) {
     return max_conc;

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -253,7 +253,7 @@ class ThreadPool {
         new tvm::runtime::threading::ThreadGroup(
           num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
           exclude_worker0_ /* include_main_thread */));
-    num_workers_used_ = threads_->Config(1, 0, exclude_worker0_);
+    threads_->Configure(1, 0, exclude_worker0_);
   }
   ~ThreadPool() {
     for (std::unique_ptr<SpscTaskQueue>& q : queues_) {
@@ -301,11 +301,11 @@ class ThreadPool {
     return dmlc::ThreadLocalStore<ThreadPool>::Get();
   }
 
-  void UpdateWorkerConfig(int mode, int nthreads) {
+  void UpdateWorkerConfiguration(int mode, int nthreads) {
     // this will also reset the affinity of the ThreadGroup
     // may use less than the MaxConcurrency number of workers
-    num_workers_used_ = threads_->Config(mode, nthreads,
-                                                                exclude_worker0_);
+    num_workers_used_ = threads_->Configure(mode, nthreads,
+                                            exclude_worker0_);
   }
 
  private:
@@ -342,7 +342,7 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
     int mode = args[0];
     int nthreads = args[1];
-    ThreadPool::ThreadLocal()->UpdateWorkerConfig(mode, nthreads);
+    ThreadPool::ThreadLocal()->UpdateWorkerConfiguration(mode, nthreads);
 });
 
 

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -301,7 +301,7 @@ class ThreadPool {
   }
 
   void UpdateWorkerConfig(int mode, int nthreads) {
-    unsigned int num_workers_used = threading::ConfigThreadGroup(mode, nthreads, threads_.get());
+    unsigned int num_workers_used = threads_->ConfigThreadGroup(mode, nthreads);
     bool reverse = mode == -1;
     // may use less than the MaxConcurrency number of workers
     num_workers_used_ = num_workers_used;

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -244,7 +244,6 @@ class SpscTaskQueue {
 class ThreadPool {
  public:
   ThreadPool(): num_workers_(tvm::runtime::threading::MaxConcurrency()) {
-    num_workers_used_ = num_workers_;
     for (int i = 0; i < num_workers_; ++i) {
       // The SpscTaskQueue only hosts ONE item at a time
       queues_.emplace_back(std::unique_ptr<SpscTaskQueue>(new SpscTaskQueue()));
@@ -253,16 +252,10 @@ class ThreadPool {
         new tvm::runtime::threading::ThreadGroup(
           num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
           exclude_worker0_ /* include_main_thread */));
-    const char *val = getenv("TVM_BIND_THREADS");
-    if (val == nullptr || atoi(val) == 1) {
-      if (static_cast<size_t>(num_workers_) <= num_workers_used_) {
-        num_workers_used_ = threads_->Configure(1, 0, exclude_worker0_);
-      } else {
-        LOG(WARNING)
-          << "The thread affinity cannot be set when the number of workers"
-          << "is larger than the number of available cores in the system.";
-      }
-    }
+    num_workers_used_ = threads_->Configure(1, 0, exclude_worker0_);
+    // if MaxConcurrency restricted the number of workers (e.g., due to
+    // hyperthreading), respect the restriction
+    num_workers_used_ = std::min(num_workers_, num_workers_used_);
   }
   ~ThreadPool() {
     for (std::unique_ptr<SpscTaskQueue>& q : queues_) {
@@ -315,6 +308,9 @@ class ThreadPool {
     // may use less than the MaxConcurrency number of workers
     num_workers_used_ = threads_->Configure(mode, nthreads,
                                             exclude_worker0_);
+    // if MaxConcurrency restricted the number of workers (e.g., due to
+    // hyperthreading), respect the restriction
+    num_workers_used_ = std::min(num_workers_, num_workers_used_);
   }
 
  private:

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -255,7 +255,7 @@ class ThreadPool {
           exclude_worker0_ /* include_main_thread */));
     const char *val = getenv("TVM_BIND_THREADS");
     if (val == nullptr || atoi(val) == 1) {
-      if (static_cast<size_t>(num_workers_) <= std::thread::hardware_concurrency()) {
+      if (static_cast<size_t>(num_workers_) <= num_workers_used_) {
         num_workers_used_ = threads_->Configure(1, 0, exclude_worker0_);
       } else {
         LOG(WARNING)

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -253,6 +253,7 @@ class ThreadPool {
         new tvm::runtime::threading::ThreadGroup(
           num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
           exclude_worker0_ /* include_main_thread */));
+    threads_->Config(1, 0, exclude_worker0_);
   }
   ~ThreadPool() {
     for (std::unique_ptr<SpscTaskQueue>& q : queues_) {
@@ -302,10 +303,9 @@ class ThreadPool {
 
   void UpdateWorkerConfig(int mode, int nthreads) {
     // this will also reset the affinity of the ThreadGroup
-    unsigned int num_workers_used = threads_->ConfigThreadGroup(mode, nthreads,
-                                                                exclude_worker0_);
     // may use less than the MaxConcurrency number of workers
-    num_workers_used_ = num_workers_used;
+    num_workers_used_ = threads_->Config(mode, nthreads,
+                                                                exclude_worker0_);
   }
 
  private:

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -386,7 +386,6 @@ void setAffinityPref(bool ascending) {
 
     ThreadPool::affinity_order = sorted_order;
     ThreadPool::preferred_num = preferred_num;
-    LOG(INFO) << "preferred_num: " << preferred_num;
 }
 
 void setNthreadsPref(int nthreads) {
@@ -397,7 +396,6 @@ void setNthreadsPref(int nthreads) {
     } else {
         ThreadPool::nthreads = nthreads;
     }
-    LOG(INFO) << "nthreads: " << ThreadPool::nthreads;
 }
 
 TVM_REGISTER_GLOBAL("runtime.config_threadpool")

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -348,11 +348,11 @@ void setAffinityPref(bool ascending) {
     std::vector<unsigned int> sorted_order;
 
     for (unsigned int i = 0; i < threads; i++) {
-        snprintf(filepath, 128,  "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", i);
+        snprintf(filepath, sizeof(filepath),  "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", i);
         FILE *fp = std::fopen(filepath, "r");
-        long long cur_freq = -1;
+        int64_t cur_freq = -1;
         if (fp) {
-                int read = std::fscanf(fp, "%lli", &cur_freq);
+                int read = std::fscanf(fp, "%" PRId64, &cur_freq);
                 std::fclose(fp);
                 if (!read)
                     LOG(WARNING) << "CPU max frequency info empty!";
@@ -363,10 +363,10 @@ void setAffinityPref(bool ascending) {
         }
     }
 
-    auto max = [] (std::pair<unsigned int, long long> a, std::pair<unsigned int, long long> b) {
+    auto max = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, long long> b) {
         return a.second > b.second;
     };
-    auto min = [] (std::pair<unsigned int, long long> a, std::pair<unsigned int, long long> b) {
+    auto min = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, long long> b) {
         return a.second < b.second;
     };
     if (ascending) {

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -344,11 +344,12 @@ int ThreadPool::nthreads = 0;
 void setAffinityPref(bool ascending) {
     unsigned int threads = std::thread::hardware_concurrency();
     char filepath[128];
-    std::vector<std::pair <unsigned int, long long>> max_freqs;
+    std::vector<std::pair <unsigned int, int64_t>> max_freqs;
     std::vector<unsigned int> sorted_order;
 
     for (unsigned int i = 0; i < threads; i++) {
-        snprintf(filepath, sizeof(filepath),  "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", i);
+        snprintf(filepath, sizeof(filepath),
+                 "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", i);
         FILE *fp = std::fopen(filepath, "r");
         int64_t cur_freq = -1;
         if (fp) {
@@ -363,10 +364,10 @@ void setAffinityPref(bool ascending) {
         }
     }
 
-    auto max = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, long long> b) {
+    auto max = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, int64_t> b) {
         return a.second > b.second;
     };
-    auto min = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, long long> b) {
+    auto min = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, int64_t> b) {
         return a.second < b.second;
     };
     if (ascending) {
@@ -375,7 +376,7 @@ void setAffinityPref(bool ascending) {
         std::sort(max_freqs.begin(), max_freqs.end(), max);
     }
     auto it = max_freqs.begin();
-    long long preferred_freq = it->second;
+    int64_t preferred_freq = it->second;
     int preferred_num = 0;
     for (; it != max_freqs.end(); it++) {
         sorted_order.push_back(it->first);

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -400,22 +400,19 @@ void setNthreadsPref(int nthreads) {
     LOG(INFO) << "nthreads: " << ThreadPool::nthreads;
 }
 
-//TVM_REGISTER_GLOBAL("runtime.config_threadpool")
-//.set_body([](TVMArgs args, TVMRetValue* rv) {
-//    LOG(INFO) << "config threadpool";
-//    std::string mode = args[0];
-//    int nthreads = args[1];
-//    if (mode == "big") {
-//        setAffinityPref(false);
-//    } else if (mode == "little") {
-//        setAffinityPref(true);
-//    } else if (mode == "default") {
-//        ThreadPool::affinity_order.clear();
-//    }
-//    LOG(INFO) << "first";
-//    setNthreadsPref(nthreads);
-//    LOG(INFO) << "???";
-//  });
+TVM_REGISTER_GLOBAL("runtime.config_threadpool")
+.set_body([](TVMArgs args, TVMRetValue* rv) {
+    std::string mode = args[0];
+    int nthreads = args[1];
+    if (mode == "big") {
+        setAffinityPref(false);
+    } else if (mode == "little") {
+        setAffinityPref(true);
+    } else if (mode == "default") {
+        ThreadPool::affinity_order.clear();
+    }
+    setNthreadsPref(nthreads);
+  });
 
 
 }  // namespace runtime

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -252,7 +252,7 @@ class ThreadPool {
         new tvm::runtime::threading::ThreadGroup(
           num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
           exclude_worker0_ /* include_main_thread */));
-    num_workers_used_ = threads_->Configure(1, 0, exclude_worker0_);
+    num_workers_used_ = threads_->Configure(threading::ThreadGroup::kBig, 0, exclude_worker0_);
     // if MaxConcurrency restricted the number of workers (e.g., due to
     // hyperthreading), respect the restriction
     num_workers_used_ = std::min(num_workers_, num_workers_used_);
@@ -303,7 +303,7 @@ class ThreadPool {
     return dmlc::ThreadLocalStore<ThreadPool>::Get();
   }
 
-  void UpdateWorkerConfiguration(int mode, int nthreads) {
+  void UpdateWorkerConfiguration(threading::ThreadGroup::AffinityMode mode, int nthreads) {
     // this will also reset the affinity of the ThreadGroup
     // may use less than the MaxConcurrency number of workers
     num_workers_used_ = threads_->Configure(mode, nthreads,
@@ -345,7 +345,9 @@ class ThreadPool {
 
 TVM_REGISTER_GLOBAL("runtime.config_threadpool")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
-    int mode = args[0];
+    threading::ThreadGroup::AffinityMode mode =\
+    static_cast<threading::ThreadGroup::AffinityMode>(\
+    static_cast<int>(args[0]));
     int nthreads = args[1];
     ThreadPool::ThreadLocal()->UpdateWorkerConfiguration(mode, nthreads);
 });

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -300,18 +300,13 @@ class ThreadPool {
     return dmlc::ThreadLocalStore<ThreadPool>::Get();
   }
 
-  void updateWorkerConfig(int mode, int nthreads) {
-    std::vector<unsigned int> sorted_order;
-    unsigned int num_workers_used = threading::configThreadGroup(mode, nthreads, &sorted_order);
+  void UpdateWorkerConfig(int mode, int nthreads) {
+    unsigned int num_workers_used = threading::ConfigThreadGroup(mode, nthreads, threads_.get());
     bool reverse = mode == -1;
     // may use less than the MaxConcurrency number of workers
     num_workers_used_ = num_workers_used;
     // rebind thread affinity in ThreadGroup (backend)
-    if (num_workers_used <= sorted_order.size()) {
-      threads_->SetAffinity(exclude_worker0_, &sorted_order, reverse);
-    } else {
-      LOG(WARNING) << "num_workers exceeds CPU affinity list size, affinity config failed!";
-    }
+    threads_->SetAffinity(exclude_worker0_, reverse);
   }
 
  private:
@@ -348,7 +343,7 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
     int mode = args[0];
     int nthreads = args[1];
-    ThreadPool::ThreadLocal()->updateWorkerConfig(mode, nthreads);
+    ThreadPool::ThreadLocal()->UpdateWorkerConfig(mode, nthreads);
 });
 
 

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -346,7 +346,7 @@ TVM_REGISTER_GLOBAL("runtime.config_threadpool")
     int mode = args[1];
     int nthreads = args[2];
     std::vector<unsigned int> sorted_order;
-    unsigned int num_workers_used = threading::configThreadGroup(mode, nthreads, sorted_order);
+    unsigned int num_workers_used = threading::configThreadGroup(mode, nthreads, &sorted_order);
     bool reverse = mode == -1;
     if (num_workers_used <= sorted_order.size()) {
       ThreadPool::ThreadLocal()->updateWorkerConfig(num_workers_used, exclude_worker0,

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -253,7 +253,7 @@ class ThreadPool {
         new tvm::runtime::threading::ThreadGroup(
           num_workers_, [this](int worker_id) { this->RunWorker(worker_id); },
           exclude_worker0_ /* include_main_thread */));
-    threads_->Config(1, 0, exclude_worker0_);
+    num_workers_used_ = threads_->Config(1, 0, exclude_worker0_);
   }
   ~ThreadPool() {
     for (std::unique_ptr<SpscTaskQueue>& q : queues_) {

--- a/src/runtime/thread_pool.cc
+++ b/src/runtime/thread_pool.cc
@@ -301,12 +301,11 @@ class ThreadPool {
   }
 
   void UpdateWorkerConfig(int mode, int nthreads) {
-    unsigned int num_workers_used = threads_->ConfigThreadGroup(mode, nthreads);
-    bool reverse = mode == -1;
+    // this will also reset the affinity of the ThreadGroup
+    unsigned int num_workers_used = threads_->ConfigThreadGroup(mode, nthreads,
+                                                                exclude_worker0_);
     // may use less than the MaxConcurrency number of workers
     num_workers_used_ = num_workers_used;
-    // rebind thread affinity in ThreadGroup (backend)
-    threads_->SetAffinity(exclude_worker0_, reverse);
   }
 
  private:

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -82,9 +82,8 @@ class ThreadGroup::Impl {
     CHECK_LE(threads_.size() + exclude_worker0, sorted_order_.size());
     if (sorted_order_.size() != threads_.size()) {
       LOG(WARNING) << "setting affinity with subset of threads!";
-      LOG(WARNING) << "total threads: " << sorted_order_.size() << ", using: "
-                   << threads_.size() + exclude_worker0;
     }
+
     for (unsigned i = 0; i < threads_.size(); ++i) {
       unsigned core_id;
       if (reverse) {

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -54,8 +54,16 @@ class ThreadGroup::Impl {
     if (nthreads) {
       num_workers_used = nthreads;
     }
-
-    SetAffinity(exclude_worker0, mode == -1);
+    const char *val = getenv("TVM_BIND_THREADS");
+    if (val == nullptr || atoi(val) == 1) {
+      if (static_cast<size_t>(num_workers_) <= std::thread::hardware_concurrency()) {
+        SetAffinity(exclude_worker0, mode == -1);
+      } else {
+        LOG(WARNING)
+          << "The thread affinity cannot be set when the number of workers"
+          << "is larger than the number of available cores in the system.";
+      }
+    }
     return num_workers_used;
   }
 

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -45,7 +45,7 @@ class ThreadGroup::Impl {
       if (t.joinable()) t.join();
     }
   }
-  
+
  private:
   // bind worker threads to disjoint cores
   // if worker 0 is offloaded to master, i.e. exclude_worker0 is true,

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -117,7 +117,7 @@ class ThreadGroup::Impl {
   }
 
   void InitSortedOrder() {
-    unsigned int threads = threading::MaxConcurrency();
+    unsigned int threads = std::thread::hardware_concurrency();
     std::vector<std::pair <unsigned int, int64_t> > max_freqs;
 
     for (unsigned int i = 0; i < threads; ++i) {

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -7,6 +7,7 @@
 #include <dmlc/logging.h>
 #include <thread>
 #include <algorithm>
+#include <fstream>
 #if defined(__linux__)
 #include <sched.h>
 #endif
@@ -19,8 +20,7 @@ class ThreadGroup::Impl {
  public:
   Impl(int num_workers,
        std::function<void(int)> worker_callback,
-       bool exclude_worker0,
-       std::vector<unsigned int> *affinity_order)
+       bool exclude_worker0)
       : num_workers_(num_workers) {
     CHECK_GE(num_workers, 1)
       << "Requested a non-positive number of worker threads.";
@@ -30,7 +30,7 @@ class ThreadGroup::Impl {
     const char *val = getenv("TVM_BIND_THREADS");
     if (val == nullptr || atoi(val) == 1) {
       if (static_cast<size_t>(num_workers_) <= std::thread::hardware_concurrency()) {
-        SetAffinity(exclude_worker0, affinity_order);
+        SetAffinity(exclude_worker0);
       } else {
         LOG(WARNING)
           << "The thread affinity cannot be set when the number of workers"
@@ -46,11 +46,10 @@ class ThreadGroup::Impl {
     }
   }
 
- private:
   // bind worker threads to disjoint cores
   // if worker 0 is offloaded to master, i.e. exclude_worker0 is true,
   // the master thread is bound to core 0.
-  void SetAffinity(bool exclude_worker0, std::vector<unsigned int> *affinity_order) {
+  void SetAffinity(bool exclude_worker0, std::vector<unsigned int> *order = NULL, bool reverse = false) {
 #if defined(__ANDROID__)
 #ifndef CPU_SET
 #define CPU_SETSIZE 1024
@@ -68,8 +67,12 @@ class ThreadGroup::Impl {
 #if defined(__linux__) || defined(__ANDROID__)
     for (unsigned i = 0; i < threads_.size(); ++i) {
       unsigned core_id;
-      if (affinity_order != NULL && affinity_order->size() >= threads_.size()) {
-        core_id = (*affinity_order)[i+exclude_worker0];
+      if (order != NULL && order->size() >= threads_.size()) {
+        if (reverse) {
+          core_id = (*order)[order->size() - (i + exclude_worker0) - 1];
+        } else {
+          core_id = (*order)[i + exclude_worker0];
+        }
       } else {
         core_id = i + exclude_worker0;
       }
@@ -86,8 +89,12 @@ class ThreadGroup::Impl {
     if (exclude_worker0) {  // bind the master thread to core 0
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
-      if (affinity_order != NULL && affinity_order->size() >= threads_.size()) {
-        CPU_SET((*affinity_order)[0], &cpuset);
+      if (order != NULL && order->size() >= threads_.size()) {
+        if (reverse) {
+          CPU_SET((*order)[order->size() - 1], &cpuset);
+        } else {
+          CPU_SET((*order)[0], &cpuset);
+        }
       } else {
         CPU_SET(0, &cpuset);
       }
@@ -102,18 +109,21 @@ class ThreadGroup::Impl {
 #endif
   }
 
+ private:
   int num_workers_;
   std::vector<std::thread> threads_;
-  std::vector<int> affinity_order_;
 };
 
 ThreadGroup::ThreadGroup(int num_workers,
                          std::function<void(int)> worker_callback,
-                         bool exclude_worker0,
-                         std::vector<unsigned int> *affinity_order)
-  : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0, affinity_order)) {}
+                         bool exclude_worker0)
+  : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 ThreadGroup::~ThreadGroup() { delete impl_; }
 void ThreadGroup::Join() { impl_->Join(); }
+void ThreadGroup::SetAffinity(bool exclude_worker0, std::vector<unsigned int> *order,
+                              bool reverse) {
+  impl_->SetAffinity(exclude_worker0, order, reverse);
+}
 
 void Yield() {
   std::this_thread::yield();
@@ -135,6 +145,62 @@ int MaxConcurrency() {
   }
   return std::max(max_concurrency, 1);
 }
+
+
+unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> &sorted_order) {
+  unsigned int threads = std::thread::hardware_concurrency();
+  std::vector<std::pair <unsigned int, int64_t>> max_freqs;
+  int preferred_num = 0;
+
+  // big or LITTLE
+  if (mode) {
+    for (unsigned int i = 0; i < threads; ++i) {
+      std::ostringstream filepath;
+      filepath << "/sys/devices/system/cpu/cpu"  << i << "/cpufreq/cpuinfo_max_freq";
+      std::ifstream ifs(filepath.str());
+      int64_t cur_freq = -1;
+      if (!ifs.fail()) {
+        ifs >> cur_freq;
+        ifs.close();
+        max_freqs.push_back(std::make_pair(i, cur_freq));
+        if (cur_freq < 0) {
+          LOG(WARNING) << "failed to read CPU max frequency!";
+        }
+      } else {
+        LOG(WARNING) << "failed to read CPU max frequency!";
+        break;
+      }
+    }
+
+    auto max = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, int64_t> b) {
+      return a.second > b.second;
+    };
+    std::sort(max_freqs.begin(), max_freqs.end(), max);
+    int64_t preferred_freq;
+    if (mode == 1) {
+      preferred_freq = max_freqs.begin()->second;
+    } else {
+      preferred_freq = max_freqs.rend()->second;
+    }
+    for (auto it = max_freqs.begin(); it != max_freqs.end(); it++) {
+      sorted_order.push_back(it->first);
+      if (preferred_freq == it->second) {
+        preferred_num++;
+      }
+    }
+  }
+
+  unsigned int num_workers_used = preferred_num;
+  // if a specific number was given, use that
+  if (nthreads)
+    num_workers_used = nthreads;
+  // use default
+  if (!num_workers_used)
+    num_workers_used = threading::MaxConcurrency();
+
+  return num_workers_used;
+}
+
 
 }  // namespace threading
 }  // namespace runtime

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -49,7 +49,8 @@ class ThreadGroup::Impl {
   // bind worker threads to disjoint cores
   // if worker 0 is offloaded to master, i.e. exclude_worker0 is true,
   // the master thread is bound to core 0.
-  void SetAffinity(bool exclude_worker0, std::vector<unsigned int> *order = NULL, bool reverse = false) {
+  void SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order = NULL,
+                   bool reverse = false) {
 #if defined(__ANDROID__)
 #ifndef CPU_SET
 #define CPU_SETSIZE 1024
@@ -120,7 +121,7 @@ ThreadGroup::ThreadGroup(int num_workers,
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 ThreadGroup::~ThreadGroup() { delete impl_; }
 void ThreadGroup::Join() { impl_->Join(); }
-void ThreadGroup::SetAffinity(bool exclude_worker0, std::vector<unsigned int> *order,
+void ThreadGroup::SetAffinity(bool exclude_worker0, const std::vector<unsigned int> *order,
                               bool reverse) {
   impl_->SetAffinity(exclude_worker0, order, reverse);
 }
@@ -147,7 +148,7 @@ int MaxConcurrency() {
 }
 
 
-unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> &sorted_order) {
+unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int> *sorted_order) {
   unsigned int threads = std::thread::hardware_concurrency();
   std::vector<std::pair <unsigned int, int64_t>> max_freqs;
   int preferred_num = 0;
@@ -183,7 +184,7 @@ unsigned int configThreadGroup(int mode, int nthreads, std::vector<unsigned int>
       preferred_freq = max_freqs.rend()->second;
     }
     for (auto it = max_freqs.begin(); it != max_freqs.end(); it++) {
-      sorted_order.push_back(it->first);
+      sorted_order->push_back(it->first);
       if (preferred_freq == it->second) {
         preferred_num++;
       }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -177,7 +177,6 @@ int MaxConcurrency() {
 unsigned int ConfigThreadGroup(int mode, int nthreads, ThreadGroup *thread_group) {
   unsigned int threads = std::thread::hardware_concurrency();
   std::vector<std::pair <unsigned int, int64_t>> max_freqs;
-  int preferred_num = 0;
 
   // big or LITTLE
   if (mode) {

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -79,12 +79,14 @@ class ThreadGroup::Impl {
 #endif
 #endif
 #if defined(__linux__) || defined(__ANDROID__)
+    CHECK_LE(threads_.size() + exclude_worker0, sorted_order_.size());
+    if (sorted_order_.size() != threads_.size()) {
+      LOG(WARNING) << "setting affinity with subset of threads!";
+      LOG(WARNING) << "total threads: " << sorted_order_.size() << ", using: "
+                   << threads_.size() + exclude_worker0;
+    }
     for (unsigned i = 0; i < threads_.size(); ++i) {
       unsigned core_id;
-      CHECK_LE(threads_.size() + exclude_worker0, sorted_order_.size());
-      if (sorted_order_.size() != threads_.size()) {
-        LOG(WARNING) << "setting affinity with subset of threads!";
-      }
       if (reverse) {
         core_id = sorted_order_[sorted_order_.size() - (i + exclude_worker0) - 1];
       } else {

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -63,7 +63,7 @@ class ThreadGroup::Impl {
             filepath << "/sys/devices/system/cpu/cpu"  << i << "/cpufreq/cpuinfo_max_freq";
             std::ifstream ifs(filepath.str());
             if (!ifs.fail()) {
-              if(!(ifs >> cur_freq)) {
+              if (!(ifs >> cur_freq)) {
                 cur_freq = -1;
               }
               ifs.close();

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -81,7 +81,10 @@ class ThreadGroup::Impl {
 #if defined(__linux__) || defined(__ANDROID__)
     for (unsigned i = 0; i < threads_.size(); ++i) {
       unsigned core_id;
-      CHECK_EQ(sorted_order_.size(), threads_.size() + exclude_worker0);
+      CHECK_LE(threads_.size() + exclude_worker0, sorted_order_.size());
+      if (sorted_order_.size() != threads_.size()) {
+        LOG(WARNING) << "setting affinity with subset of threads!";
+      }
       if (reverse) {
         core_id = sorted_order_[sorted_order_.size() - (i + exclude_worker0) - 1];
       } else {
@@ -158,6 +161,8 @@ class ThreadGroup::Impl {
       }
     }
     if (big_count_ + little_count_ != static_cast<int>(sorted_order_.size())) {
+      LOG(WARNING) << big_count_;
+      LOG(INFO) << little_count_;
       LOG(WARNING) << "more than two frequencies detected!";
     }
   }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -169,12 +169,12 @@ class ThreadGroup::Impl {
     }
 #endif
   }
+
   int num_workers_;
   std::vector<std::thread> threads_;
   std::vector<unsigned int> sorted_order_;
   int max_count_ = 0;
   int min_count_ = 0;
-
 };
 
 ThreadGroup::ThreadGroup(int num_workers,

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -137,8 +137,8 @@ class ThreadGroup::Impl {
       max_freqs.push_back(std::make_pair(i, cur_freq));
     }
 
-    auto fcmpbyfreq = [] (std::pair<unsigned int, int64_t> a,
-                          std::pair<unsigned int, int64_t> b) {
+    auto fcmpbyfreq = [] (std::pair<unsigned int, int64_t> &a,
+                          std::pair<unsigned int, int64_t> &b) {
       if (a.second == b.second) {
         return a.first < b.first;
       } else {

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -55,8 +55,7 @@ class ThreadGroup::Impl {
       if (sorted_order_.empty()) {
         for (unsigned int i = 0; i < threads; ++i) {
           int64_t cur_freq = -1;
-          #if defined(_WIN32)
-          #else
+          #if defined(__linux__) || defined(__ANDROID__)
             std::ostringstream filepath;
             filepath << "/sys/devices/system/cpu/cpu"  << i << "/cpufreq/cpuinfo_max_freq";
             std::ifstream ifs(filepath.str());
@@ -64,11 +63,13 @@ class ThreadGroup::Impl {
               ifs >> cur_freq;
               ifs.close();
             }
+          #else
           #endif
           max_freqs.push_back(std::make_pair(i, cur_freq));
         }
 
-        auto fcmpbyfreq = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, int64_t> b) {
+        auto fcmpbyfreq = [] (std::pair<unsigned int, int64_t> a,
+                              std::pair<unsigned int, int64_t> b) {
           if (a.second == b.second) {
             return a.first < b.first;
           } else {
@@ -87,7 +88,7 @@ class ThreadGroup::Impl {
             little_count_++;
           }
         }
-        if (big_count_ + little_count_ != (int) sorted_order_.size()) {
+        if (big_count_ + little_count_ != static_cast<int>(sorted_order_.size())) {
           LOG(WARNING) << "more than two frequencies detected!";
         }
       }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -156,13 +156,11 @@ class ThreadGroup::Impl {
       if (big_freq == it->second) {
         big_count_++;
       }
-      if (little_freq == it->second) {
+      if (big_freq != little_freq && little_freq == it->second) {
         little_count_++;
       }
     }
     if (big_count_ + little_count_ != static_cast<int>(sorted_order_.size())) {
-      LOG(WARNING) << big_count_;
-      LOG(INFO) << little_count_;
       LOG(WARNING) << "more than two frequencies detected!";
     }
   }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -24,7 +24,6 @@ class ThreadGroup::Impl {
       : num_workers_(num_workers) {
     CHECK_GE(num_workers, 1)
       << "Requested a non-positive number of worker threads.";
-    LOG(INFO) << "num workers: " << num_workers;
     for (int i = exclude_worker0; i < num_workers_; ++i) {
       threads_.emplace_back([worker_callback, i] { worker_callback(i); });
     }

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -46,61 +46,65 @@ class ThreadGroup::Impl {
     }
   }
 
-  unsigned int ConfigThreadGroup(int mode, int nthreads, bool exclude_worker0) {
-    unsigned int threads = std::thread::hardware_concurrency();
-    std::vector<std::pair <unsigned int, int64_t>> max_freqs;
+  int Config(int mode, int nthreads, bool exclude_worker0) {
+    unsigned int threads = threading::MaxConcurrency();
+    std::vector<std::pair <unsigned int, int64_t> > max_freqs;
 
     // big or LITTLE
     if (mode) {
       if (sorted_order_.empty()) {
-          for (unsigned int i = 0; i < threads; ++i) {
+        for (unsigned int i = 0; i < threads; ++i) {
+          int64_t cur_freq = -1;
+          #if defined(_WIN32)
+          #else
             std::ostringstream filepath;
             filepath << "/sys/devices/system/cpu/cpu"  << i << "/cpufreq/cpuinfo_max_freq";
             std::ifstream ifs(filepath.str());
-            int64_t cur_freq = -1;
             if (!ifs.fail()) {
               ifs >> cur_freq;
               ifs.close();
-              max_freqs.push_back(std::make_pair(i, cur_freq));
-              if (cur_freq < 0) {
-                LOG(WARNING) << "failed to read CPU max frequency!";
-              }
-            } else {
-              LOG(WARNING) << "failed to read CPU max frequency!";
-              break;
             }
-          }
-        auto max = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, int64_t> b) {
-          return a.second > b.second;
-        };
+          #endif
+          max_freqs.push_back(std::make_pair(i, cur_freq));
+        }
 
-        std::sort(max_freqs.begin(), max_freqs.end(), max);
-        int64_t max_freq = max_freqs.begin()->second;
-        int64_t min_freq = max_freqs.rbegin()->second;
+        auto fcmpbyfreq = [] (std::pair<unsigned int, int64_t> a, std::pair<unsigned int, int64_t> b) {
+          if (a.second == b.second) {
+            return a.first < b.first;
+          } else {
+            return a.second > b.second;
+          }
+        };
+        std::sort(max_freqs.begin(), max_freqs.end(), fcmpbyfreq);
+        int64_t big_freq = max_freqs.begin()->second;
+        int64_t little_freq = max_freqs.rbegin()->second;
         for (auto it = max_freqs.begin(); it != max_freqs.end(); it++) {
-            sorted_order_.push_back(it->first);
-            if (max_freq == it->second) {
-              max_count_++;
-            }
-            if (min_freq == it->second) {
-              min_count_++;
-            }
+          sorted_order_.push_back(it->first);
+          if (big_freq == it->second) {
+            big_count_++;
+          }
+          if (little_freq == it->second) {
+            little_count_++;
+          }
+        }
+        if (big_count_ + little_count_ != (int) sorted_order_.size()) {
+          LOG(WARNING) << "more than two frequencies detected!";
         }
       }
     }
 
-    unsigned int num_workers_used = 0;
+    int num_workers_used = 0;
     if (mode == -1) {
-      num_workers_used = min_count_;
+      num_workers_used = little_count_;
     } else if (mode == 1) {
-      num_workers_used = max_count_;
+      num_workers_used = big_count_;
+    } else {
+      // use default
+      num_workers_used = threading::MaxConcurrency();
     }
     // if a specific number was given, use that
     if (nthreads)
       num_workers_used = nthreads;
-    // use default
-    if (!num_workers_used)
-      num_workers_used = threading::MaxConcurrency();
 
     SetAffinity(exclude_worker0, mode == -1);
     return num_workers_used;
@@ -173,8 +177,8 @@ class ThreadGroup::Impl {
   int num_workers_;
   std::vector<std::thread> threads_;
   std::vector<unsigned int> sorted_order_;
-  int max_count_ = 0;
-  int min_count_ = 0;
+  int big_count_ = 0;
+  int little_count_ = 0;
 };
 
 ThreadGroup::ThreadGroup(int num_workers,
@@ -183,8 +187,8 @@ ThreadGroup::ThreadGroup(int num_workers,
   : impl_(new ThreadGroup::Impl(num_workers, worker_callback, exclude_worker0)) {}
 ThreadGroup::~ThreadGroup() { delete impl_; }
 void ThreadGroup::Join() { impl_->Join(); }
-unsigned int ThreadGroup::ConfigThreadGroup(int mode, int nthreads, bool exclude_worker0) {
-  return impl_->ConfigThreadGroup(mode, nthreads, exclude_worker0);
+int ThreadGroup::Config(int mode, int nthreads, bool exclude_worker0) {
+  return impl_->Config(mode, nthreads, exclude_worker0);
 }
 
 void Yield() {


### PR DESCRIPTION
Currently one common use mode of tvm is to use all the available cores on a system, as defined in [MaxConcurrency](https://github.com/dmlc/tvm/blob/cdfdda4e01d90f6ded9208ff2de9cc699f1beea8/src/runtime/sgx/trusted/threading_backend.cc#L60). On asymmetric or heterogeneous multicores (e.g., big.LITTLE), however, we may want to specify a subset of CPU cores (with a preference for the CPU core type).

This PR introduces a new global function to change the runtime configuration `runtime.config_threadpool` which allows the user to specify a CPU type as well as the number of threads to use. 
arguments: 
`mode` : `{big, little, default}`
`nthreads`: `{0, 1, 2, ...}`
Mode will select the preferred CPU type (based on CPU clock rate). "big" will prefer higher clocked cores first, while "little" will prefer lower clocked cores first.  Choosing "default" will not change the CPU affinity preference order from the system's CPU id ordering.
Nthreads selects the number of CPUs to use, picking CPUs to use in the order specified by `mode`.
If a value of 0 is picked, all of the cores of the preferred `mode` will be used.

Example:
System has 4x Cortex A-53 (LITTLE) + 2x Cortex A-72 (big).
cpuid 0: LITTLE
cpuid 1: LITTLE
cpuid 2: LITTLE
cpuid 3: LITTLE
cpuid 4: big
cpuid 5: big

`config_threadpool("big", 1)` -> changes affinity order to `[4,5,1,2,3]`, will use CPU 4
`config_threadpool("big", 2)` -> changes affinity order to `[4,5,1,2,3]`, will use CPUs 4, 5
`config_threadpool("big", 3)` -> changes affinity order to `[4,5,1,2,3]`, will use CPUs 4,5,0
`config_threadpool("big", 0)` -> changes affinity order to `[4,5,1,2,3]`, will use CPUs 4,5

`config_threadpool("little", 0)` ->leaves affinity order as  `[0,1,2,3,4,5]`, will use CPUs 0,1,2,3
`config_threadpool("little", 5)` ->leaves affinity order as  `[0,1,2,3,4,5]`, will use CPUs 0,1,2,3,4

`config_threadpool("default", 0)` ->leaves affinity order as  `[0,1,2,3,4,5]`, will use CPUs 0,1,2,3,4,5

Note that if `config_threadpool` is not called, the default behavior remains the same as in current tvm.

On a few toy experiments, we can observe that restricting the runtime to 2x A-72 cores can actually outperform 4x A-53 _PLUS_ 2x A-72 cores due to the current static work partitioning scheme.

misc:
I do not know the current standard for docstrings of `TVM_REGISTER_GLOBAL` functions, let me know where that should go.

Currently this scheme will fix CPU affinity once the runtime spawns the threads for execution. We can modify the scheme to support switching affinity dynamically within the same runtime instance, but this requires considering how we want to handle migrating existing threads, as the existing threading backend implementation only sets thread affinity at thread creation time. 