### PR TITLE
[TVM] Fixed SPIR-V codegen for OpControlBarrier

### DIFF
--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -91,12 +91,16 @@ spirv::Value CodeGenSPIRV::CreateStorageSync(const Call* op) {
   if (sync == "warp") {
     return value;
   } else if (sync == "shared") {
+    auto type_int = builder_->GetSType(Int(32));
     builder_->MakeInst(
-        spv::OpControlBarrier,
-        spv::ScopeWorkgroup,
-        spv::ScopeWorkgroup,
+      spv::OpControlBarrier,
+      builder_->IntImm(type_int, static_cast<int64_t>(spv::ScopeWorkgroup)),
+      builder_->IntImm(type_int, static_cast<int64_t>(spv::ScopeWorkgroup)),
+      builder_->IntImm(type_int, static_cast<int64_t>(
         spv::MemorySemanticsSequentiallyConsistentMask |
-        spv::MemorySemanticsWorkgroupMemoryMask);
+        spv::MemorySemanticsWorkgroupMemoryMask
+        ))
+    );
   } else {
     LOG(FATAL) << "Do not support sync " << sync;
   }

--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -98,9 +98,7 @@ spirv::Value CodeGenSPIRV::CreateStorageSync(const Call* op) {
       builder_->IntImm(type_int, static_cast<int64_t>(spv::ScopeWorkgroup)),
       builder_->IntImm(type_int, static_cast<int64_t>(
         spv::MemorySemanticsSequentiallyConsistentMask |
-        spv::MemorySemanticsWorkgroupMemoryMask
-        ))
-    );
+        spv::MemorySemanticsWorkgroupMemoryMask)));
   } else {
     LOG(FATAL) << "Do not support sync " << sync;
   }


### PR DESCRIPTION
SPIR-V codegen was not emitting correct code for OpControlBarrier. This manifested in the test_ewise.py unit test failing for test_multiple_cache_write() on Windows 10.

OpControlBarrier expects ids of integers, not the integers themselves. The fix for this is to generate constants for each required id.
