### PR TITLE
[TEAM] New reviewer: kazum

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 
 ## Reviewers
 - [Masahiro Masuda](https://github.com/masahi)
+- [Kazutaka Morita](https://github.com/kazum)
 - [Pariksheet Pinjari](https://github.com/PariksheetPinjari909)
 - [Siva](https://github.com/srkreddy1238)
 - [Alex Weaver](https://github.com/alex-weaver)


### PR DESCRIPTION
This PR welcomes @kazum as Reviewer of TVM stack. Kazutaka contributes to the nnvm frontend, and contributed initial support for SDAccel driver. He also helps reviews quite a few PRs in the nnvm and core part of the TVM.

- [Kazutaka's history ](https://github.com/dmlc/tvm/commits?author=kazum)
- [Recent code reviews by Kazutaka](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Akazum)