### PR TITLE
[RPC] Added native debug logging to Android RPC

### DIFF
--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -42,5 +42,5 @@
 #include <android/log.h>
 
 void dmlc::CustomLogMessage::Log(const std::string& msg) {
-  __android_log_print(ANDROID_LOG_DEBUG, "TVM_RUNTIME", "%s", msg.c_str());
+  __android_log_write(ANDROID_LOG_DEBUG, "TVM_RUNTIME", msg.c_str());
 }

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -6,6 +6,9 @@
 #include <sys/stat.h>
 #include <fstream>
 
+#define DMLC_LOG_CUSTOMIZE 1
+#define DMLC_LOG_BEFORE_THROW 1
+
 #include "../src/runtime/c_runtime_api.cc"
 #include "../src/runtime/cpu_device_api.cc"
 #include "../src/runtime/workspace_pool.cc"
@@ -34,3 +37,10 @@
 #include "../src/runtime/vulkan/vulkan_device_api.cc"
 #include "../src/runtime/vulkan/vulkan_module.cc"
 #endif
+
+
+#include <android/log.h>
+
+void dmlc::CustomLogMessage::Log(const std::string& msg) {
+    __android_log_print(ANDROID_LOG_DEBUG, "TVM_RUNTIME", "%s", msg.c_str());
+}

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -6,8 +6,14 @@
 #include <sys/stat.h>
 #include <fstream>
 
+#include <android/log.h>
+
 #define DMLC_LOG_CUSTOMIZE 1
 #define DMLC_LOG_BEFORE_THROW 1
+
+void dmlc::CustomLogMessage::Log(const std::string& msg) {
+  __android_log_print(ANDROID_LOG_DEBUG, "TVM_RUNTIME", "%s", msg.c_str());
+}
 
 #include "../src/runtime/c_runtime_api.cc"
 #include "../src/runtime/cpu_device_api.cc"
@@ -37,10 +43,3 @@
 #include "../src/runtime/vulkan/vulkan_device_api.cc"
 #include "../src/runtime/vulkan/vulkan_module.cc"
 #endif
-
-
-#include <android/log.h>
-
-void dmlc::CustomLogMessage::Log(const std::string& msg) {
-    __android_log_print(ANDROID_LOG_DEBUG, "TVM_RUNTIME", "%s", msg.c_str());
-}

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -6,14 +6,8 @@
 #include <sys/stat.h>
 #include <fstream>
 
-#include <android/log.h>
-
 #define DMLC_LOG_CUSTOMIZE 1
 #define DMLC_LOG_BEFORE_THROW 1
-
-void dmlc::CustomLogMessage::Log(const std::string& msg) {
-  __android_log_print(ANDROID_LOG_DEBUG, "TVM_RUNTIME", "%s", msg.c_str());
-}
 
 #include "../src/runtime/c_runtime_api.cc"
 #include "../src/runtime/cpu_device_api.cc"
@@ -43,3 +37,10 @@ void dmlc::CustomLogMessage::Log(const std::string& msg) {
 #include "../src/runtime/vulkan/vulkan_device_api.cc"
 #include "../src/runtime/vulkan/vulkan_module.cc"
 #endif
+
+
+#include <android/log.h>
+
+void dmlc::CustomLogMessage::Log(const std::string& msg) {
+  __android_log_print(ANDROID_LOG_DEBUG, "TVM_RUNTIME", "%s", msg.c_str());
+}

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -6,7 +6,16 @@
 #include <sys/stat.h>
 #include <fstream>
 
+/* Enable custom logging - this will cause TVM to pass every log message
+ * through CustomLogMessage instead of LogMessage. By enabling this, we must
+ * implement dmlc::CustomLogMessage::Log. We use this to pass TVM log
+ * messages to Android logcat.
+ */
 #define DMLC_LOG_CUSTOMIZE 1
+
+/* Ensure that fatal errors are passed to the logger before throwing
+ * in LogMessageFatal
+ */
 #define DMLC_LOG_BEFORE_THROW 1
 
 #include "../src/runtime/c_runtime_api.cc"
@@ -42,5 +51,7 @@
 #include <android/log.h>
 
 void dmlc::CustomLogMessage::Log(const std::string& msg) {
+  // This is called for every message logged by TVM.
+  // We pass the message to logcat.
   __android_log_write(ANDROID_LOG_DEBUG, "TVM_RUNTIME", msg.c_str());
 }


### PR DESCRIPTION
Native code on Android does not automatically forward stdout/stderr to logcat. This PR sets up custom logging so that log messages from TVM are visible in the logcat output. This makes debugging issues in native TVM significantly easier.
