### PR TITLE
[RUNTIME][OPENCL] show correct device type name

### DIFF
--- a/src/runtime/opencl/opencl_common.h
+++ b/src/runtime/opencl/opencl_common.h
@@ -108,6 +108,8 @@ class OpenCLThreadEntry;
  */
 class OpenCLWorkspace : public DeviceAPI {
  public:
+  // type key
+  std::string type_key;
   // global platform id
   cl_platform_id platform_id;
   // global platform name
@@ -138,9 +140,10 @@ class OpenCLWorkspace : public DeviceAPI {
     }
   }
   // Initialzie the device.
-  void Init(const std::string& device_type, const std::string& platform_name = "");
+  void Init(const std::string& type_key, const std::string& device_type,
+            const std::string& platform_name = "");
   virtual void Init() {
-    Init("gpu");
+    Init("opencl", "gpu");
   }
   // Check whether the context is OpenCL or not.
   virtual bool IsOpenCLDevice(TVMContext ctx) {
@@ -240,7 +243,7 @@ class OpenCLModuleNode : public ModuleNode {
    */
   virtual const std::shared_ptr<cl::OpenCLWorkspace>& GetGlobalWorkspace();
 
-  virtual const char* type_key() const;
+  const char* type_key() const final { return workspace_->type_key.c_str(); }
 
   PackedFunc GetFunction(
       const std::string& name,

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -227,7 +227,8 @@ bool MatchPlatformInfo(
   return param_value.find(value) != std::string::npos;
 }
 
-void OpenCLWorkspace::Init(const std::string& device_type, const std::string& platform_name) {
+void OpenCLWorkspace::Init(const std::string& type_key, const std::string& device_type,
+                           const std::string& platform_name) {
   if (initialized_) return;
   std::lock_guard<std::mutex> lock(this->mu);
   if (initialized_) return;
@@ -246,6 +247,7 @@ void OpenCLWorkspace::Init(const std::string& device_type, const std::string& pl
     }
     std::vector<cl_device_id> devices_matched = cl::GetDeviceIDs(platform_id, device_type);
     if (devices_matched.size() > 0) {
+      this->type_key = type_key;
       this->platform_id = platform_id;
       this->platform_name = cl::GetPlatformInfo(platform_id, CL_PLATFORM_NAME);
       this->device_type = device_type;
@@ -271,7 +273,7 @@ void OpenCLWorkspace::Init(const std::string& device_type, const std::string& pl
     this->queues.push_back(
         clCreateCommandQueue(this->context, did, 0, &err_code));
     OPENCL_CHECK_ERROR(err_code);
-    LOG(INFO) << "opencl(" << i
+    LOG(INFO) << type_key << "(" << i
               << ")=\'" << cl::GetDeviceInfo(did, CL_DEVICE_NAME)
               << "\' cl_device_id=" << did;
   }

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -100,10 +100,6 @@ const std::shared_ptr<cl::OpenCLWorkspace>& OpenCLModuleNode::GetGlobalWorkspace
   return cl::OpenCLWorkspace::Global();
 }
 
-const char* OpenCLModuleNode::type_key() const {
-  return "opencl";
-}
-
 PackedFunc OpenCLModuleNode::GetFunction(
     const std::string& name,
     const std::shared_ptr<ModuleNode>& sptr_to_self) {

--- a/src/runtime/opencl/sdaccel/sdaccel_device_api.cc
+++ b/src/runtime/opencl/sdaccel/sdaccel_device_api.cc
@@ -23,7 +23,7 @@ const std::shared_ptr<OpenCLWorkspace>& SDAccelWorkspace::Global() {
 }
 
 void SDAccelWorkspace::Init() {
-  OpenCLWorkspace::Init("accelerator", "Xilinx");
+  OpenCLWorkspace::Init("sdaccel", "accelerator", "Xilinx");
 }
 
 bool SDAccelWorkspace::IsOpenCLDevice(TVMContext ctx) {

--- a/src/runtime/opencl/sdaccel/sdaccel_module.cc
+++ b/src/runtime/opencl/sdaccel/sdaccel_module.cc
@@ -21,15 +21,10 @@ class SDAccelModuleNode : public OpenCLModuleNode {
                              std::string source)
       : OpenCLModuleNode(data, fmt, fmap, source) {}
   const std::shared_ptr<cl::OpenCLWorkspace>& GetGlobalWorkspace() final;
-  const char* type_key() const final;
 };
 
 const std::shared_ptr<cl::OpenCLWorkspace>& SDAccelModuleNode::GetGlobalWorkspace() {
   return cl::SDAccelWorkspace::Global();
-}
-
-const char* SDAccelModuleNode::type_key() const {
-  return "sdaccel";
 }
 
 Module SDAccelModuleCreate(


### PR DESCRIPTION
Show the correct OpenCL device type name in the output log.  For example, we get the below output when we run TVM on AWS F1, but `opencl(n)` should be `sdaccel(n)` here. 
```
$ python -m nose -vs tests/python/integration/test_ewise_fpga.py
test_ewise_fpga.test_exp ... [18:02:00] /home/centos/src/project_data/tvm/src/runtime/opencl/opencl_device_api.cc:255: Initialize OpenCL platform 'Xilinx'
[18:02:00] /home/centos/src/project_data/tvm/src/runtime/opencl/opencl_device_api.cc:276: opencl(0)='xilinx_aws-vu9p-f1_dynamic_5_0' cl_device_id=0x1c77c30
[18:02:00] /home/centos/src/project_data/tvm/src/runtime/opencl/opencl_device_api.cc:276: opencl(1)='xilinx_aws-vu9p-f1_dynamic_5_0' cl_device_id=0x1c73fc0
[18:02:00] /home/centos/src/project_data/tvm/src/runtime/opencl/opencl_device_api.cc:276: opencl(2)='xilinx_aws-vu9p-f1_dynamic_5_0' cl_device_id=0x1c76c30
[18:02:00] /home/centos/src/project_data/tvm/src/runtime/opencl/opencl_device_api.cc:276: opencl(3)='xilinx_aws-vu9p-f1_dynamic_5_0' cl_device_id=0x1c756f0

...
```