### PR TITLE
[BUILD] restrict runtime include headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,11 +48,8 @@ tvm_option(USE_RANDOM "Build with random support" OFF)
 
 # include directories
 include_directories("include")
-include_directories("nnvm/include")
-include_directories("dmlc-core/include")
-include_directories("HalideIR/src")
 include_directories("dlpack/include")
-include_directories("topi/include")
+include_directories("dmlc-core/include")
 
 # initial variables
 set(TVM_LINKER_LIBS "")
@@ -168,6 +165,17 @@ target_link_libraries(tvm ${TVM_LINKER_LIBS} ${TVM_RUNTIME_LINKER_LIBS})
 target_link_libraries(tvm_topi tvm ${TVM_LINKER_LIBS} ${TVM_RUNTIME_LINKER_LIBS})
 target_link_libraries(tvm_runtime ${TVM_RUNTIME_LINKER_LIBS})
 target_link_libraries(nnvm_compiler tvm)
+
+# Related headers
+target_include_directories(
+  tvm
+  PUBLIC "HalideIR/src")
+target_include_directories(
+  nnvm_compiler
+  PUBLIC "nnvm/include")
+target_include_directories(
+  tvm_topi
+  PUBLIC "topi/include")
 
 # Tests
 set(TEST_EXECS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,8 @@ target_link_libraries(nnvm_compiler tvm)
 # Related headers
 target_include_directories(
   tvm
-  PUBLIC "HalideIR/src")
+  PUBLIC "HalideIR/src"
+  PUBLIC "topi/include")
 target_include_directories(
   tvm_topi
   PUBLIC "topi/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,10 +171,11 @@ target_include_directories(
   tvm
   PUBLIC "HalideIR/src")
 target_include_directories(
-  nnvm_compiler
-  PUBLIC "nnvm/include")
-target_include_directories(
   tvm_topi
+  PUBLIC "topi/include")
+target_include_directories(
+  nnvm_compiler
+  PUBLIC "nnvm/include"
   PUBLIC "topi/include")
 
 # Tests

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifndef DLPACK_PATH
   DLPACK_PATH = $(ROOTDIR)/dlpack
 endif
 
-INCLUDE_FLAGS = -Iinclude -I$(DLPACK_PATH)/include -I$(DMLC_CORE_PATH)/include -IHalideIR/src -Itopi/include
+INCLUDE_FLAGS = -Iinclude -I$(DLPACK_PATH)/include -I$(DMLC_CORE_PATH)/include
 PKG_CFLAGS = -std=c++11 -Wall -O2 $(INCLUDE_FLAGS) -fPIC
 PKG_LDFLAGS =
 

--- a/apps/howto_deploy/Makefile
+++ b/apps/howto_deploy/Makefile
@@ -8,7 +8,7 @@ PKG_CFLAGS = -std=c++11 -O2 -fPIC\
 	-I${DMLC_CORE}/include\
 	-I${TVM_ROOT}/dlpack/include\
 
-PKG_LDFLAGS = -L${TVM_ROOT}/lib -ldl -lpthread
+PKG_LDFLAGS = -L${TVM_ROOT}/build -ldl -lpthread
 
 .PHONY: clean all
 


### PR DESCRIPTION
To prevent non-runtime headers from being added to runtime.