### PR TITLE
[DOCS][SDACCEL] Update AWS F1 deployment

### DIFF
--- a/docs/deploy/aws_fpga.md
+++ b/docs/deploy/aws_fpga.md
@@ -116,7 +116,6 @@ export XCL_TARGET=hw
 
 python build.py
 ```
-The result shows CL_INVALID_PROGRAM error.  It is because AWS SDAccel expects awsxclbin binary, but we pass xclbin instead of it.  We don't load FPGA image here, so simply ignore the error for now.
 
 - Create AWS FPGA image and upload it to AWS S3.
 ```


### PR DESCRIPTION
The SDAccel runtime doesn't create a program at the compile time now (#1408).  We don't get CL_INVALID_PROGRAM error anymore on synthesis.