### PR TITLE
Fix runtime error on osx

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -104,10 +104,11 @@ setup_kwargs = {}
 
 # For bdist_wheel only
 if wheel_include_libs:
-    for path in LIB_LIST:
-        shutil.copy(path, os.path.join(CURRENT_DIR, 'tvm'))
-        _, libname = os.path.split(path)
-        fo.write("include tvm/%s\n" % libname)
+    with open("MANIFEST.in", "w") as fo:
+        for path in LIB_LIST:
+            shutil.copy(path, os.path.join(CURRENT_DIR, 'tvm'))
+            _, libname = os.path.split(path)
+            fo.write("include tvm/%s\n" % libname)
     setup_kwargs = {
         "include_package_data": True
     }
@@ -118,7 +119,7 @@ if include_libs:
         LIB_LIST[i] = os.path.relpath(path, curr_path)
     setup_kwargs = {
         "include_package_data": True,
-        "package_data": {'tvm': LIB_LIST}
+        "data_files": [('tvm', LIB_LIST)]
     }
 
 setup(name='tvm',


### PR DESCRIPTION
I get following error when run a tvm sample code on osx after build `master` and install it by `python setup.py install`. I'm not sure, but fixed my error by changing `"package_data": {'tvm': LIB_LIST}` to `"data_files": [('tvm', LIB_LIST)]`. 
@abergeron  @tqchen Could you review this?

## Error message

```
$ python tvm_sample.py
Traceback (most recent call last):
  File "/Users/tatsuya/misc/nnvm/samples/tvm_concat.py", line 2, in <module>
    import topi
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/topi-0.4.0-py3.6.egg/topi/__init__.py", line 12, in <module>
    from tvm._ffi.libinfo import __version__
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/__init__.py", line 5, in <module>
    from . import tensor
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/tensor.py", line 4, in <module>
    from ._ffi.node import NodeBase, NodeGeneric, register_node, convert_to_node
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/_ffi/node.py", line 8, in <module>
    from .node_generic import NodeGeneric, convert_to_node, const
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/_ffi/node_generic.py", line 7, in <module>
    from .base import string_types
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/_ffi/base.py", line 43, in <module>
    _LIB, _LIB_NAME = _load_lib()
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/_ffi/base.py", line 34, in _load_lib
    lib_path = libinfo.find_lib_path()
  File "/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/_ffi/libinfo.py", line 93, in find_lib_path
    raise RuntimeError(message)
RuntimeError: Cannot find the files.
List of candidates:
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/libtvm.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/build/libtvm.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/build/Release/libtvm.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/lib/libtvm.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/libtvm.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/tvm-0.4.0-py3.6-macosx-10.13-x86_64.egg/tvm/libtvm_runtime.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/build/libtvm_runtime.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/build/Release/libtvm_runtime.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/site-packages/lib/libtvm_runtime.dylib
/Users/tatsuya/venv/nnvm-dev/lib/python3.6/libtvm_runtime.dylib
```