### PR TITLE
Fix conda 2

### DIFF
--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -12,12 +12,15 @@ build:
 
 requirements:
   build:
+    - {{ compiler('cxx') }}  # [linux]
+    - llvmdev ==6.0.0  # [osx]
+  host:
     # The OS X build will require some manual setup or it will break
     # See https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html#macos-sdk
-    - {{ compiler('cxx') }}
+    # It is also ass-backward because of llvm brokeness when mixed with the
+    # conda OS X compiler
+    - {{ compiler('cxx') }}  # [osx]
     - cmake
-  host:
-    - llvmdev ==6.0.0
     - zlib  # [linux]
 
 about:

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -11,13 +11,14 @@ build:
   number: 0
 
 requirements:
-  host:
+  build:
     # The OS X build will require some manual setup or it will break
     # See https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html#macos-sdk
     - {{ compiler('cxx') }}
-  build:
-    - llvmdev ==6.0.0
     - cmake
+  host:
+    - llvmdev ==6.0.0
+    - zlib  # [linux]
 
 about:
   home: https://github.com/dmlc/tvm

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     # conda OS X compiler
     - {{ compiler('cxx') }}  # [osx]
     - cmake
+    - llvmdev ==6.0.0  # [linux]
     - zlib  # [linux]
 
 about:


### PR DESCRIPTION
This is a quick follow-up to my previous conda packages PR which fixes some things in the libs recipe I discovered trying to install packages from one machine on another. 

It should make the packages truly compatible will all conda supported platforms.

It is super ugly because of a weird interaction between conda compiler and llvm packages on OS X, but I'm trying to report that bug upstream.
