### PR TITLE
[BUILD] warning fix: new does not have an alignment parameter    

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 project(tvm C CXX)
+
 # Utility functions
 include(cmake/util/Util.cmake)
 include(cmake/util/FindCUDA.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ else(MSVC)
   check_cxx_compiler_flag("-std=c++11"    SUPPORT_CXX11)
   set(CMAKE_C_FLAGS "-O2 -Wall -fPIC ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++11 ${CMAKE_CXX_FLAGS}")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+    set(CMAKE_CXX_FLAGS "-faligned-new ${CMAKE_CXX_FLAGS}")
+  endif()
 endif(MSVC)
 
 # add source group

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
 project(tvm C CXX)
-
 # Utility functions
 include(cmake/util/Util.cmake)
 include(cmake/util/FindCUDA.cmake)
@@ -78,7 +77,8 @@ else(MSVC)
   check_cxx_compiler_flag("-std=c++11"    SUPPORT_CXX11)
   set(CMAKE_C_FLAGS "-O2 -Wall -fPIC ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "-O2 -Wall -fPIC -std=c++11 ${CMAKE_CXX_FLAGS}")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND
+      CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
     set(CMAKE_CXX_FLAGS "-faligned-new ${CMAKE_CXX_FLAGS}")
   endif()
 endif(MSVC)


### PR DESCRIPTION
The below warning is shown with environment GCC 7.2 and -std=c++11

`This PR will fix the below warnings
tvm/vta/src/sim/sim_driver.cc: In constructor _vta::sim::DRAM::Page::Page(size_t, size_t)_:
tvm/vta/src/sim/sim_driver.cc:196:33: warning: _new_ of type _vta::sim::DRAM::Page::DType {aka std::aligned_storage<4096, 256>
	::type}_ with extended alignment 256 [-Waligned-new=]                                   
		   data = new DType[num_pages];                                                     
									 ^                                                       
tvm/vta/src/sim/sim_driver.cc:196:33: note: uses _void* operator new [](std::size_t)_, which does not have an alignment parameter    
tvm/vta/src/sim/sim_driver.cc:196:33: note: use _-faligned-new_ to enable C++17 over-aligned new support
tvm/vta/src/sim/sim_driver.cc: In instantiation of _vta::sim::SRAM<kBits, kLane, kMaxNumElem>::SRAM() [with int kBits = 8; int
	kLane = 256; int kMaxNumElem = 1024]_:                                                 
tvm/vta/src/sim/sim_driver.cc:345:12:   required from here
tvm/vta/src/sim/sim_driver.cc:226:13: warning: _new_ of type _vta::sim::SRAM<8, 256, 1024>::DType {aka std::aligned_storage<25
	6, 256>::type}_ with extended alignment 256 [-Waligned-new=]                            
		 data_ = new DType[kMaxNumElem];                                                    
				 ^~~~~~~~~~~~~~~~~~~~~~                                                     
tvm/vta/src/sim/sim_driver.cc:226:13: note: uses _void* operator new [](std::size_t)_, which does not have an alignment parameter    
tvm/vta/src/sim/sim_driver.cc:226:13: note: use _-faligned-new_ to enable C++17 over-aligned new support
tvm/vta/src/sim/sim_driver.cc: In instantiation of _vta::sim::SRAM<kBits, kLane, kMaxNumElem>::SRAM() [with int kBits = 32; in
	t kLane = 16; int kMaxNumElem = 2048]_:                                                 
tvm/vta/src/sim/sim_driver.cc:345:12:   required from here
tvm/vta/src/sim/sim_driver.cc:226:13: warning: _new_ of type _vta::sim::SRAM<32, 16, 2048>::DType {aka std::aligned_storage<64
	, 64>::type}_ with extended alignment 64 [-Waligned-new=]                                 
tvm/vta/src/sim/sim_driver.cc:226:13: note: uses _void* operator new [](std::size_t)_, which does not have an alignment parameter    
tvm/vta/src/sim/sim_driver.cc:226:13: note: use _-faligned-new_ to enable C++17 over-aligned new support`

This PR will avoid the issue
Reference: https://github.com/google/flatbuffers/pull/4621/files