### PR TITLE
[VTA] Timing closure fix

### DIFF
--- a/vta/config/vta_config.json
+++ b/vta/config/vta_config.json
@@ -1,7 +1,7 @@
 {
   "TARGET" : "sim",
   "HW_FREQ" : 100,
-  "HW_CLK_TARGET" : 8,
+  "HW_CLK_TARGET" : 7,
   "HW_VER" : "0.0.0",
   "LOG_INP_WIDTH" : 3,
   "LOG_WGT_WIDTH" : 3,


### PR DESCRIPTION
This change is a one-liner (or shall I say a one-characterer)

Refers to this issue: https://discuss.tvm.ai/t/timing-violation-for-vta-hardware-implementation/508/5

Lowered clock period target for more aggressive pipelining and close timing for default config.

No noticeable degradation on performance, e2e resnet-18 inference still at 0.4s.