### PR TITLE
[RPC] perfom full rpc tracker handshake in jvm

### DIFF
--- a/jvm/core/src/main/java/ml/dmlc/tvm/rpc/ConnectTrackerServerProcessor.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/rpc/ConnectTrackerServerProcessor.java
@@ -201,6 +201,12 @@ public class ConnectTrackerServerProcessor implements ServerProcessor {
     if (trackerMagic != RPC.RPC_TRACKER_MAGIC) {
       throw new SocketException("failed to connect to tracker (WRONG MAGIC)");
     }
+    String infoJSON = generateCinfo(key);
+    Utils.sendString(trackerOut, infoJSON);
+    int recvCode = Integer.parseInt(Utils.recvString(trackerIn));
+    if (recvCode != RPC.TrackerCode.SUCCESS) {
+      throw new SocketException("failed to connect to tracker (not SUCCESS)");
+    }
     return trackerSocket;
   }
 
@@ -236,6 +242,12 @@ public class ConnectTrackerServerProcessor implements ServerProcessor {
       return true;
     }
     return false;
+  }
+
+  // handcrafted JSON
+  private String generateCinfo(String key) {
+    String cinfo = "{\"key\" : " + "\"server:" + key + "\"}";
+    return "[" + RPC.TrackerCode.UPDATE_INFO + ", " + cinfo + "]";
   }
 
   // handcrafted JSON

--- a/jvm/core/src/main/java/ml/dmlc/tvm/rpc/RPC.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/rpc/RPC.java
@@ -32,6 +32,7 @@ public class RPC {
 
   public class TrackerCode {
     public static final int PUT = 3;
+    public static final int UPDATE_INFO = 5;
     public static final int GET_PENDING_MATCHKEYS = 7;
     public static final int SUCCESS = 0;
   }


### PR DESCRIPTION
Previously the jvm implementation of RPC did not fully register a device so that an [IP_ADDRESS]:[KEY] pairing would show up when doing a `query_rpc_tracker`. This PR adds the handshake component that sends this JSON to the tracker.