### PR TITLE
[NNVM][TEST] Test against numerical grad

### DIFF
--- a/docs/api/python/nnvm/index.rst
+++ b/docs/api/python/nnvm/index.rst
@@ -11,3 +11,4 @@ This document contains the python API to NNVM compiler toolchain.
    symbol
    graph
    top
+   testing

--- a/docs/api/python/nnvm/testing.rst
+++ b/docs/api/python/nnvm/testing.rst
@@ -1,0 +1,14 @@
+nnvm.testing
+------------
+
+.. automodule:: nnvm.testing
+
+.. autofunction:: nnvm.testing.ctx_list
+
+nnvm.testing.check_computation
+------------------------------
+
+.. automodule:: nnvm.testing.check_computation
+    :members:
+
+.. include:: testing_new_ops.rst

--- a/docs/api/python/nnvm/testing_new_ops.rst
+++ b/docs/api/python/nnvm/testing_new_ops.rst
@@ -1,7 +1,7 @@
 Testing new operations
 ----------------------
 
-When adding new operations, it it a good idea to test them. Testing
+When adding new operations, it is a good idea to test them. Testing
 should be done with the function ``nnvm.testing.check_function``. You
 should provide it with the symbol representing the result of a
 computation and a reference numpy implementation. By default, it will

--- a/docs/api/python/nnvm/testing_new_ops.rst
+++ b/docs/api/python/nnvm/testing_new_ops.rst
@@ -1,0 +1,135 @@
+Testing new operations
+----------------------
+
+When adding new operations, it it a good idea to test them. Testing
+should be done with the function ``nnvm.testing.check_function``. You
+should provide it with the symbol representing the result of a
+computation and a reference numpy implementation. By default, it will
+also check analytical gradients against numerical gradients if
+analytical gradients are implemented for your operation. You can also
+pass a reference implementation for the gradients, but numerical
+gradients will still be checked. Numerical gradient checking may be
+switched off explicitly, but doing this is not a good idea generally.
+Here is an example testing the logarithm operation:
+
+.. code:: python
+
+    import numpy as np
+    import nnvm
+    import nnvm.symbol as sym
+    from nnvm.testing.check_computation import check_function
+
+    x = sym.Variable("x")
+    y = sym.log(x)
+
+    def forward(x):
+        return np.log(x)
+
+    def backward(head_grads, x):
+        return [1. / x * head_grads]
+
+    dtype = "float32"
+    shape = {'x': (1, 3, 32, 32)}
+    check_function(y, forward, backward, in_range=(0.001, 2.0), dtype=dtype, shape=shape)
+
+If you run the code above, you might get an ``AssertionError`` in rare
+cases. That’s why it is recommended to run new tests a lot of times.
+
+.. code:: python
+
+    for _ in range(10000):
+        check_function(y, forward, backward, in_range=(0.001, 2.0), dtype=dtype, shape=shape)
+
+If you run the code above then sooner or later you will get an exception
+which may look like this:
+
+.. code-block:: text
+
+    AssertionError: Analytical and numerical grads wrt x differ too much
+    analytical grad = [
+            ...
+        ]
+    numerical grad = [
+            ...
+        ]
+    distance > atol*sqrt(n) + rtol*grad_norm
+    distance 308.50885009765625 > 0.01*55.42562584220407 + 0.1*2167.70703125
+
+It means that either you have a mistake in the ``FGradient`` function or
+the numerical error is too high. Generally, if you look at the printed
+gradients and see that they differ only slightly or just in a single
+position, then it is a numerical error. But if the gradients look
+completely different, especially if many corresponding positions have
+different signs, then it must be something wrong with the analytical
+gradient implementation.
+
+Then try to make this error reproducible, and also try to reduce the
+shape of inputs, but not too much, a vector of 10 elements is a
+reasonable choice. Also you won’t need reference functions ``forward``
+and ``backward``, and restricting the number of targets might also be a
+good idea. Since the error may manifest itself only in rare cases, you
+might want to run it in a loop.
+
+.. code:: python
+
+    shape = {'x': (10,)}
+    np.random.seed(42)
+
+    for _ in range(1000):
+        check_function(y, in_range=(0.001, 2.0), dtype=dtype, shape=shape,
+                       numerical_grads=True, only_targets=['llvm'])
+
+Running this code will result in the following:
+
+.. code-block:: text
+
+    check_function failed while checking gradients numerically, here is the main graph
+    Graph(%x, %head_grads_0) {
+      %x, shape=[10], dtype=0
+      %head_grads_0, shape=[10], dtype=0
+      %1 = log(%x), shape=[10], dtype=0
+      %3 = elemwise_div(%head_grads_0, %x), shape=[10], dtype=0
+      ret %1, %3, %head_grads_0
+    }
+    graph_attr_keys = [layout_inputs, dtype_num_unknown_nodes, dtype, shape_num_unknown_nodes, shape]
+
+    Generated inputs:
+    {'x': array([2.5660574e-01, 1.5313280e+00, 1.0232578e-03, 8.3371508e-01,
+           1.0454979e+00, 1.1021420e-01, 1.9461832e+00, 4.5302454e-01,
+           6.0909325e-01, 6.0858107e-01], dtype=float32), 'head_grads_0': array([0.4616029 , 0.00394617, 1.4589603 , 1.9337242 , 0.44936267,
+           1.3264314 , 1.4840508 , 1.6970023 , 0.84583575, 0.60655886],
+          dtype=float32)}
+
+    ...
+
+    AssertionError: Analytical and numerical grads wrt x differ too much
+    analytical grad = [1.7988799e+00 2.5769596e-03 1.4257993e+03 2.3194065e+00 4.2980734e-01
+     1.2035031e+01 7.6254421e-01 3.7459390e+00 1.3886802e+00 9.9667716e-01]
+     numerical grad = [1.7948151e+00 1.9073486e-03 9.9268610e+02 2.3174286e+00 4.2915344e-01
+     1.1980057e+01 7.6198578e-01 3.7412643e+00 1.3866425e+00 9.9563599e-01]
+    distance > atol*sqrt(n) + rtol*grad_norm
+    distance 433.11322021484375 > 0.01*3.1622776601683795 + 0.1*992.7716674804688
+
+In this case the largest difference is in the 2nd position (starting
+from 0) which corresponds to input value ``1.0232578e-03``. This value
+is too close to the singularity, so the numerical derivative gets too
+imprecise. The solution is to shrink the range for ``x``, here, for
+example, ``(0.002, 2.0)`` turned out to be enough. Don’t forget to run
+lots of tests, so that other people don’t get false positives.
+
+.. code:: python
+
+    for _ in range(100):
+        check_function(y, in_range={x: (0.002, 2.0)}, dtype=dtype, shape=(1, 3, 32, 32),
+                       numerical_grads=True, only_targets=['llvm'])
+
+If you need a more precise control over which values get passed to the
+checking function, you can use ``values={x: ...}``:
+
+.. code:: python
+
+    x_val = np.array([1.2594858e+00, 1.0960974e-01, 1.4975418e+00, 6.3585603e-01,
+           1.2692513e-03, 1.0227472e+00, 9.4656967e-02, 5.5306298e-01,
+           1.4142460e+00, 1.2631655e-01], dtype=np.float32)
+    check_function(y, values={x: x_val}, dtype=dtype, shape=shape,
+                   numerical_grads=True, only_targets=['llvm'])

--- a/nnvm/python/nnvm/testing/__init__.py
+++ b/nnvm/python/nnvm/testing/__init__.py
@@ -12,3 +12,4 @@ from . import inception_v3
 from . import dcgan
 from . import dqn
 from . import yolo2_detection
+from . import check_computation

--- a/nnvm/python/nnvm/testing/check_computation.py
+++ b/nnvm/python/nnvm/testing/check_computation.py
@@ -163,6 +163,26 @@ def check_function(symbol, forward=None, backward=None, grad_input_vars=None,
 
     quiet : bool, optional
         Don't dump additional information to stdout on failure.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        x = sym.Variable("x", shape=(1, 2))
+        y = sym.Variable("y", shape=(1, 2))
+
+        # check the function and its gradients both numerically and using a reference function
+        check_function(x + 2*y,
+                       lambda x, y: x + 2*y,
+                       lambda x, y, head_grads: {'x': head_grads, 'y': 2*head_grads},
+                       dtype='float32')
+
+        # just check gradients numerically
+        check_function(x + 2*y, dtype='float32', numerical_grads=True)
+
+        # just check the forward computation
+        check_function(x + 2*y, lambda x, y: x + 2*y,
+                       dtype='float32', numerical_grads=False)
     """
     if numerical_grads is None and forward is None and backward is None:
         raise ValueError("No reference function was passed to check_function. If you only want to "
@@ -410,6 +430,10 @@ def check_numerical_grads(function, input_values, grad_values, function_value=No
     """A helper function that checks that numerical gradients of a function are equal to
     gradients computed in some different way (analytical gradients).
 
+    Numerical gradients are computed using finite difference approximation. To reduce the number of
+    function evaluations, the number of points used is gradually increased if the error value is
+    too high (up to 5 points).
+
     Parameters
     ----------
     function
@@ -427,7 +451,8 @@ def check_numerical_grads(function, input_values, grad_values, function_value=No
         Should be equal to `function(**input_values)`.
 
     delta : float, optional
-        A small number used for numerical computation of partial derivatives.
+        A small number used for numerical computation of partial derivatives. The default 1e-3 is a
+        good choice for float32.
 
     atol : float, optional
         Absolute tolerance.

--- a/nnvm/python/nnvm/testing/check_computation.py
+++ b/nnvm/python/nnvm/testing/check_computation.py
@@ -1,0 +1,380 @@
+# pylint: disable=cell-var-from-loop
+"""Helper utilities to check functions and their gradients."""
+from __future__ import absolute_import as _abs
+
+import logging
+import numpy as np
+
+import tvm
+from tvm.contrib import graph_runtime
+
+import nnvm
+from nnvm.compiler import graph_util
+from nnvm.compiler.graph_attr import TCODE_TO_DTYPE
+from .config import ctx_list
+
+def graph_to_function(graph, target, ctx):
+    """Convert a graph to a function taking a keyword args and returning a list of results
+    (both args and results are numpy arrays).
+
+    Example::
+
+        fun = graph_to_function(graph, llvm, cpu(0))
+        [res1, res2] = fun(x=np.zeros((1,2)), y=np.zeros((1,)))
+
+    Parameters
+    ----------
+    graph : nnvm.graph.Graph
+        A graph we want to convert to a function.
+
+    target : str or :any:`tvm.target.Target`, optional
+        The build target
+
+    ctx : TVMContext
+        The context to deploy the module.
+
+    Returns
+    -------
+    function : Callable[..., List[numpy.ndarray]]
+    """
+
+    shapes = graph.json_attr('shape')
+    dtypes = graph.json_attr('dtype')
+
+    if shapes is None or dtypes is None:
+        graph = graph.apply('InferShape').apply('InferType')
+        shapes = graph.json_attr('shape')
+        dtypes = graph.json_attr('dtype')
+
+    dtypes = [TCODE_TO_DTYPE[dtype] for dtype in dtypes]
+
+    ishapes = {x: shapes[graph.index.entry_id(x)] for x in graph.index.input_names}
+    idtypes = {x: dtypes[graph.index.entry_id(x)] for x in graph.index.input_names}
+
+    compute_graph, lib, _ = nnvm.compiler.build(graph, target, shape=ishapes, dtype=idtypes)
+    module = graph_runtime.create(compute_graph, lib, ctx)
+
+    shapes = compute_graph.json_attr('shape')
+    dtypes = [TCODE_TO_DTYPE[dtype] for dtype in compute_graph.json_attr('dtype')]
+
+    def run(**kwargs):
+        module.run(**kwargs)
+        res = []
+        for i, out_entry in enumerate(compute_graph.index.output_entries):
+            res.append(
+                module.get_output(
+                    i, tvm.nd.empty(shapes[out_entry[0]], dtypes[out_entry[0]])).asnumpy())
+        return res
+
+    return run
+
+
+def check_function(symbol, grad_input_vars=None, np_forward=None, np_backward=None,
+                   shape=None, dtype=None, in_range=None,
+                   numerical_grads='if_possible', delta=1e-2,
+                   atol=1e-5, rtol=1e-5, ng_atol=1e-2, ng_rtol=1e-2,
+                   dump_graph=False):
+    """Compute the function and/or its gradients on a random input and raise
+    an exception if the result doesn't match the reference implementation.
+
+    Parameters
+    ----------
+    symbol : nnvm.Symbol
+        A symbol representing the output.
+
+    grad_input_vars : List[nnvm.Symbol or str or (str, Tuple[int])], optional
+        A list of variables with respect to which the gradients will be computed.
+        None (default) means that all input variables will be used. May be a
+        list of pairs `(var_name, shape)`.
+
+    np_forward : Callable[..., List[numpy.ndarray]], optional
+        A reference implementation to compare with.
+
+    np_backward : Callable[..., List[numpy.ndarray]], optional
+        A reference implementation of gradients. Should also accept head_grads besides
+        normal inputs. Should return gradients with respect to variables from grad_input_vars in
+        exactly the same order.
+
+    shape : Dict[str, Tuple], optional
+        A dict mapping input variable names to shapes.
+        By default shapes will be inferred automatically.
+
+    dtype : Dict[str, str] or str, optional
+        A dict mapping input variable names to dtypes, or just a single dtype.
+        By default dtypes will be inferred automatically.
+
+    in_range : Dict[str, (float, float)] or (float, float), optional
+        A dict mapping input variable names to ranges or just a single range
+        (the same for all variables). Input values will be generated from
+        uniform distributions on these ranges. `head_grads` can also be
+        assigned a range this way.
+
+    numerical_grads : bool or "if_possible"
+        Whether to additionally check against numerically computed gradients. If 'if_possible' is
+        passed (which is the default) then it will try to create a gradient computation graph and
+        then check gradients numerically only if this graph can be created (i.e. if there are some
+        operations with unimplemented gradients, it will just issue a warning).
+
+    delta : float
+        A small value used for numerical gradient computation (usually called h in textbooks).
+
+    atol : float
+        Absolute tolerance.
+
+    rtol : float
+        Relative tolerance.
+
+    ng_atol : float
+        Absolute tolerance for numerical grad checking.
+
+    ng_rtol : float
+        Relative tolerance for numerical grad checking.
+
+    dump_graph : bool
+        Dump the graph even on success.
+    """
+
+    if numerical_grads not in [False, True, 'if_possible']:
+        raise ValueError("numerical_grads must be a bool or 'if_possible', not {}"
+                         .format(numerical_grads))
+
+    input_vars = [x for x in symbol.list_input_variables()]
+    input_dict = {x.attr('name'): x for x in input_vars}
+
+    if grad_input_vars is None:
+        grad_input_vars = input_vars
+
+    shape = shape.copy() if shape else {}
+
+    grad_input_vars_real = []
+    for x in grad_input_vars:
+        if isinstance(x, tuple):
+            if len(x) != 2:
+                raise ValueError("Expected (var_name, shape), not {}".format(x))
+            shape[x[0] if isinstance(x[0], str) else x[0].attr('name')] = x[1]
+            x = x[0]
+
+        grad_input_vars_real.append(input_dict[x] if isinstance(x, str) else x)
+
+    grad_input_vars = grad_input_vars_real
+
+    # Infer the output shape and dtype by creating a graph and running passes
+
+    forward_graph = nnvm.graph.create(symbol)
+
+    if dtype is not None:
+        nnvm.compiler.graph_attr.set_dtype_inputs(forward_graph, dtype)
+
+    if shape is not None:
+        nnvm.compiler.graph_attr.set_shape_inputs(forward_graph, shape)
+
+    forward_graph = forward_graph.apply('InferShape').apply('InferType')
+    shapes = forward_graph.json_attr('shape')
+    dtypes = forward_graph.json_attr('dtype')
+    out_shape = shapes[forward_graph.index.output_entries[0][0]]
+    out_dtype = dtypes[forward_graph.index.output_entries[0][0]]
+
+    backward_graph = None
+
+    # If we want gradients, we have to recreate the graph, but now with gradient computations
+    # Note that here we need out_shape for defining the shape of head grads, so we have to
+    # create the graph twice
+    if np_backward is not None or numerical_grads:
+        try:
+            head_grads_symbol = nnvm.symbol.Variable("head_grads", shape=out_shape, dtype=out_dtype)
+            grad_symbols = graph_util.gradients([symbol], grad_input_vars,
+                                                grad_ys=head_grads_symbol)
+            # Sometimes grads do not depend on head_grads, so head_grads does not appear
+            # in the variable list; adding it manually prevents this, making things a bit easier
+            backward_graph = \
+                nnvm.graph.create(nnvm.symbol.Group([symbol] + grad_symbols + [head_grads_symbol]))
+
+            if dtype is not None:
+                nnvm.compiler.graph_attr.set_dtype_inputs(backward_graph, dtype)
+
+            if shape is not None:
+                nnvm.compiler.graph_attr.set_shape_inputs(backward_graph, shape)
+
+            backward_graph = backward_graph.apply('InferShape').apply('InferType')
+            shapes = backward_graph.json_attr('shape')
+            dtypes = backward_graph.json_attr('dtype')
+        except nnvm._base.NNVMError as err:
+            if np_backward is None and numerical_grads == "if_possible":
+                logging.warning("Won't check gradients because: %s", str(err).split('\n', 1)[0])
+                numerical_grads = False
+                backward_graph = None
+            else:
+                raise
+
+    main_graph = backward_graph if backward_graph is not None else forward_graph
+
+    if dump_graph:
+        print()
+        print(main_graph.ir(join_node_attrs=['shape', 'dtype']))
+
+    # Generate random data for inputs (including head_grads)
+
+    np_inputs = {}
+
+    for x in main_graph.symbol.list_input_variables():
+        x_name = x.attr('name')
+
+        low = -1.0
+        high = 1.0
+        if in_range is not None:
+            if isinstance(in_range, dict):
+                if x_name in in_range:
+                    low = in_range[x_name][0]
+                    high = in_range[x_name][1]
+            else:
+                low = in_range[0]
+                high = in_range[1]
+
+        x_node_id = main_graph.index.node_id(x_name)
+        x_shape = shapes[x_node_id]
+        x_dtype = dtypes[x_node_id]
+
+        if not isinstance(x_dtype, str):
+            x_dtype = TCODE_TO_DTYPE[x_dtype]
+
+        x_value = np.random.uniform(size=x_shape, low=low, high=high).astype(x_dtype)
+
+        np_inputs[x_name] = x_value
+
+    np_inputs_without_head_grads = {k: np_inputs[k] for k in np_inputs if k != 'head_grads'}
+
+    # Compute and compare the results
+    for target, ctx in ctx_list():
+        try:
+            nnvm_res = None
+            main_function = graph_to_function(main_graph, target, ctx)
+            # nnvm_res contains the output and gradients (if they are needed)
+            nnvm_res = main_function(**np_inputs)
+
+            if np_forward is not None:
+                numpy_res = np_forward(**np_inputs_without_head_grads)
+                np.testing.assert_allclose(nnvm_res[0], numpy_res, atol=atol, rtol=rtol)
+
+            if np_backward is not None:
+                numpy_grads = np_backward(**np_inputs)
+                for i, np_grad in enumerate(numpy_grads):
+                    np.testing.assert_allclose(nnvm_res[i + 1], np_grad, atol=atol, rtol=rtol)
+
+            if numerical_grads:
+                forward_function = graph_to_function(forward_graph, target, ctx)
+
+                # Since the result may be non-scalar, we have to put another operation on the top,
+                # so we just multiple by the randomly generated head_grads.
+                # This way we can reuse the gradient values which has been already computed.
+                def function(**kwargs):
+                    res = forward_function(**kwargs)[0]
+                    return np.dot(np_inputs['head_grads'].ravel(), res.ravel())
+
+                function_value = np.dot(np_inputs['head_grads'].ravel(), nnvm_res[0].ravel())
+                grad_var_names = [x.attr('name') for x in grad_input_vars]
+                grad_values = {x: v for x, v in zip(grad_var_names, nnvm_res[1:])}
+
+                check_numerical_grads(
+                    function,
+                    grad_input_vars=grad_var_names,
+                    input_values=np_inputs_without_head_grads,
+                    function_value=function_value,
+                    grad_values=grad_values,
+                    delta=delta, atol=ng_atol, rtol=ng_rtol)
+
+        except:
+            print("\ncheck_function failed, here is the main graph")
+            print(main_graph.ir(join_node_attrs=['shape', 'dtype']))
+            if nnvm_res is not None:
+                print("Generated inputs:")
+                print(np_inputs)
+                print()
+            raise
+
+
+def check_numerical_grads(function, grad_input_vars, input_values, grad_values,
+                          function_value=None, delta=1e-3, atol=1e-2, rtol=1e-2):
+    """A helper function that checks that numerical gradients of a function are equal to
+    gradients computed in some different way.
+
+    We compute two approximations for each gradient using forward and backward differences.
+    Then we use the distance between these gradients as our estimate for the error and check if the
+    provided symbolic gradient lies within this distance from the central difference approximation
+    of the gradient.
+
+    Parameters
+    ----------
+    function
+        A function that takes inputs as keyword arguments (like `function(**input_values)`) and
+        returns a scalar result. Should accept and return numpy arrays.
+
+    grad_input_vars : List[str]
+        A list of variables with respect to which the gradients will be computed.
+
+    input_values : Dict[str, numpy.ndarray]
+        A dict assigning values to variables. Represents the point at which gradients should be
+        computed.
+
+    grad_values : Dict[str, numpy.ndarray]
+        Gradients computed using a different method.
+
+    function_value : float, optional
+        Should be equal to `function(**input_values)`.
+
+    delta : float
+        A small number used for numerical computation of partial derivatives.
+
+    atol : float
+        Absolute tolerance.
+
+    rtol : float
+        Relative tolerance.
+    """
+
+    if function_value is None:
+        function_value = function(**input_values)
+
+    # a helper to modify j-th element of val by a_delta
+    def modify(val, j, a_delta):
+        val = val.copy()
+        val.reshape(-1)[j] = val.reshape(-1)[j] + a_delta
+        return val
+
+    # numerically compute a partial derivative with respect to j-th element of the var `name`
+    def derivative(x_name, j, a_delta):
+        modified_values = {n: modify(val, j, a_delta) if n == x_name else val
+                           for n, val in input_values.items()}
+        return (function(**modified_values) - function_value)/a_delta
+
+    for x_name in grad_input_vars:
+        grad = grad_values[x_name]
+
+        if grad.shape != input_values[x_name].shape:
+            raise AssertionError(
+                "Gradient wrt '{}' has unexpected shape {}, expected {} "
+                .format(x.attr('name'), grad.shape, input_values[x_name].shape))
+
+        ngrad1 = np.zeros_like(grad)
+        ngrad2 = np.zeros_like(grad)
+
+        # compute partial derivatives for each position in this variable
+        for j in range(np.prod(grad.shape)):
+            ngrad1.reshape(-1)[j] = derivative(x_name, j, delta)
+            ngrad2.reshape(-1)[j] = derivative(x_name, j, -delta)
+
+        ngrad = (ngrad1 + ngrad2)/2
+        dist_1_2 = np.linalg.norm(ngrad1 - ngrad2)
+        dist_n_s = np.linalg.norm(ngrad - grad)
+
+        if dist_n_s > dist_1_2 + atol + np.linalg.norm(ngrad)*rtol:
+            raise AssertionError(
+                "Sym and num grads wrt {} differ too much\n"
+                "sym grad = {}\n num grad = {}\ndistance {} > {} + {} + {}*{}"
+                .format(x_name, grad, ngrad,
+                        dist_n_s, dist_1_2, atol, np.linalg.norm(ngrad), rtol))
+
+        max_diff = np.max(np.abs(ngrad - grad))
+        avg_diff = np.mean(np.abs(ngrad - grad))
+        logging.info("Numerical grad test wrt %s of shape %s passes, "
+                     "dist = %f, max_diff = %f, avg_diff = %f",
+                     x_name, grad.shape, dist_n_s, max_diff, avg_diff)

--- a/nnvm/python/nnvm/testing/check_computation.py
+++ b/nnvm/python/nnvm/testing/check_computation.py
@@ -1,4 +1,4 @@
-# pylint: disable=cell-var-from-loop
+# pylint: disable=cell-var-from-loop,no-else-return
 """Helper utilities to check functions and their gradients."""
 from __future__ import absolute_import as _abs
 

--- a/nnvm/python/nnvm/testing/check_computation.py
+++ b/nnvm/python/nnvm/testing/check_computation.py
@@ -251,6 +251,12 @@ def check_function(symbol, forward=None, backward=None, grad_input_vars=None,
     out_shapes = [shapes[forward_graph.index.output_entries[i][0]] for i in range(out_len)]
     out_dtypes = [dtypes[forward_graph.index.output_entries[i][0]] for i in range(out_len)]
 
+    if not all(out_shapes) or -1 in out_dtypes:
+        if not quiet:
+            print(forward_graph.ir(join_node_attrs=['shape', 'dtype']))
+        raise ValueError("Could not infer shapes or dtypes for outputs.\n"
+                         "out_shapes = {}\nout_dtypes = {}".format(out_shapes, out_dtypes))
+
     backward_graph = None
 
     # If we want gradients, we have to recreate the graph, but now with gradient computations

--- a/nnvm/python/nnvm/testing/check_computation.py
+++ b/nnvm/python/nnvm/testing/check_computation.py
@@ -97,10 +97,12 @@ def infer_shapes_dtypes(graph, shape=None, dtype=None, fallback_dtype=None):
 
     out_len = len(graph.symbol.list_output_names())
 
+    index = graph.index
+
     output_shapes = \
-        [tuple(shapes[graph.index.output_entries[i][0]]) for i in range(out_len)]
+        [tuple(shapes[index.entry_id(index.output_entries[i])]) for i in range(out_len)]
     output_dtypes = \
-        [TCODE_TO_DTYPE[dtypes[graph.index.output_entries[i][0]]] for i in range(out_len)]
+        [TCODE_TO_DTYPE[dtypes[index.entry_id(index.output_entries[i])]] for i in range(out_len)]
 
     # Postprocess the results
     input_shapes = shape.copy()
@@ -435,6 +437,7 @@ def check_function(symbol, forward=None, backward=None, grad_input_vars=None,
             main_function = graph_to_function(main_graph, target, ctx)
 
             # nnvm_res contains the output and gradients (if they are needed)
+            debug_stage = "running"
             nnvm_res = main_function(**np_inputs)
 
             if backward_graph is not None:

--- a/nnvm/python/nnvm/testing/check_computation.py
+++ b/nnvm/python/nnvm/testing/check_computation.py
@@ -94,7 +94,7 @@ def _dict_var_to_dict_str(dictionary):
 def check_function(symbol, forward=None, backward=None, grad_input_vars=None,
                    shape=None, dtype=None, in_range=None,
                    exclude_targets=None, only_targets=None,
-                   numerical_grads='if_possible', numerical_grads_params=None,
+                   numerical_grads=None, numerical_grads_params=None,
                    atol=1e-5, rtol=1e-5, quiet=False):
     """Compute the function and/or its gradients on a random input and raise
     an exception if the result doesn't match the reference implementation.
@@ -139,11 +139,11 @@ def check_function(symbol, forward=None, backward=None, grad_input_vars=None,
     only_targets : Set[str], optional
         Test only for those targets from `ctx_list()` that are also in this set.
 
-    numerical_grads : bool or "if_possible", optional
-        Whether to additionally check against numerically computed gradients. If 'if_possible' is
-        passed (which is the default) then it will try to create a gradient computation graph and
-        then check gradients numerically only if this graph can be created (i.e. if there are some
-        operations with unimplemented gradients, it will just issue a warning).
+    numerical_grads : bool or 'if_possible', optional
+        Whether to additionally check against numerically computed gradients. If 'if_possible' or
+        None is passed (which is the default) then it will try to create a gradient computation
+        graph and then check gradients numerically only if this graph can be created (i.e. if there
+        are some operations with unimplemented gradients, it will just issue a warning).
 
     numerical_grads_params : dict, optional
         Additional parameters for `check_numerical_grads`.
@@ -157,6 +157,12 @@ def check_function(symbol, forward=None, backward=None, grad_input_vars=None,
     quiet : bool, optional
         Don't dump additional information to stdout on failure.
     """
+    if numerical_grads is None and forward is None and backward is None:
+        raise ValueError("No reference function was passed to check_function. If you only want to "
+                         "check gradients numerically, pass numerical_grads=True explicitly.")
+
+    if numerical_grads is None:
+        numerical_grads = 'if_possible'
 
     if numerical_grads not in [False, True, 'if_possible']:
         raise ValueError("numerical_grads must be a bool or 'if_possible', not {}"

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -218,7 +218,9 @@ def test_dense():
         (w, (3, 100)),
         (b, (3,))
     ]
-    check_function(y, inputs, forward, dtype=dtype)
+    # Don't check gradients on cuda because is doesn't yet support ewise after reduce
+    check_function(y, inputs, forward, dtype=dtype, exclude_targets={'cuda'}, numerical_grads=True)
+    check_function(y, inputs, forward, dtype=dtype, only_targets={'cuda'}, numerical_grads=False)
 
 
 def test_batchnorm():

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -41,6 +41,8 @@ def test_check_function():
 
     # test just numerical gradients
     # different styles of shape and dtype passing
+    check_function(x + 2*y, shape={'x': (1, 2), y: (1, 2)},
+                   numerical_grads=True)
     check_function(x + 2*y, shape={'x': (1, 2), y: (1, 2)}, dtype='float32',
                    numerical_grads=True)
     check_function(x + 2*y, shape={'x': (1, 2), y: (1, 2)}, dtype={x: 'float32', 'y': 'float32'},
@@ -149,13 +151,16 @@ def test_check_function():
     y = sym.dense(data=x, bias=b, weight=w, units=4)
     def _fwd_dense(x, w, b):
         return np.dot(x, w.T) + b
-    _check_function_must_fail(y, _fwd_dense, error=ValueError)
     check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'x': 'float32'}, numerical_grads=False)
     check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'w': 'float64'}, numerical_grads=False)
     _check_function_must_fail(y, _fwd_dense, shape={'x': (1,2)},
                               dtype={'w': 'float64', 'b': 'float32'},
                               numerical_grads=False,
                               error=nnvm._base.NNVMError)
+    # fails because no shape
+    _check_function_must_fail(y, _fwd_dense, error=ValueError)
+    # ok because type is float32 by default
+    check_function(y, _fwd_dense, shape={'x': (1,2)})
 
 def test_relu():
     x = sym.Variable("x")

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -116,6 +116,15 @@ def test_check_function():
     z = sym.Group([2*x + y, x + 2*y, x, y, sym.sum(x)])
     check_function(z, lambda x, y: [2*x + y, x + 2*y, x, y, np.sum(x)])
 
+    # passing additional parameters to forward and backward
+    def _fwd3(x, p):
+        assert p == 'v'
+        return x + 1
+    def _bwd3(x, p, head_grads):
+        assert p == 'v'
+        return head_grads
+    check_function(x + 1, _fwd3, _bwd3, additional_params={'p': 'v'})
+
 def test_relu():
     x = sym.Variable("x")
     y = sym.relu(sym.leaky_relu(x, alpha=0.3) - 0.2)

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -176,9 +176,11 @@ def test_softmax():
         return [grad]
 
     dtype = "float32"
-    dshape = (10, 1000)
-    inputs = [(x, dshape)]
-    check_function(y, inputs, forward, backward, dtype=dtype)
+    inputs = [x]
+    check_function(y, inputs, forward, backward,
+                   shape={'x': (10, 1000)}, dtype=dtype, numerical_grads=False)
+    check_function(y, inputs, forward, backward,
+                   shape={'x': (2, 10)}, dtype=dtype)
 
 
 def test_log_softmax():
@@ -194,9 +196,11 @@ def test_log_softmax():
         return [grad]
 
     dtype = "float32"
-    dshape = (10, 1000)
-    inputs = [(x, dshape)]
-    check_function(y, inputs, forward, backward, dtype=dtype)
+    inputs = [x]
+    check_function(y, inputs, forward, backward,
+                   shape={'x': (10, 1000)}, dtype=dtype, numerical_grads=False)
+    check_function(y, inputs, forward, backward,
+                   shape={'x': (2, 10)}, dtype=dtype)
 
 
 def test_dense():

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -149,7 +149,7 @@ def test_check_function():
     y = sym.dense(data=x, bias=b, weight=w, units=4)
     def _fwd_dense(x, w, b):
         return np.dot(x, w.T) + b
-    #check_function(y, _fwd_dense) # TODO: Segfault
+    _check_function_must_fail(y, _fwd_dense, error=ValueError)
     check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'x': 'float32'}, numerical_grads=False)
     check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'w': 'float64'}, numerical_grads=False)
     _check_function_must_fail(y, _fwd_dense, shape={'x': (1,2)},

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -67,6 +67,9 @@ def test_check_function():
     check_function(x + 2*y, _fwd2, shape=(100,), in_range={'x': (0.8, 0.9)}, numerical_grads=False)
     check_function(x + 2*y, backward=lambda x, y, head_grads: [1.0, 2.0],
                    in_range={'head_grads_0': (1.0, 1.0)})
+    # explicit passing of values
+    check_function(x + 2*y, backward=lambda x, y, head_grads: [1.0, 2.0],
+                   values={'head_grads_0': np.full((1, 2), 1.0)})
 
     # check that the function reports errors
     def _check_function_must_fail(*args, **kwargs):
@@ -225,7 +228,7 @@ def test_log():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, in_range=(0.001, 2.0), dtype=dtype, shape=shape)
+    check_function(y, forward, backward, in_range=(0.002, 2.0), dtype=dtype, shape=shape)
 
 
 def test_tanh():

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -22,8 +22,7 @@ def test_relu():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 def test_prelu_nchw():
     x = sym.Variable("x")
@@ -35,8 +34,7 @@ def test_prelu_nchw():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32), 'a': (3,)}
-    inputs = [x, a]
-    check_function(y, inputs, forward, dtype=dtype, shape=shape)
+    check_function(y, forward, dtype=dtype, shape=shape)
 
 def test_prelu_nhwc():
     x = sym.Variable("x")
@@ -48,8 +46,7 @@ def test_prelu_nhwc():
 
     dtype = "float32"
     shape = {'x': (1, 32, 32, 3), 'a': (3,)}
-    inputs = [x, a]
-    check_function(y, inputs, forward, dtype=dtype, shape=shape)
+    check_function(y, forward, dtype=dtype, shape=shape)
 
 def test_sym_scalar_pow():
     scalar = 3
@@ -64,8 +61,7 @@ def test_sym_scalar_pow():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_scalar_sym_pow():
@@ -81,8 +77,7 @@ def test_scalar_sym_pow():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_exp():
@@ -97,8 +92,7 @@ def test_exp():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_log():
@@ -113,8 +107,7 @@ def test_log():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, in_range=(0.001, 2.0), dtype=dtype, shape=shape)
+    check_function(y, forward, backward, in_range=(0.001, 2.0), dtype=dtype, shape=shape)
 
 
 def test_tanh():
@@ -130,8 +123,7 @@ def test_tanh():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_sigmoid():
@@ -147,8 +139,7 @@ def test_sigmoid():
 
     dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_softmax():
@@ -164,10 +155,9 @@ def test_softmax():
         return [grad]
 
     dtype = "float32"
-    inputs = [x]
-    check_function(y, inputs, forward, backward,
+    check_function(y, forward, backward,
                    shape={'x': (10, 1000)}, dtype=dtype, numerical_grads=False)
-    check_function(y, inputs, forward, backward,
+    check_function(y, forward, backward,
                    shape={'x': (2, 10)}, dtype=dtype)
 
 
@@ -184,10 +174,9 @@ def test_log_softmax():
         return [grad]
 
     dtype = "float32"
-    inputs = [x]
-    check_function(y, inputs, forward, backward,
+    check_function(y, forward, backward,
                    shape={'x': (10, 1000)}, dtype=dtype, numerical_grads=False)
-    check_function(y, inputs, forward, backward,
+    check_function(y, forward, backward,
                    shape={'x': (2, 10)}, dtype=dtype)
 
 
@@ -206,11 +195,10 @@ def test_dense():
         'w': (3, 100),
         'b': (3,)
     }
-    inputs = [x, w, b]
     # Don't check gradients on cuda because is doesn't yet support ewise after reduce
-    check_function(y, inputs, forward, dtype=dtype, shape=shape,
+    check_function(y, forward, dtype=dtype, shape=shape,
                    exclude_targets={'cuda'}, numerical_grads=True)
-    check_function(y, inputs, forward, dtype=dtype, shape=shape,
+    check_function(y, forward, dtype=dtype, shape=shape,
                    only_targets={'cuda'}, numerical_grads=False)
 
 
@@ -235,9 +223,8 @@ def test_batchnorm():
         'moving_mean': (20,),
         'moving_var': (20,)
     }
-    inputs = [x, gamma, beta, moving_mean, moving_var]
 
-    check_function(y, inputs, forward, in_range=(0.001, 1.0), dtype=dtype, shape=shape)
+    check_function(y, forward, in_range=(0.001, 1.0), dtype=dtype, shape=shape)
 
 
 def verify_concatenate(ishape, axis):
@@ -370,8 +357,7 @@ def verify_squeeze(shape, axis):
         return [np.reshape(head_grads, x.shape)]
 
     dtype = "float32"
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_squeeze():
@@ -391,8 +377,7 @@ def test_pad():
 
     dtype = "float32"
     shape = {'x': (1, 3, 28, 28)}
-    inputs = [x]
-    check_function(y, inputs, forward, dtype=dtype, shape=shape)
+    check_function(y, forward, dtype=dtype, shape=shape)
 
 def verify_lrn(ishape, size, axis, bias, alpha, beta):
     x = sym.Variable("x")

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -88,6 +88,8 @@ def test_check_function():
     _check_function_must_fail(x + 2*y, lambda x, y: x + y)
     _check_function_must_fail(x + 2*y, backward=lambda x, y, head_grads: [1.0, 2.0])
     _check_function_must_fail(sym.block_grad(x + 2*y), numerical_grads=True)
+    _check_function_must_fail(x*x, numerical_grads=True,
+                              numerical_grads_params={'atol': 0.0, 'rtol': 0.0})
 
     # different styles of returning results from the forward function
     check_function(x + 2*y, lambda x, y: [x + 2*y], numerical_grads=False)

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -158,9 +158,9 @@ def test_check_function():
                               numerical_grads=False,
                               error=nnvm._base.NNVMError)
     # fails because no shape
-    _check_function_must_fail(y, _fwd_dense, error=ValueError)
+    _check_function_must_fail(y, _fwd_dense, numerical_grads=False, error=ValueError)
     # ok because type is float32 by default
-    check_function(y, _fwd_dense, shape={'x': (1,2)})
+    check_function(y, _fwd_dense, shape={'x': (1,2)}, numerical_grads=False)
 
 def test_relu():
     x = sym.Variable("x")

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -150,10 +150,11 @@ def test_check_function():
     def _fwd_dense(x, w, b):
         return np.dot(x, w.T) + b
     #check_function(y, _fwd_dense) # TODO: Segfault
-    check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'x': 'float32'})
-    check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'w': 'float64'})
+    check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'x': 'float32'}, numerical_grads=False)
+    check_function(y, _fwd_dense, shape={'x': (1,2)}, dtype={'w': 'float64'}, numerical_grads=False)
     _check_function_must_fail(y, _fwd_dense, shape={'x': (1,2)},
                               dtype={'w': 'float64', 'b': 'float32'},
+                              numerical_grads=False,
                               error=nnvm._base.NNVMError)
 
 def test_relu():

--- a/nnvm/tests/python/compiler/test_top_level1.py
+++ b/nnvm/tests/python/compiler/test_top_level1.py
@@ -175,9 +175,8 @@ def test_relu():
         return [(sub > 0).astype("float") * \
                 ((x > 0).astype("float") + 0.3 * (x < 0).astype("float")) * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 def test_prelu_nchw():
     x = sym.Variable("x")
@@ -187,9 +186,8 @@ def test_prelu_nchw():
     def forward(x, a):
         return (x < 0) * (x * a.reshape(3, 1, 1)) + (x>=0) * x
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32), 'a': (3,)}
-    check_function(y, forward, dtype=dtype, shape=shape)
+    check_function(y, forward, shape=shape)
 
 def test_prelu_nhwc():
     x = sym.Variable("x")
@@ -199,9 +197,8 @@ def test_prelu_nhwc():
     def forward(x, a):
         return (x < 0) * (x * a.reshape(1, 1, 3)) + (x>=0) * x
 
-    dtype = "float32"
     shape = {'x': (1, 32, 32, 3), 'a': (3,)}
-    check_function(y, forward, dtype=dtype, shape=shape)
+    check_function(y, forward, shape=shape)
 
 def test_sym_scalar_pow():
     scalar = 3
@@ -214,9 +211,8 @@ def test_sym_scalar_pow():
     def backward(head_grads, x):
         return [scalar * x**(scalar -  1) * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_scalar_sym_pow():
@@ -230,9 +226,8 @@ def test_scalar_sym_pow():
     def backward(head_grads, x):
         return [np.log(scalar) * scalar**x * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_exp():
@@ -245,9 +240,8 @@ def test_exp():
     def backward(head_grads, x):
         return [np.exp(x) * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_log():
@@ -260,9 +254,8 @@ def test_log():
     def backward(head_grads, x):
         return [1. / x * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, in_range=(0.002, 2.0), dtype=dtype, shape=shape)
+    check_function(y, forward, backward, in_range=(0.002, 2.0), shape=shape)
 
 
 def test_tanh():
@@ -276,9 +269,8 @@ def test_tanh():
         y_np = forward(x)
         return [(1 - y_np**2) * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_sigmoid():
@@ -292,9 +284,8 @@ def test_sigmoid():
         y_np = forward(x)
         return [y_np *(1 - y_np) * head_grads]
 
-    dtype = "float32"
     shape = {'x': (1, 3, 32, 32)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_softmax():
@@ -309,11 +300,10 @@ def test_softmax():
         grad = y * (head_grads - np.sum(y * head_grads, axis=1, keepdims=True))
         return [grad]
 
-    dtype = "float32"
     check_function(y, forward, backward,
-                   shape={'x': (10, 1000)}, dtype=dtype, numerical_grads=False)
+                   shape={'x': (10, 1000)}, numerical_grads=False)
     check_function(y, forward, backward,
-                   shape={'x': (2, 10)}, dtype=dtype)
+                   shape={'x': (2, 10)})
 
 
 def test_log_softmax():
@@ -328,11 +318,10 @@ def test_log_softmax():
         grad = head_grads - np.exp(y) * np.sum(head_grads, axis=1, keepdims=True)
         return [grad]
 
-    dtype = "float32"
     check_function(y, forward, backward,
-                   shape={'x': (10, 1000)}, dtype=dtype, numerical_grads=False)
+                   shape={'x': (10, 1000)}, numerical_grads=False)
     check_function(y, forward, backward,
-                   shape={'x': (2, 10)}, dtype=dtype)
+                   shape={'x': (2, 10)})
 
 
 def test_dense():
@@ -344,16 +333,15 @@ def test_dense():
 
     def forward(x, dense_weight, dense_bias):
         return np.dot(x, dense_weight.T) + dense_bias
-    dtype = "float32"
     shape = {
         'x': (10, 100),
         'w': (3, 100),
         'b': (3,)
     }
     # Don't check gradients on cuda because is doesn't yet support ewise after reduce
-    check_function(y, forward, dtype=dtype, shape=shape,
+    check_function(y, forward, shape=shape,
                    exclude_targets={'cuda'}, numerical_grads=True)
-    check_function(y, forward, dtype=dtype, shape=shape,
+    check_function(y, forward, shape=shape,
                    only_targets={'cuda'}, numerical_grads=False)
 
 
@@ -370,7 +358,6 @@ def test_batchnorm():
     def forward(x, gamma, beta, moving_mean, moving_var):
         return (x - moving_mean) / np.sqrt(moving_var + eps) * gamma + beta
 
-    dtype = "float32"
     shape = {
         'x': (10, 20),
         'gamma': (20,),
@@ -379,7 +366,7 @@ def test_batchnorm():
         'moving_var': (20,)
     }
 
-    check_function(y, forward, in_range=(0.001, 1.0), dtype=dtype, shape=shape)
+    check_function(y, forward, in_range=(0.001, 1.0), shape=shape)
 
 
 def verify_concatenate(ishape, axis):
@@ -511,8 +498,7 @@ def verify_squeeze(shape, axis):
     def backward(head_grads, x):
         return [np.reshape(head_grads, x.shape)]
 
-    dtype = "float32"
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_squeeze():
@@ -530,9 +516,8 @@ def test_pad():
                       pad_width=((0, 0), (0, 0), (0, 1), (2, 3)),
                       mode='constant', constant_values=1.)
 
-    dtype = "float32"
     shape = {'x': (1, 3, 28, 28)}
-    check_function(y, forward, dtype=dtype, shape=shape)
+    check_function(y, forward, shape=shape)
 
 def verify_lrn(ishape, size, axis, bias, alpha, beta):
     x = sym.Variable("x")

--- a/nnvm/tests/python/compiler/test_top_level3.py
+++ b/nnvm/tests/python/compiler/test_top_level3.py
@@ -5,15 +5,15 @@ import topi.testing
 import nnvm.symbol as sym
 import nnvm.compiler
 from nnvm.testing.config import ctx_list
-from test_top_level1 import helper
+from nnvm.testing.check_computation import check_function
 
 def check_map(symfunc, np_func, np_backward=None, dtype="float32", rnd_min=-1, rnd_max=1):
     x = sym.Variable("x")
     y = symfunc(x)
     dshape = (1, 3, 32, 32)
-    inputs = [('x', dshape, x)]
-    helper(y, inputs, dtype, lambda x: np_func(x), np_backward,
-           rnd_min=rnd_min, rnd_max=rnd_max)
+    inputs = [('x', dshape)]
+    check_function(y, inputs, lambda x: np_func(x), np_backward,
+                   dtype=dtype, in_range=(rnd_min, rnd_max))
 
 
 def test_floor():

--- a/nnvm/tests/python/compiler/test_top_level3.py
+++ b/nnvm/tests/python/compiler/test_top_level3.py
@@ -10,10 +10,10 @@ from nnvm.testing.check_computation import check_function
 def check_map(symfunc, np_func, np_backward=None, dtype="float32", rnd_min=-1, rnd_max=1):
     x = sym.Variable("x")
     y = symfunc(x)
-    dshape = (1, 3, 32, 32)
-    inputs = [('x', dshape)]
+    shape = {'x': (1, 3, 32, 32)}
+    inputs = [x]
     check_function(y, inputs, lambda x: np_func(x), np_backward,
-                   dtype=dtype, in_range=(rnd_min, rnd_max))
+                   dtype=dtype, shape=shape, in_range=(rnd_min, rnd_max))
 
 
 def test_floor():

--- a/nnvm/tests/python/compiler/test_top_level3.py
+++ b/nnvm/tests/python/compiler/test_top_level3.py
@@ -11,8 +11,7 @@ def check_map(symfunc, np_func, np_backward=None, dtype="float32", rnd_min=-1, r
     x = sym.Variable("x")
     y = symfunc(x)
     shape = {'x': (1, 3, 32, 32)}
-    inputs = [x]
-    check_function(y, inputs, lambda x: np_func(x), np_backward,
+    check_function(y, lambda x: np_func(x), np_backward,
                    dtype=dtype, shape=shape, in_range=(rnd_min, rnd_max))
 
 

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -225,7 +225,10 @@ def test_broadcast():
         da = head_grads / b
         db = _collapse(- head_grads * a / b**2)
         return da, db
-    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype)
+    # We avoid computing numerical derivatives too close to zero here
+    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype, numerical_grads=False)
+    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype,
+                   in_range={'b': (0.1, 20)})
 
     y = sym.broadcast_mod(a, b)
     check_function(y, inputs,

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -183,17 +183,14 @@ def test_clip():
         mask2 = np.less_equal(x, a_max).astype("float")
         return [head_grads * mask1 * mask2]
 
-
-    dtype = "float32"
     shape = {'x': (3, 4, 5)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_broadcast():
     a = sym.Variable("a")
     b = sym.Variable("b")
     shape = {'a': (3, 4, 5), 'b': (1, 5)}
-    dtype = "float32"
 
     def _collapse(g):
         return g.reshape(-1, shape['b'][-1]).sum(0, keepdims=True)
@@ -203,21 +200,21 @@ def test_broadcast():
         da = head_grads
         db = _collapse(head_grads)
         return da, db
-    check_function(y, lambda a, b: a + b, _backward_add, dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: a + b, _backward_add, shape=shape)
 
     y = sym.broadcast_sub(a, b)
     def _backward_sub(head_grads, a, b):
         da = head_grads
         db = -_collapse(head_grads)
         return da, db
-    check_function(y, lambda a, b: a - b, _backward_sub, dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: a - b, _backward_sub, shape=shape)
 
     y = sym.broadcast_mul(a, b)
     def _backward_mul(head_grads, a, b):
         da = head_grads * b
         db = _collapse(head_grads * a)
         return da, db
-    check_function(y, lambda a, b: a * b, _backward_mul, dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: a * b, _backward_mul, shape=shape)
 
     y = sym.broadcast_div(a, b)
     def _backward_div(head_grads, a, b):
@@ -225,8 +222,8 @@ def test_broadcast():
         db = _collapse(- head_grads * a / b**2)
         return da, db
     # We avoid computing numerical derivatives too close to zero here
-    check_function(y, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape, numerical_grads=False)
-    check_function(y, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape,
+    check_function(y, lambda a, b: a / b, _backward_div, shape=shape, numerical_grads=False)
+    check_function(y, lambda a, b: a / b, _backward_div, shape=shape,
                    in_range={'b': (0.1, 20)})
 
     y = sym.broadcast_mod(a, b)
@@ -235,15 +232,15 @@ def test_broadcast():
                    in_range={'a': (0.001, 100), 'b': (1, 100)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_max(a, b)
-    check_function(y, lambda a, b: np.maximum(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.maximum(a, b), shape=shape)
 
     y = sym.broadcast_min(a, b)
-    check_function(y, lambda a, b: np.minimum(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.minimum(a, b), shape=shape)
 
     y = sym.broadcast_pow(a, b)
     check_function(y,
                    lambda a, b: np.power(a, b),
-                   in_range={'a': (0.001, 100), 'b': (0.001, 2)}, dtype=dtype, shape=shape)
+                   in_range={'a': (0.001, 100), 'b': (0.001, 2)}, shape=shape)
 
     y = sym.broadcast_left_shift(a, b)
     check_function(y, lambda a, b: a << b, dtype='int32', shape=shape)
@@ -252,10 +249,10 @@ def test_broadcast():
     check_function(y, lambda a, b: a >> b, dtype='int32', shape=shape)
 
     y = sym.broadcast_greater(a, b)
-    check_function(y, lambda a, b: np.greater(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.greater(a, b), shape=shape)
 
     y = sym.broadcast_less(a, b)
-    check_function(y, lambda a, b: np.less(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.less(a, b), shape=shape)
 
     y = sym.broadcast_equal(a, b)
     check_function(y, lambda a, b: np.equal(a, b),
@@ -284,10 +281,8 @@ def test_greater():
     def backward(head_grads, l, r):
         return {'l': np.zeros_like(l)}
 
-
-    dtype = "float32"
     shape = {'l': (3, 4, 5), 'r': (3, 4, 5)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_less():
@@ -301,10 +296,8 @@ def test_less():
     def backward(head_grads, l, r):
         return {'l': np.zeros_like(l)}
 
-
-    dtype = "float32"
     shape = {'l': (3, 4, 5), 'r': (3, 4, 5)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_reshape_like():
@@ -319,10 +312,8 @@ def test_reshape_like():
         return [np.reshape(head_grads, x.shape),
                 np.zeros_like(y)]
 
-
-    dtype = "float32"
     shape = {'x': (3, 4, 5), 'y': (5, 4, 3)}
-    check_function(z, forward, backward, dtype=dtype, shape=shape)
+    check_function(z, forward, backward, shape=shape)
 
 
 def verify_expand_like(in_shape, out_shape, axis, exclude):
@@ -366,9 +357,8 @@ def verify_expand_like(in_shape, out_shape, axis, exclude):
                 np.zeros_like(y)]
 
 
-    dtype = "float32"
     shape = {'x': in_shape, 'y': out_shape}
-    check_function(z, forward, backward, dtype=dtype, shape=shape)
+    check_function(z, forward, backward, shape=shape)
 
 
 def test_expand_like():
@@ -393,9 +383,8 @@ def verify_elemwise_sum(num_args):
     def backward(head_grads, **inputs):
         return [head_grads] * num_args
 
-    dtype = "float32"
     shape = {s[i]: (3, 4, 5) for i in range(num_args)}
-    check_function(y, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, shape=shape)
 
 
 def test_elemwise_sum():
@@ -415,10 +404,9 @@ def test_block_grad():
         return [np.zeros_like(head_grads)]
 
 
-    dtype = "float32"
     shape = {'x': (3, 4, 5)}
     # Numerical grad checking would fail for this function
-    check_function(y, forward, backward, dtype=dtype, shape=shape, numerical_grads=False)
+    check_function(y, forward, backward, shape=shape, numerical_grads=False)
 
 
 def test_full():

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -186,15 +186,13 @@ def test_clip():
 
     dtype = "float32"
     shape = {'x': (3, 4, 5)}
-    inputs = [x]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_broadcast():
     a = sym.Variable("a")
     b = sym.Variable("b")
     shape = {'a': (3, 4, 5), 'b': (1, 5)}
-    inputs = [a, b]
     dtype = "float32"
 
     def _collapse(g):
@@ -205,21 +203,21 @@ def test_broadcast():
         da = head_grads
         db = _collapse(head_grads)
         return da, db
-    check_function(y, inputs, lambda a, b: a + b, _backward_add, dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: a + b, _backward_add, dtype=dtype, shape=shape)
 
     y = sym.broadcast_sub(a, b)
     def _backward_sub(head_grads, a, b):
         da = head_grads
         db = -_collapse(head_grads)
         return da, db
-    check_function(y, inputs, lambda a, b: a - b, _backward_sub, dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: a - b, _backward_sub, dtype=dtype, shape=shape)
 
     y = sym.broadcast_mul(a, b)
     def _backward_mul(head_grads, a, b):
         da = head_grads * b
         db = _collapse(head_grads * a)
         return da, db
-    check_function(y, inputs, lambda a, b: a * b, _backward_mul, dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: a * b, _backward_mul, dtype=dtype, shape=shape)
 
     y = sym.broadcast_div(a, b)
     def _backward_div(head_grads, a, b):
@@ -227,52 +225,52 @@ def test_broadcast():
         db = _collapse(- head_grads * a / b**2)
         return da, db
     # We avoid computing numerical derivatives too close to zero here
-    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape, numerical_grads=False)
-    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape,
+    check_function(y, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape, numerical_grads=False)
+    check_function(y, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape,
                    in_range={'b': (0.1, 20)})
 
     y = sym.broadcast_mod(a, b)
-    check_function(y, inputs,
+    check_function(y,
                    lambda a, b: np.mod(a, b),
                    in_range={'a': (0.001, 100), 'b': (1, 100)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_max(a, b)
-    check_function(y, inputs, lambda a, b: np.maximum(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.maximum(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_min(a, b)
-    check_function(y, inputs, lambda a, b: np.minimum(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.minimum(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_pow(a, b)
-    check_function(y, inputs,
+    check_function(y,
                    lambda a, b: np.power(a, b),
                    in_range={'a': (0.001, 100), 'b': (0.001, 2)}, dtype=dtype, shape=shape)
 
     y = sym.broadcast_left_shift(a, b)
-    check_function(y, inputs, lambda a, b: a << b, dtype='int32', shape=shape)
+    check_function(y, lambda a, b: a << b, dtype='int32', shape=shape)
 
     y = sym.broadcast_right_shift(a, b)
-    check_function(y, inputs, lambda a, b: a >> b, dtype='int32', shape=shape)
+    check_function(y, lambda a, b: a >> b, dtype='int32', shape=shape)
 
     y = sym.broadcast_greater(a, b)
-    check_function(y, inputs, lambda a, b: np.greater(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.greater(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_less(a, b)
-    check_function(y, inputs, lambda a, b: np.less(a, b), dtype=dtype, shape=shape)
+    check_function(y, lambda a, b: np.less(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_equal(a, b)
-    check_function(y, inputs, lambda a, b: np.equal(a, b),
+    check_function(y, lambda a, b: np.equal(a, b),
                    in_range={'a': (-2, 2), 'b': (-2, 2)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_not_equal(a, b)
-    check_function(y, inputs, lambda a, b: np.not_equal(a, b),
+    check_function(y, lambda a, b: np.not_equal(a, b),
                    in_range={'a': (-2, 2), 'b': (-2, 2)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_greater_equal(a, b)
-    check_function(y, inputs, lambda a, b: np.greater_equal(a, b),
+    check_function(y, lambda a, b: np.greater_equal(a, b),
                    in_range={'a': (-3, 3), 'b': (-3, 3)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_less_equal(a, b)
-    check_function(y, inputs, lambda a, b: np.less_equal(a, b),
+    check_function(y, lambda a, b: np.less_equal(a, b),
                    in_range={'a': (-3, 3), 'b': (-3, 3)}, dtype='int32', shape=shape)
 
 def test_greater():
@@ -284,13 +282,12 @@ def test_greater():
         return np.greater(l, r).astype("float32")
 
     def backward(head_grads, l, r):
-        return [np.zeros_like(l)]
+        return {'l': np.zeros_like(l)}
 
 
     dtype = "float32"
     shape = {'l': (3, 4, 5), 'r': (3, 4, 5)}
-    inputs = [l, r]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_less():
@@ -302,13 +299,12 @@ def test_less():
         return np.less(l, r).astype("float32")
 
     def backward(head_grads, l, r):
-        return [np.zeros_like(l)]
+        return {'l': np.zeros_like(l)}
 
 
     dtype = "float32"
     shape = {'l': (3, 4, 5), 'r': (3, 4, 5)}
-    inputs = [l, r]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_reshape_like():
@@ -326,8 +322,7 @@ def test_reshape_like():
 
     dtype = "float32"
     shape = {'x': (3, 4, 5), 'y': (5, 4, 3)}
-    inputs = [x, y]
-    check_function(z, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(z, forward, backward, dtype=dtype, shape=shape)
 
 
 def verify_expand_like(in_shape, out_shape, axis, exclude):
@@ -373,8 +368,7 @@ def verify_expand_like(in_shape, out_shape, axis, exclude):
 
     dtype = "float32"
     shape = {'x': in_shape, 'y': out_shape}
-    inputs = [x, y]
-    check_function(z, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(z, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_expand_like():
@@ -401,8 +395,7 @@ def verify_elemwise_sum(num_args):
 
     dtype = "float32"
     shape = {s[i]: (3, 4, 5) for i in range(num_args)}
-    inputs = [s[i] for i in range(num_args)]
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
+    check_function(y, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_elemwise_sum():
@@ -424,9 +417,8 @@ def test_block_grad():
 
     dtype = "float32"
     shape = {'x': (3, 4, 5)}
-    inputs = [x]
     # Numerical grad checking would fail for this function
-    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape, numerical_grads=False)
+    check_function(y, forward, backward, dtype=dtype, shape=shape, numerical_grads=False)
 
 
 def test_full():

--- a/nnvm/tests/python/compiler/test_top_level4.py
+++ b/nnvm/tests/python/compiler/test_top_level4.py
@@ -185,40 +185,41 @@ def test_clip():
 
 
     dtype = "float32"
-    inputs = [(x, (3, 4, 5))]
-    check_function(y, inputs, forward, backward, dtype=dtype)
+    shape = {'x': (3, 4, 5)}
+    inputs = [x]
+    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_broadcast():
     a = sym.Variable("a")
     b = sym.Variable("b")
-    inputs = [(a, (3, 4, 5)),
-              (b, (1, 5))]
+    shape = {'a': (3, 4, 5), 'b': (1, 5)}
+    inputs = [a, b]
     dtype = "float32"
 
     def _collapse(g):
-        return g.reshape(-1, inputs[-1][1][-1]).sum(0, keepdims=True)
+        return g.reshape(-1, shape['b'][-1]).sum(0, keepdims=True)
 
     y = sym.broadcast_add(a, b)
     def _backward_add(head_grads, a, b):
         da = head_grads
         db = _collapse(head_grads)
         return da, db
-    check_function(y, inputs, lambda a, b: a + b, _backward_add, dtype=dtype)
+    check_function(y, inputs, lambda a, b: a + b, _backward_add, dtype=dtype, shape=shape)
 
     y = sym.broadcast_sub(a, b)
     def _backward_sub(head_grads, a, b):
         da = head_grads
         db = -_collapse(head_grads)
         return da, db
-    check_function(y, inputs, lambda a, b: a - b, _backward_sub, dtype=dtype)
+    check_function(y, inputs, lambda a, b: a - b, _backward_sub, dtype=dtype, shape=shape)
 
     y = sym.broadcast_mul(a, b)
     def _backward_mul(head_grads, a, b):
         da = head_grads * b
         db = _collapse(head_grads * a)
         return da, db
-    check_function(y, inputs, lambda a, b: a * b, _backward_mul, dtype=dtype)
+    check_function(y, inputs, lambda a, b: a * b, _backward_mul, dtype=dtype, shape=shape)
 
     y = sym.broadcast_div(a, b)
     def _backward_div(head_grads, a, b):
@@ -226,53 +227,53 @@ def test_broadcast():
         db = _collapse(- head_grads * a / b**2)
         return da, db
     # We avoid computing numerical derivatives too close to zero here
-    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype, numerical_grads=False)
-    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype,
+    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape, numerical_grads=False)
+    check_function(y, inputs, lambda a, b: a / b, _backward_div, dtype=dtype, shape=shape,
                    in_range={'b': (0.1, 20)})
 
     y = sym.broadcast_mod(a, b)
     check_function(y, inputs,
                    lambda a, b: np.mod(a, b),
-                   in_range={'a': (0.001, 100), 'b': (1, 100)}, dtype='int32')
+                   in_range={'a': (0.001, 100), 'b': (1, 100)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_max(a, b)
-    check_function(y, inputs, lambda a, b: np.maximum(a, b), dtype=dtype)
+    check_function(y, inputs, lambda a, b: np.maximum(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_min(a, b)
-    check_function(y, inputs, lambda a, b: np.minimum(a, b), dtype=dtype)
+    check_function(y, inputs, lambda a, b: np.minimum(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_pow(a, b)
     check_function(y, inputs,
                    lambda a, b: np.power(a, b),
-                   in_range={'a': (0.001, 100), 'b': (0.001, 2)}, dtype=dtype)
+                   in_range={'a': (0.001, 100), 'b': (0.001, 2)}, dtype=dtype, shape=shape)
 
     y = sym.broadcast_left_shift(a, b)
-    check_function(y, inputs, lambda a, b: a << b, dtype='int32')
+    check_function(y, inputs, lambda a, b: a << b, dtype='int32', shape=shape)
 
     y = sym.broadcast_right_shift(a, b)
-    check_function(y, inputs, lambda a, b: a >> b, dtype='int32')
+    check_function(y, inputs, lambda a, b: a >> b, dtype='int32', shape=shape)
 
     y = sym.broadcast_greater(a, b)
-    check_function(y, inputs, lambda a, b: np.greater(a, b), dtype=dtype)
+    check_function(y, inputs, lambda a, b: np.greater(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_less(a, b)
-    check_function(y, inputs, lambda a, b: np.less(a, b), dtype=dtype)
+    check_function(y, inputs, lambda a, b: np.less(a, b), dtype=dtype, shape=shape)
 
     y = sym.broadcast_equal(a, b)
     check_function(y, inputs, lambda a, b: np.equal(a, b),
-                   in_range={'a': (-2, 2), 'b': (-2, 2)}, dtype='int32')
+                   in_range={'a': (-2, 2), 'b': (-2, 2)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_not_equal(a, b)
     check_function(y, inputs, lambda a, b: np.not_equal(a, b),
-                   in_range={'a': (-2, 2), 'b': (-2, 2)}, dtype='int32')
+                   in_range={'a': (-2, 2), 'b': (-2, 2)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_greater_equal(a, b)
     check_function(y, inputs, lambda a, b: np.greater_equal(a, b),
-                   in_range={'a': (-3, 3), 'b': (-3, 3)}, dtype='int32')
+                   in_range={'a': (-3, 3), 'b': (-3, 3)}, dtype='int32', shape=shape)
 
     y = sym.broadcast_less_equal(a, b)
     check_function(y, inputs, lambda a, b: np.less_equal(a, b),
-                   in_range={'a': (-3, 3), 'b': (-3, 3)}, dtype='int32')
+                   in_range={'a': (-3, 3), 'b': (-3, 3)}, dtype='int32', shape=shape)
 
 def test_greater():
     l = sym.Variable("l")
@@ -287,9 +288,9 @@ def test_greater():
 
 
     dtype = "float32"
-    inputs = [(l, (3, 4, 5)),
-              (r, (3, 4, 5))]
-    check_function(y, inputs, forward, backward, dtype=dtype)
+    shape = {'l': (3, 4, 5), 'r': (3, 4, 5)}
+    inputs = [l, r]
+    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_less():
@@ -305,9 +306,9 @@ def test_less():
 
 
     dtype = "float32"
-    inputs = [(l, (3, 4, 5)),
-              (r, (3, 4, 5))]
-    check_function(y, inputs, forward, backward, dtype=dtype)
+    shape = {'l': (3, 4, 5), 'r': (3, 4, 5)}
+    inputs = [l, r]
+    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_reshape_like():
@@ -324,9 +325,9 @@ def test_reshape_like():
 
 
     dtype = "float32"
-    inputs = [(x, (3, 4, 5)),
-              (y, (5, 4, 3))]
-    check_function(z, inputs, forward, backward, dtype=dtype)
+    shape = {'x': (3, 4, 5), 'y': (5, 4, 3)}
+    inputs = [x, y]
+    check_function(z, inputs, forward, backward, dtype=dtype, shape=shape)
 
 
 def verify_expand_like(in_shape, out_shape, axis, exclude):
@@ -371,9 +372,9 @@ def verify_expand_like(in_shape, out_shape, axis, exclude):
 
 
     dtype = "float32"
-    inputs = [(x, in_shape),
-              (y, out_shape)]
-    check_function(z, inputs, forward, backward, dtype=dtype)
+    shape = {'x': in_shape, 'y': out_shape}
+    inputs = [x, y]
+    check_function(z, inputs, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_expand_like():
@@ -399,9 +400,9 @@ def verify_elemwise_sum(num_args):
         return [head_grads] * num_args
 
     dtype = "float32"
-    inputs = [(s[i], (3, 4, 5))
-              for i in range(num_args)]
-    check_function(y, inputs, forward, backward, dtype=dtype)
+    shape = {s[i]: (3, 4, 5) for i in range(num_args)}
+    inputs = [s[i] for i in range(num_args)]
+    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape)
 
 
 def test_elemwise_sum():
@@ -422,9 +423,10 @@ def test_block_grad():
 
 
     dtype = "float32"
-    inputs = [(x, (3, 4, 5))]
+    shape = {'x': (3, 4, 5)}
+    inputs = [x]
     # Numerical grad checking would fail for this function
-    check_function(y, inputs, forward, backward, dtype=dtype, numerical_grads=False)
+    check_function(y, inputs, forward, backward, dtype=dtype, shape=shape, numerical_grads=False)
 
 
 def test_full():


### PR DESCRIPTION
This PR moves the helper function checking nnvm operations against numpy reference implementations from `test_top_level#` to `nnvm.testing` and adds the ability to compare symbolic gradients to numerically computed gradients. Also this PR fixes a wrong gradient implementation for the division operation (it was found using this approach).

Currently only tests that used the old helper function are rewritten in such a way that they now use the new function. There are still many tests which didn't use the helper function, they should also be rewritten so that they use this function, if possible, but this is left for future work.