### PR TITLE
[VTA] bugfix parameter derivation

### DIFF
--- a/vta/config/vta_config.py
+++ b/vta/config/vta_config.py
@@ -86,8 +86,10 @@ def main():
     if not ok_path_list:
         raise RuntimeError("Cannot find config in %s" % str(path_list))
     cfg = json.load(open(ok_path_list[0]))
-    cfg["LOG_OUT_WIDTH"] = cfg["LOG_INP_WIDTH"]
-    cfg["LOG_OUT_BUFF_SIZE"] = cfg["LOG_ACC_BUFF_SIZE"] + cfg["LOG_ACC_WIDTH"] - cfg["LOG_OUT_WIDTH"]
+    cfg["LOG_OUT_BUFF_SIZE"] = (
+        cfg["LOG_ACC_BUFF_SIZE"] +
+        cfg["LOG_OUT_WIDTH"] -
+        cfg["LOG_ACC_WIDTH"])
     pkg = get_pkg_config(cfg)
 
     if args.target:

--- a/vta/python/vta/environment.py
+++ b/vta/python/vta/environment.py
@@ -110,7 +110,7 @@ class Environment(object):
         self.INP_WIDTH = 1 << self.LOG_INP_WIDTH
         self.WGT_WIDTH = 1 << self.LOG_WGT_WIDTH
         self.ACC_WIDTH = 1 << self.LOG_ACC_WIDTH
-        self.OUT_WIDTH = self.INP_WIDTH
+        self.OUT_WIDTH = 1 << self.LOG_OUT_WIDTH
         # tensor intrinsic shape
         self.BATCH = 1 << self.LOG_BATCH
         self.BLOCK_IN = 1 << self.LOG_BLOCK_IN


### PR DESCRIPTION
- This fixes a bug in the way we derive the size of the output buffer.
- It also derives the `OUT_WIDTH` vta environment variable from the vta_config.json `LOG_OUT_WIDTH` entry.
