### PR TITLE
Fix a testcase name in test_codegen_cuda

### DIFF
--- a/tests/python/unittest/test_codegen_cuda.py
+++ b/tests/python/unittest/test_codegen_cuda.py
@@ -91,4 +91,4 @@ def test_cuda_vectorize_load():
 if __name__ == "__main__":
     test_cuda_vectorize_add()
     test_cuda_multiply_add()
-    test_cuda_load_store()
+    test_cuda_vectorize_load()


### PR DESCRIPTION
This PR fixes calling a wrong testcase name in test_codegen_cuda.