### PR TITLE
[NNVM] Enhance operator fusion for more element wise patterns

### DIFF
--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -161,6 +161,42 @@ nnvm::Graph GraphFusePartition(nnvm::Graph g) {
       }
     }
   }
+
+  if (opt_level >= 1) {
+    std::vector<std::vector<uint32_t>> children_group_ids(idx.num_nodes());
+    std::vector<std::vector<uint32_t>> node_ids_per_group(idx.num_nodes());
+    for (uint32_t nid = idx.num_nodes() - 1; nid != 0; --nid) {
+      const auto& inode = idx[nid];
+      if (inode.source->is_variable()) continue;
+      CHECK_NE(group_vec[nid], -1);
+      node_ids_per_group[group_vec[nid]].push_back(nid);
+      if (inode.inputs.size() != 1) continue;
+      const auto& parent_nid = inode.inputs[0].node_id;
+      // if parent node has more than one child, record each child's group id.
+      if (ref_count[parent_nid] > 1) children_group_ids[parent_nid].push_back(group_vec[nid]);
+    }
+    std::vector<int> new_group_id(idx.num_nodes(), -1);
+    for (uint32_t nid = idx.num_nodes() - 1; nid != 0; --nid) {
+      if (new_group_id[group_vec[nid]] != -1) {
+        // propagate new group id from child
+        group_vec[nid] = new_group_id[group_vec[nid]];
+      }
+      const auto& group_ids = children_group_ids[nid];
+      if (group_ids.size() <= 1) continue;
+      const auto child_group_id = group_ids[0];
+      // fuse this node with children if all children belong to the same group
+      auto is_same_group_id = [child_group_id](uint32_t id) { return id == child_group_id; };
+      if (std::all_of(group_ids.begin(), group_ids.end(), is_same_group_id)) {
+        new_group_id[group_vec[nid]] = child_group_id;
+        group_vec[nid] = child_group_id;
+        for (uint32_t nid2 : node_ids_per_group[child_group_id]) {
+          pattern_vec[nid2] = pattern_vec[nid];
+          master_vec[nid2] = master_vec[nid];
+        }
+      }
+    }
+  }
+
   g.attrs["group_root"] = std::make_shared<any>(std::move(group_vec));
   g.attrs["group_master"] = std::make_shared<any>(std::move(master_vec));
   g.attrs["pattern"] = std::make_shared<any>(std::move(pattern_vec));

--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -181,6 +181,8 @@ nnvm::Graph GraphFusePartition(nnvm::Graph g) {
         // propagate new group id from child
         group_vec[nid] = new_group_id[group_vec[nid]];
       }
+      TOpPattern pt = op_pattern.get(idx[nid].source->op(), kOpaque);
+      if (pt == kOpaque) continue;
       const auto& group_ids = children_group_ids[nid];
       if (group_ids.size() <= 1) continue;
       const auto child_group_id = group_ids[0];

--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -208,8 +208,8 @@ nnvm::Graph GraphFusePartition(nnvm::Graph g) {
         propagate the new group id to a grand parent and upward
   */
   if (opt_level >= 1) {
-    std::vector<std::vector<uint32_t>> children_group_ids(idx.num_nodes());
-    std::vector<std::vector<uint32_t>> node_ids_per_group(idx.num_nodes());
+    std::vector<std::vector<uint32_t> > children_group_ids(idx.num_nodes());
+    std::vector<std::vector<uint32_t> > node_ids_per_group(idx.num_nodes());
     for (uint32_t nid = idx.num_nodes() - 1; nid != 0; --nid) {
       const auto& inode = idx[nid];
       if (inode.source->is_variable()) continue;

--- a/nnvm/tests/python/compiler/test_op_fusion.py
+++ b/nnvm/tests/python/compiler/test_op_fusion.py
@@ -105,16 +105,15 @@ def test_fuse_conv2d_elu():
     size = 64
     dshape = (1, in_channel, size, size)
     oshape = (1, out_channel, size, size)
-    sym1 = get_sym(out_channel)
-    sym2 = get_sym(out_channel)
-    _, params1 = utils.create_workload(sym1, 1, dshape[1:])
-    _, params2 = utils.create_workload(sym2, 1, dshape[1:])
-    for (p1, p2) in zip(params1.values(), params2.values()):
-        p2.copyfrom(p1)
-
     data = np.random.uniform(-1, 1, dshape).astype(np.float32)
 
     for target, ctx in ctx_list():
+        sym1 = get_sym(out_channel)
+        sym2 = get_sym(out_channel)
+        _, params1 = utils.create_workload(sym1, 1, dshape[1:], seed=0)
+        _, params2 = utils.create_workload(sym2, 1, dshape[1:], seed=0)
+        print(params1.keys())
+        print(params2.keys())
         print("Running on target", target)
         output, g1 = build_and_run(sym1, params1, data, oshape, target, ctx, opt_level=2)
         output2, g2 = build_and_run(sym2, params2, data, oshape, target, ctx, opt_level=0)

--- a/nnvm/tests/python/compiler/test_op_fusion.py
+++ b/nnvm/tests/python/compiler/test_op_fusion.py
@@ -85,7 +85,7 @@ def build_and_run(sym, params, data, out_shape, target, ctx, opt_level=2):
     module.set_input("data", data)
     module.run()
     out =  module.get_output(0, tvm.nd.empty(out_shape))
-    return out.asnumpy()
+    return out.asnumpy(), graph
 
 
 def test_fuse_conv2d_elu():
@@ -112,9 +112,11 @@ def test_fuse_conv2d_elu():
         sym2 = get_sym(out_channel)
         _, params1 = utils.create_workload(sym1, 1, dshape[1:], seed=0)
         _, params2 = utils.create_workload(sym2, 1, dshape[1:], seed=0)
-        output1 = build_and_run(sym1, params1, data, oshape, target, ctx, opt_level=2)
-        output2 = build_and_run(sym2, params2, data, oshape, target, ctx, opt_level=0)
+        output1, g1 = build_and_run(sym1, params1, data, oshape, target, ctx, opt_level=2)
+        output2, g2 = build_and_run(sym2, params2, data, oshape, target, ctx, opt_level=0)
         np.testing.assert_allclose(output1, output2, rtol=1e-5, atol=1e-5)
+        # data, conv weight, bias, batch norm gamma, batch norm beta, conv op
+        assert g1.index.num_nodes == 6
 
 if __name__ == "__main__":
     test_injective_reduce_injective()

--- a/nnvm/tests/python/compiler/test_op_fusion.py
+++ b/nnvm/tests/python/compiler/test_op_fusion.py
@@ -85,7 +85,7 @@ def build_and_run(sym, params, data, out_shape, target, ctx, opt_level=2):
     module.set_input("data", data)
     module.run()
     out =  module.get_output(0, tvm.nd.empty(out_shape))
-    return out.asnumpy(), graph
+    return out.asnumpy()
 
 
 def test_fuse_conv2d_elu():
@@ -112,12 +112,9 @@ def test_fuse_conv2d_elu():
         sym2 = get_sym(out_channel)
         _, params1 = utils.create_workload(sym1, 1, dshape[1:], seed=0)
         _, params2 = utils.create_workload(sym2, 1, dshape[1:], seed=0)
-        print(params1.keys())
-        print(params2.keys())
-        print("Running on target", target)
-        output, g1 = build_and_run(sym1, params1, data, oshape, target, ctx, opt_level=2)
-        output2, g2 = build_and_run(sym2, params2, data, oshape, target, ctx, opt_level=0)
-        np.testing.assert_allclose(output, output2, rtol=1e-5, atol=1e-5)
+        output1 = build_and_run(sym1, params1, data, oshape, target, ctx, opt_level=2)
+        output2 = build_and_run(sym2, params2, data, oshape, target, ctx, opt_level=0)
+        np.testing.assert_allclose(output1, output2, rtol=1e-5, atol=1e-5)
 
 if __name__ == "__main__":
     test_injective_reduce_injective()

--- a/topi/python/topi/arm_cpu/conv2d.py
+++ b/topi/python/topi/arm_cpu/conv2d.py
@@ -39,11 +39,10 @@ def decl_spatial_pack(cfg, data, kernel, strides, padding, layout, out_dtype):
 def schedule_conv2d_nchw_arm_cpu(cfg, outs):
     """TOPI schedule callback"""
     s = tvm.create_schedule([x.op for x in outs])
-    scheduled_ops = []
 
     def _callback(op):
         # schedule conv2d
-        if 'spatial_conv_output' in op.tag and op not in scheduled_ops:
+        if 'spatial_conv_output' in op.tag:
             output = op.output(0)
             conv = op.input_tensors[0]
 
@@ -64,8 +63,6 @@ def schedule_conv2d_nchw_arm_cpu(cfg, outs):
         if 'winograd_conv_output' in op.tag:
             output = op.output(0)
             _schedule_winograd(cfg, s, output, outs[0])
-
-        scheduled_ops.append(op)
 
     traverse_inline(s, outs[0].op, _callback)
     return s


### PR DESCRIPTION
Relevant discussion is [here](https://discuss.tvm.ai/t/nnvm-fusing-convolution-with-exponential-linear-unit/560).

@tqchen @srkreddy1238 @PariksheetPinjari909 @merrymercy please review.

This PR enhances NNVM operator fusion to support certain element wise patterns, like the one below. This pattern occurs when exponential linear unit is used, for example (see the link above for more info). 

![abf7821fe5d8169fee908f4891279189ff60ea9b](https://user-images.githubusercontent.com/1776403/43643812-715857aa-9767-11e8-8d14-0a35f4f68d98.png)

This PR enables to fuse all operators above into a single operator. The followings patterns are supported.
* Any number of child nodes from the top node
* The path from the top node to bottom node can contain any number of element wise ops.

 The restrictions:
* All branches must meet at the bottom node.
* 'In-between' nodes cannot have more than one child.


NNVM can already fuse operators in red below. I added a simple post processing that
* Check if all children nodes are fused into a single op by the existing fusion algorithm
* Fuse the parent node to children nodes. and update its group id to be the children's group id
* If the parent node originally belongs to another group (for example, conv + batch norm), propagate the new group id to grand parent and upward

![image](https://user-images.githubusercontent.com/1776403/43645139-0439ddba-976c-11e8-89e5-091c95fdcded.png)

TOPI schedules for all backend are updated to prevent scheduling the same op more than once. This is required because the same op can be reached from more than one route during output-to-input traversal.

A test cast added at nnvm/tests/python/compiler/test_op_fusion.py.