### PR TITLE
fix a build break on windows

### DIFF
--- a/nnvm/src/compiler/graph_runtime.cc
+++ b/nnvm/src/compiler/graph_runtime.cc
@@ -6,6 +6,10 @@
 #include <dmlc/memory_io.h>
 #include "./graph_runtime.h"
 
+namespace dmlc{
+  DMLC_REGISTRY_ENABLE(::tvm::NodeFactoryReg);
+}
+
 namespace nnvm {
 namespace compiler {
 


### PR DESCRIPTION
This PR is going to fix #1547 , the root cause is because we static link dmlc-core to tvm shared lib, but on windows, by default the shared library won't expose the symbols (Need annotation like TVM_EXPORTS ). dmlc::Registry::Get is not exposed in this case, that is why we get the link error.
I am using a quick fix that re-enable the registry in nnvm compiler shared lib, but not sure will cause any obj confliction on different platform. A better fix may be expose the symbol in dmlc-core, does tvm/dmlc team have any suggestion?
