### PR TITLE
[TOPI] Prevent scheduling the same operation more than once

### DIFF
--- a/topi/python/topi/arm_cpu/conv2d.py
+++ b/topi/python/topi/arm_cpu/conv2d.py
@@ -39,10 +39,11 @@ def decl_spatial_pack(cfg, data, kernel, strides, padding, layout, out_dtype):
 def schedule_conv2d_nchw_arm_cpu(cfg, outs):
     """TOPI schedule callback"""
     s = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
 
     def _callback(op):
         # schedule conv2d
-        if 'spatial_conv_output' in op.tag:
+        if 'spatial_conv_output' in op.tag and op not in scheduled_ops:
             output = op.output(0)
             conv = op.input_tensors[0]
 
@@ -63,6 +64,8 @@ def schedule_conv2d_nchw_arm_cpu(cfg, outs):
         if 'winograd_conv_output' in op.tag:
             output = op.output(0)
             _schedule_winograd(cfg, s, output, outs[0])
+
+        scheduled_ops.append(op)
 
     traverse_inline(s, outs[0].op, _callback)
     return s

--- a/topi/python/topi/arm_cpu/depthwise_conv2d.py
+++ b/topi/python/topi/arm_cpu/depthwise_conv2d.py
@@ -79,8 +79,10 @@ def schedule_depthwise_conv2d_nchw_(cfg, outs):
 
         return s
 
+    scheduled_ops = []
+
     def _callback(op):
-        if op.tag == 'depthwise_conv2d_nchw':
+        if op.tag == 'depthwise_conv2d_nchw' and op not in scheduled_ops:
             output = op.output(0)
             kernel = op.input_tensors[1]
             data = op.input_tensors[0]
@@ -89,6 +91,8 @@ def schedule_depthwise_conv2d_nchw_(cfg, outs):
                 data_pad = data
                 data = data_pad.op.input_tensors[0]
             _schedule(cfg, s, data, data_pad, kernel, output)
+
+        scheduled_ops.append(op)
 
     traverse_inline(s, outs[0].op, _callback)
     return s

--- a/topi/python/topi/cuda/reduction.py
+++ b/topi/python/topi/cuda/reduction.py
@@ -88,6 +88,7 @@ def schedule_reduce(outs):
     """
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     sch = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
 
     def traverse_before_reduce(operator):
         """Internal travserse function"""
@@ -96,9 +97,12 @@ def schedule_reduce(outs):
         elif tag.is_injective(operator.tag):
             sch[operator].compute_inline()
             for tensor in operator.input_tensors:
-                traverse_before_reduce(tensor.op)
+                if tensor.op not in scheduled_ops:
+                    traverse_before_reduce(tensor.op)
         else:
             raise RuntimeError("Unsupported operator: %s" % operator.tag)
+
+        scheduled_ops.append(operator)
 
     def traverse_after_reduce(operator):
         """Internal travserse function"""
@@ -107,13 +111,18 @@ def schedule_reduce(outs):
         elif operator.tag == 'comm_reduce':
             _schedule_reduce(operator, sch, is_idx_reduce=False)
             for tensor in operator.input_tensors:
-                traverse_before_reduce(tensor.op)
+                if tensor.op not in scheduled_ops:
+                    traverse_before_reduce(tensor.op)
         elif operator.tag == 'comm_reduce_idx':
             _schedule_reduce(operator, sch, is_idx_reduce=True)
-            for tensor in operator.input_tensors[0].op.input_tensors:
-                traverse_before_reduce(tensor.op)
+            input_tensors = operator.input_tensors[0].op.input_tensors
+            for tensor in input_tensors:
+                if tensor.op not in scheduled_ops:
+                    traverse_before_reduce(tensor.op)
         else:
             raise RuntimeError("Unsupported operator: %s" % operator.tag)
+
+        scheduled_ops.append(operator)
 
     traverse_after_reduce(outs[0].op)
     return sch

--- a/topi/python/topi/mali/dense.py
+++ b/topi/python/topi/mali/dense.py
@@ -81,6 +81,8 @@ def schedule_dense(outs):
 #        bias = s[outs[0]].op.input_tensors[1]
 #        print(tvm.lower(s, [data, weight, bias, outs[0]], simple_mode=True))
 
+    scheduled_ops = []
+
     def traverse(OP):
         """Internal travserse function"""
         # inline all one-to-one-mapping operators except the last stage (output)
@@ -88,7 +90,7 @@ def schedule_dense(outs):
             if OP not in s.outputs:
                 s[OP].compute_inline()
             for tensor in OP.input_tensors:
-                if tensor.op.input_tensors:
+                if tensor.op.input_tensors and tensor.op not in scheduled_ops:
                     traverse(tensor.op)
         # schedule dense
         elif OP.tag == 'dense':
@@ -96,6 +98,8 @@ def schedule_dense(outs):
             _schedule(dense)
         else:
             raise RuntimeError("Unsupported operator: %s" % OP.tag)
+
+        scheduled_ops.append(OP)
 
     traverse(outs[0].op)
     return s

--- a/topi/python/topi/opengl/pooling.py
+++ b/topi/python/topi/opengl/pooling.py
@@ -21,6 +21,8 @@ def schedule_global_pool(outs):
     """
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
     def _schedule(Pool):
         if Pool.op in s.outputs:
             Out = Pool
@@ -36,7 +38,7 @@ def schedule_global_pool(outs):
             if OP not in s.outputs:
                 s[OP].opengl()
             for tensor in OP.input_tensors:
-                if tensor.op.input_tensors:
+                if tensor.op.input_tensors and tensor.op not in scheduled_ops:
                     traverse(tensor.op)
         # schedule global_pool
         elif OP.tag.startswith('global_pool'):
@@ -44,6 +46,8 @@ def schedule_global_pool(outs):
             _schedule(Pool)
         else:
             raise RuntimeError("Unsupported operator: %s" % OP.tag)
+
+        scheduled_ops.append(OP)
 
     traverse(outs[0].op)
     return s
@@ -66,6 +70,8 @@ def schedule_pool(outs):
     """
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
     def _schedule(PaddedInput, Pool):
         if isinstance(PaddedInput.op, tvm.tensor.ComputeOp):
             s[PaddedInput].opengl()
@@ -82,7 +88,7 @@ def schedule_pool(outs):
         if tag.is_broadcast(OP.tag):
             if OP not in s.outputs:
                 s[OP].compute_inline()
-            for tensor in OP.input_tensors:
+            for tensor in OP.input_tensors and tensor.op not in scheduled_ops:
                 if tensor.op.input_tensors:
                     traverse(tensor.op)
         # schedule pool
@@ -92,6 +98,8 @@ def schedule_pool(outs):
             _schedule(PaddedInput, Pool)
         else:
             raise RuntimeError("Unsupported operator: %s" % OP.tag)
+
+        scheduled_ops.append(OP)
 
     traverse(outs[0].op)
     return s


### PR DESCRIPTION
Split from #1548.

Future updates to NNVM operator fusion may introduce cases where the same op can be reached from more than one route during output-to-input traversal. This PR makes sure an operation is scheduled only once.

This PR will be followed by #1548, where a relevant test case is included.  
