### PR TITLE
Fix windows link error by expose the entry point for REGISTER_NODE_TYPE

### DIFF
--- a/include/tvm/base.h
+++ b/include/tvm/base.h
@@ -83,5 +83,11 @@ struct NodeFactoryReg
       ::dmlc::Registry<::tvm::NodeFactoryReg>::Get()->__REGISTER__(TypeName::_type_key) \
       .set_body([]() { return std::make_shared<TypeName>(); })
 
+TVM_DLL::dmlc::Registry<::tvm::NodeFactoryReg > * GetTVMNodeFactoryRegistry();
+
+#define TVM_EXTERNAL_REGISTER_NODE_TYPE(TypeName)                                \
+  static DMLC_ATTRIBUTE_UNUSED ::tvm::NodeFactoryReg & __make_Node ## _ ## TypeName ## __ = \
+      ::tvm::GetTVMNodeFactoryRegistry()->__REGISTER__(TypeName::_type_key) \
+      .set_body([]() { return std::make_shared<TypeName>(); })
 }  // namespace tvm
 #endif  // TVM_BASE_H_

--- a/nnvm/src/compiler/graph_runtime.cc
+++ b/nnvm/src/compiler/graph_runtime.cc
@@ -100,6 +100,6 @@ TVM_REGISTER_GLOBAL("nnvm.compiler._load_param_dict")
     *rv = ret;
   });
 
-TVM_REGISTER_NODE_TYPE(NDArrayWrapperNode);
+TVM_EXTERNAL_REGISTER_NODE_TYPE(NDArrayWrapperNode);
 }  // namespace compiler
 }  // namespace nnvm

--- a/src/api/api_base.cc
+++ b/src/api/api_base.cc
@@ -41,4 +41,8 @@ TVM_REGISTER_API("_TVMSetStream")
 .set_body([](TVMArgs args,  TVMRetValue *ret) {
     TVMSetStream(args[0], args[1], args[2]);
   });
+
+TVM_DLL::dmlc::Registry<::tvm::NodeFactoryReg > * GetTVMNodeFactoryRegistry() {
+  return ::dmlc::Registry<::tvm::NodeFactoryReg>::Get();
+}
 }  // namespace tvm


### PR DESCRIPTION
This PR is to fix issue #1547 , The original plan is to expose the dmlc::Registry<T>::Get symbol in dmlc-core project, but later I found it does not work because nnvm is not only the consumer of dmlc::Registry symbol, but also need to enable registry on some new types, like:
`DMLC_REGISTRY_ENABLE(nnvm::PassFunctionReg);`

If we add MACRO like DMLC_DLL in registry.h, it will fail in nnvm because Windows does not allow to implement a function that declared as dllimport. I am currently use a workaround that in tvm lib, we expose another method that allow other component to access the dmlc::Registry<::tvm::NodeFactoryReg> instance, so nnvm could consume that one instead directly invoke the Get method in dmlc header file. 

This is the simplest solution I can think of at this moment, but not sure does it align with tvm's design. Let me know if you have any concern.