### PR TITLE
[ANDROID_RPC] Use phone layout for numerical EditText fields

### DIFF
--- a/apps/android_rpc/app/src/main/res/layout/content_main.xml
+++ b/apps/android_rpc/app/src/main/res/layout/content_main.xml
@@ -20,6 +20,7 @@
             android:hint="@string/input_address"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:inputType="phone"
             android:background="@android:drawable/editbox_background"/>
     </LinearLayout>
 
@@ -37,6 +38,7 @@
             android:minWidth="100dip"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:inputType="phone"
             android:background="@android:drawable/editbox_background"/>
     </LinearLayout>
 


### PR DESCRIPTION
Tweak the address and port EditText to use numerical input to save user input time.

CC @dayanandasiet @yzhliu 