### PR TITLE
[NNVM] Add ONNX upsample converter

### DIFF
--- a/nnvm/python/nnvm/frontend/onnx.py
+++ b/nnvm/python/nnvm/frontend/onnx.py
@@ -406,6 +406,19 @@ def _fully_connected(opset):
     return _impl
 
 
+class Upsample(OnnxOpConverter):
+    """ Operator converter for Upsample (nearest mode).
+    """
+
+    @classmethod
+    def _impl_v7(cls, inputs, attr, params):
+        scales = attr.get('scales')
+        mode = attr.get('mode')
+        assert mode == 'nearest'
+        params = {'scale': int(scales[-1])}
+        return _sym.upsampling(inputs[0], **params)
+
+
 class Shape(OnnxOpConverter):
     """ Operator converter for Shape.
     """
@@ -540,6 +553,7 @@ def _get_convert_map(opset):
         # 'Crop'
         # 'Embedding'
         # 'Upsample'
+        'Upsample' : Upsample.get_converter(opset),
         'SpatialBN': BatchNorm.get_converter(opset),
 
         # defs/generator

--- a/nnvm/python/nnvm/frontend/onnx.py
+++ b/nnvm/python/nnvm/frontend/onnx.py
@@ -414,7 +414,7 @@ class Upsample(OnnxOpConverter):
     def _impl_v7(cls, inputs, attr, params):
         scales = attr.get('scales')
         mode = attr.get('mode')
-        assert mode == 'nearest'
+        assert mode == b'nearest'
         params = {'scale': int(scales[-1])}
         return _sym.upsampling(inputs[0], **params)
 

--- a/nnvm/python/nnvm/frontend/onnx.py
+++ b/nnvm/python/nnvm/frontend/onnx.py
@@ -413,6 +413,7 @@ class Upsample(OnnxOpConverter):
     @classmethod
     def _impl_v7(cls, inputs, attr, params):
         scales = attr.get('scales')
+        assert len(scales) == 4 and scales[0] == 1.0 and scales[1] == 1.0 and scales[2] == scales[3]
         mode = attr.get('mode')
         if mode == b'nearest':
             method = "NEAREST_NEIGHBOR"
@@ -420,8 +421,7 @@ class Upsample(OnnxOpConverter):
             method = "BILINEAR"
         else:
             raise ValueError("Invalid ONNX upsample mode: {}".format(mode))
-        return _sym.upsampling(inputs[0], scale=int(scales[-1]),
-                   method=method, layout='NCHW')
+        return _sym.upsampling(inputs[0], scale=int(scales[-1]), method=method, layout='NCHW')
 
 
 class Shape(OnnxOpConverter):

--- a/nnvm/python/nnvm/frontend/onnx.py
+++ b/nnvm/python/nnvm/frontend/onnx.py
@@ -414,9 +414,13 @@ class Upsample(OnnxOpConverter):
     def _impl_v7(cls, inputs, attr, params):
         scales = attr.get('scales')
         mode = attr.get('mode')
-        assert mode == b'nearest'
-        params = {'scale': int(scales[-1])}
-        return _sym.upsampling(inputs[0], **params)
+        if mode == b'nearest':
+            method = "NEAREST_NEIGHBOR"
+        elif mode == b'linear':
+            method = "BILINEAR"
+        else:
+            raise ValueError("Invalid ONNX upsample mode: {}".format(mode))
+        return _sym.upsampling(inputs[0], scale=int(scales[-1]), method=str(method))
 
 
 class Shape(OnnxOpConverter):

--- a/nnvm/python/nnvm/frontend/onnx.py
+++ b/nnvm/python/nnvm/frontend/onnx.py
@@ -420,7 +420,8 @@ class Upsample(OnnxOpConverter):
             method = "BILINEAR"
         else:
             raise ValueError("Invalid ONNX upsample mode: {}".format(mode))
-        return _sym.upsampling(inputs[0], scale=int(scales[-1]), method=str(method))
+        return _sym.upsampling(inputs[0], scale=int(scales[-1]),
+                   method=method, layout='NCHW')
 
 
 class Shape(OnnxOpConverter):

--- a/nnvm/tests/python/frontend/onnx/test_forward.py
+++ b/nnvm/tests/python/frontend/onnx/test_forward.py
@@ -1,6 +1,8 @@
 import numpy as np
 import math
 import nnvm
+import topi
+import topi.testing
 import tvm
 from tvm.contrib import graph_runtime
 from nnvm.testing.config import ctx_list
@@ -383,19 +385,11 @@ def test_lrn():
 def _test_upsample_nearest():
     scale = 2
     in_shape = (1, 1, 3, 3)
-    out_shape = (1, 1, 3 * scale, 3 * scale)
-    scale = float(scale)
-    y = helper.make_node("Upsample", ['in'], ['out'], mode='nearest', scales=[scale])
+    out_shape = (1, 1, 3*scale, 3*scale)
+    y = helper.make_node("Upsample", ['in'], ['out'], mode='nearest', scales=[2.0])
     
-    in_array = np.random.uniform(size=in_shape).astype('float32')
-    out_array = np.zeros(out_shape).astype('float32')
-
-    def upsample_nearest(out_shape, out_array, in_array):
-        for b in range(out_shape[0]):
-            for c in range(out_shape[1]):
-                out_array[b, c, :, :] = in_array[b, c, :, :].repeat(scale, axis=0).repeat(scale, axis=1)
-
-    upsample_nearest(out_shape, out_array, in_array)
+    in_array = np.random.uniform(size=in_shape).astype(np.float32)
+    out_array = topi.testing.upsampling_python(in_array, scale, "NCHW")
 
     graph = helper.make_graph([y],
                               'upsample_nearest_test',
@@ -411,47 +405,11 @@ def _test_upsample_nearest():
 def _test_upsample_bilinear():
     scale = 2
     in_shape = (1, 1, 3, 3)
-    out_shape = (1, 1, 3 * scale, 3 * scale)
-    scale = float(scale)
-    y = helper.make_node("Upsample", ['in'], ['out'], mode='linear', scales=[scale])
+    out_shape = (1, 1, 3*scale, 3*scale)
+    y = helper.make_node("Upsample", ['in'], ['out'], mode='linear', scales=[2.0])
     
-    in_array = np.random.uniform(size=in_shape).astype('float32')
-    out_array = np.zeros(out_shape).astype('float32')
-
-    def upsample_bilinear(out_shape, out_array, in_shape, in_array):
-        for n in range(out_shape[0]):
-            for c in range(out_shape[1]):
-                for h in range(out_shape[2]):
-                    for w in range(out_shape[3]):
-                        in_y = h * 1.0 / scale
-                        y0 = math.floor(in_y)
-                        y1 = min(math.ceil(in_y), in_shape[2] - 1)
-                        y_lerp = in_y - y0
-
-                        y0 = int(y0)
-                        y1 = int(y1)
-
-                        in_x = w * 1.0 / scale
-                        x0 = math.floor(in_x)
-                        x1 = min(math.ceil(in_x), in_shape[3] - 1)
-                        x_lerp = in_x - x0
-
-                        x0 = int(x0)
-                        x1 = int(x1)
-
-                        A = in_array[n][c][y0][x0]
-                        B = in_array[n][c][y0][x1]
-                        C = in_array[n][c][y1][x0]
-                        D = in_array[n][c][y1][x1]
-
-                        top = A + (B - A) * x_lerp
-                        bottom = C + (D - C) * x_lerp
-
-                        pixel = np.float32(top + (bottom - top) * y_lerp)
-
-                        out_array[n][c][h][w] = pixel
-
-    upsample_bilinear(out_shape, out_array, in_shape, in_array)
+    in_array = np.random.uniform(size=in_shape).astype(np.float32)
+    out_array = topi.testing.bilinear_resize_python(in_array, (3*scale, 3*scale), "NCHW")
 
     graph = helper.make_graph([y],
                               'upsample_bilinear_test',

--- a/nnvm/tests/python/frontend/onnx/test_forward.py
+++ b/nnvm/tests/python/frontend/onnx/test_forward.py
@@ -386,7 +386,7 @@ def _test_upsample_nearest():
     scale = 2
     in_shape = (1, 1, 3, 3)
     out_shape = (1, 1, 3*scale, 3*scale)
-    y = helper.make_node("Upsample", ['in'], ['out'], mode='nearest', scales=[2.0])
+    y = helper.make_node("Upsample", ['in'], ['out'], mode='nearest', scales=[1.0, 1.0, 2.0, 2.0])
     
     in_array = np.random.uniform(size=in_shape).astype(np.float32)
     out_array = topi.testing.upsampling_python(in_array, scale, "NCHW")
@@ -406,7 +406,7 @@ def _test_upsample_bilinear():
     scale = 2
     in_shape = (1, 1, 3, 3)
     out_shape = (1, 1, 3*scale, 3*scale)
-    y = helper.make_node("Upsample", ['in'], ['out'], mode='linear', scales=[2.0])
+    y = helper.make_node("Upsample", ['in'], ['out'], mode='linear', scales=[1.0, 1.0, 2.0, 2.0])
     
     in_array = np.random.uniform(size=in_shape).astype(np.float32)
     out_array = topi.testing.bilinear_resize_python(in_array, (3*scale, 3*scale), "NCHW")
@@ -431,7 +431,7 @@ if __name__ == '__main__':
     # verify_super_resolution_example()
     # verify_squeezenet1_1()
     # verify_lenet()
-    verify_resnet18()
+    #verify_resnet18()
     test_reshape()
     test_reshape_like()
     test_power()

--- a/nnvm/tests/python/frontend/onnx/test_forward.py
+++ b/nnvm/tests/python/frontend/onnx/test_forward.py
@@ -462,7 +462,7 @@ def _test_upsample_bilinear():
 
     for target, ctx in ctx_list():
         tvm_out = get_tvm_output(model, in_array, target, ctx, out_shape, 'float32')
-        np.testing.assert_allclose(out_array, tvm_out)
+        np.testing.assert_allclose(out_array, tvm_out, rtol=1e-5, atol=1e-5)
 
 def test_upsample():
     _test_upsample_nearest()

--- a/nnvm/tests/python/frontend/onnx/test_forward.py
+++ b/nnvm/tests/python/frontend/onnx/test_forward.py
@@ -431,7 +431,7 @@ if __name__ == '__main__':
     # verify_super_resolution_example()
     # verify_squeezenet1_1()
     # verify_lenet()
-    #verify_resnet18()
+    verify_resnet18()
     test_reshape()
     test_reshape_like()
     test_power()


### PR DESCRIPTION
I suppose NNVM doesn't support the bilinear (trilinear) mode of *upsample* operator. And I am not sure if I need to check the of dimension of the input tensor, because ONNX supports the input tensor to be arbitrary dimension while NNVM assumes the input tensor is 4D. @tqchen 