### PR TITLE
[NNVM] Bug fix Prevent fusing convolution with injective op 

### DIFF
--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -147,8 +147,11 @@ nnvm::Graph GraphFindFusibleGroups(nnvm::Graph g) {
     bool parent_injective = false;
     for (const auto& e : inode.inputs) {
       TOpPattern pt = pattern_vec[e.node_id];
-      if (pt == kOutEWiseFusable) parent_out_ewise = true;
-      else if (pt == kInjective) parent_injective = true;
+      if (pt == kOutEWiseFusable) {
+        parent_out_ewise = true;
+      } else if (pt == kInjective) {
+        parent_injective = true;
+      }
     }
     // Change the master node from out_ewise_fusable op to itself
     if (parent_injective && parent_out_ewise) master_vec[nid] = nid;
@@ -157,8 +160,11 @@ nnvm::Graph GraphFindFusibleGroups(nnvm::Graph g) {
     for (const auto& e : inode.inputs) {
       TOpPattern pt = pattern_vec[e.node_id];
       if (parent_out_ewise && parent_injective) {
-        if (pt == kOutEWiseFusable) continue;  // Do not fuse out_ewise_fusable op
-        else if (pt == kInjective) master_vec[e.node_id] = nid;
+        if (pt == kOutEWiseFusable) {
+          continue;  // Do not fuse out_ewise_fusable op
+        } else if (pt == kInjective) {
+          master_vec[e.node_id] = nid;
+        }
       }
       if (fuse_vec[e.node_id] == FuseRule::kFuseToMaster) {
         CHECK(group_vec[e.node_id] == -1||

--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -157,7 +157,7 @@ nnvm::Graph GraphFindFusibleGroups(nnvm::Graph g) {
     for (const auto& e : inode.inputs) {
       TOpPattern pt = pattern_vec[e.node_id];
       if (parent_out_ewise && parent_injective) {
-        if (pt == kOutEWiseFusable) continue; // Do not fuse out_ewise_fusable op
+        if (pt == kOutEWiseFusable) continue;  // Do not fuse out_ewise_fusable op
         else if (pt == kInjective) master_vec[e.node_id] = nid;
       }
       if (fuse_vec[e.node_id] == FuseRule::kFuseToMaster) {

--- a/nnvm/tests/python/compiler/test_op_fusion.py
+++ b/nnvm/tests/python/compiler/test_op_fusion.py
@@ -94,8 +94,8 @@ def test_injective_conv2d():
 
     for target, ctx in ctx_list():
         graph, lib, _ = nnvm.compiler.build(net, target, shape_dict)
-        # data, global_avg_pool, conv weight, fused op
-        assert graph.index.num_nodes == 4
+        # data, global_avg_pool, conv weight, conv op, fused elemwise add
+        assert graph.index.num_nodes == 5
 
         data = tvm.nd.array(np.random.uniform(size=dshape).astype(dtype))
         kernel = tvm.nd.array(np.random.uniform(size=kshape).astype(dtype))

--- a/topi/python/topi/cuda/conv2d_nchw.py
+++ b/topi/python/topi/cuda/conv2d_nchw.py
@@ -497,7 +497,7 @@ def schedule_conv2d_small_batch(outs):
     def traverse(OP):
         """Traverse operators from computation graph"""
         # inline all one-to-one-mapping operators except the last stage (output)
-        if tag.is_broadcast(OP.tag):
+        if tag.is_injective(OP.tag):
             if OP not in s.outputs:
                 s[OP].compute_inline()
             for tensor in OP.input_tensors:

--- a/topi/python/topi/cuda/conv2d_nchw.py
+++ b/topi/python/topi/cuda/conv2d_nchw.py
@@ -497,7 +497,7 @@ def schedule_conv2d_small_batch(outs):
     def traverse(OP):
         """Traverse operators from computation graph"""
         # inline all one-to-one-mapping operators except the last stage (output)
-        if tag.is_injective(OP.tag):
+        if tag.is_broadcast(OP.tag):
             if OP not in s.outputs:
                 s[OP].compute_inline()
             for tensor in OP.input_tensors:


### PR DESCRIPTION
Continuing from #1603.

Modify operator fuser to include following logics.

* During the initial partition step, if injective op is followed by broadcast op, mark broadcast op's op pattern to be injective
* In the last grouping step, check for input nodes op patterns. If one of them is kOutEWiseFusable and the other is kInjective, ignore the kOutEWiseFusable node and fuse only kInjective node.

A test case is included. This test fails without this PR.
I confirmed that this change does not affect compling resnet, mobilenet and vgg.

@tqchen please check if the logic is good.