### PR TITLE
#1592 added a test case and a CHECK func

### DIFF
--- a/src/pass/storage_rewrite.cc
+++ b/src/pass/storage_rewrite.cc
@@ -584,6 +584,12 @@ class StoragePlanRewriter : public IRMutator {
           e->new_alloc = Allocate::make(
               e->alloc_var, alloc_type, {combo_size}, const_true(),
               Evaluate::make(0));
+          if (e->scope.tag.length() != 0) {
+            MemoryInfo info = GetMemoryInfo(e->scope.to_string());
+            uint64_t total_elem = e->const_nbits / e->elem_type.bits();
+            CHECK_LE(total_elem * e->elem_type.bits(), info->max_num_bits)
+                << "Allocation exceed bound of memory tag " << e->scope.to_string();
+          }
         }
       }
     }

--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -275,9 +275,9 @@ def test_inplace_rule2():
     tvm.ir_pass.PostOrderVisit(stmt, verify)
     assert num_alloc[0] == 2
 
-def test_inplace_rule2_with_var(test_max_num_bits=100):
+def test_inplace_rule2_with_small_max_num_bits(test_max_num_bits = 100):
     #Test Buffer
-    scope_tb = "local_TB2"
+    scope_tb = "local_TB2S"
     @tvm.register_func("tvm.info.mem.%s" % scope_tb)
     def mem_info_inp_buffer():
         return tvm.make.node("MemoryInfo",
@@ -317,11 +317,15 @@ def test_inplace_rule2_with_var(test_max_num_bits=100):
     tvm.ir_pass.PostOrderVisit(stmt, verify)
     assert num_alloc[0] == 2
 
-def test_inplace_rule2_Detection(test_max_num_bits=100):
+def test_exceed_mem(test_max_num_bits=10):
+    # The critical max_num_bits is between 639 and 640
     try:
-        test_inplace_rule2_with_var(test_max_num_bits)
-    except:
-        print 'Error! function: test_inplace_rule2_with_var(). The size of "max_num_bits" is improper.'
+        test_inplace_rule2_with_small_max_num_bits(test_max_num_bits)
+    except Exception, e:
+        estr = str(e)
+        flagAllocMsg = estr.find('Allocation exceed bound of memory')
+        flagEndMsg = estr.find('\n', flagAllocMsg + 1)
+        assert None==e, estr[flagAllocMsg:flagEndMsg]
 
 def test_inplace_rule3():
     #Test Buffer
@@ -513,7 +517,7 @@ if __name__ == "__main__":
     test_storage_combine()
     test_storage_share_gpu()
     test_inplace_rule2()
-    test_inplace_rule2_Detection(100)
+    test_exceed_mem()
     test_inplace_rule3()
     test_alloc_seq_type()
     test_alloc_seq_type2()

--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -275,6 +275,54 @@ def test_inplace_rule2():
     tvm.ir_pass.PostOrderVisit(stmt, verify)
     assert num_alloc[0] == 2
 
+def test_inplace_rule2_with_var(test_max_num_bits=100):
+    #Test Buffer
+    scope_tb = "local_TB2"
+    @tvm.register_func("tvm.info.mem.%s" % scope_tb)
+    def mem_info_inp_buffer():
+        return tvm.make.node("MemoryInfo",
+                        unit_bits= 16,
+                        max_simd_bits=32,
+                        max_num_bits=test_max_num_bits,
+                        head_address=None)
+    m = 10
+    A = tvm.placeholder((m,), name='A')
+    C = tvm.placeholder((m,), name='C')
+    D = tvm.placeholder((m,), name='D')
+    A0 = tvm.compute((m,), lambda i: A[i] + C[i], name='A0')
+    A1 = tvm.compute((m,), lambda i: D[i] * D[i], name='A1')
+    A2 = tvm.compute((m,), lambda i: A0[i] + A1[i], name='A2')
+    B = tvm.compute((m,), lambda i: A2[i], name='B')
+    s = tvm.create_schedule(B.op)
+    A0L = s.cache_read(A0, scope_tb, [A2])
+    A1L = s.cache_read(A1, scope_tb, [A2])
+    A2L = s.cache_read(A2, scope_tb, [B])
+    bounds = tvm.schedule.InferBound(s)
+    assert isinstance(bounds, tvm.container.Map)
+    stmt = tvm.schedule.ScheduleOps(s, bounds)
+    Ab = tvm.decl_buffer(A.shape, A.dtype, name='A')
+    Bb = tvm.decl_buffer(B.shape, B.dtype, name='B')
+    Cc = tvm.decl_buffer(C.shape, B.dtype, name='C')
+    Dd = tvm.decl_buffer(D.shape, B.dtype, name='D')
+    stmt = tvm.ir_pass.StorageFlatten(stmt, {A: Ab, B: Bb, C: Cc, D:Dd}, 64)
+    stmt = tvm.ir_pass.CanonicalSimplify(stmt)
+    stmt = tvm.ir_pass.Simplify(stmt)
+    stmt = tvm.ir_pass.StorageRewrite(stmt)
+    # verify only have one allocations.
+    # verify inplace folding works
+    num_alloc = [0]
+    def verify(n):
+        if isinstance(n, tvm.stmt.Allocate):
+            num_alloc[0] += 1
+    tvm.ir_pass.PostOrderVisit(stmt, verify)
+    assert num_alloc[0] == 2
+
+def test_inplace_rule2_Detection(test_max_num_bits=100):
+    try:
+        test_inplace_rule2_with_var(test_max_num_bits)
+    except:
+        print 'Error! function: test_inplace_rule2_with_var(). The size of "max_num_bits" is improper.'
+
 def test_inplace_rule3():
     #Test Buffer
     scope_tb = "local_TB3"
@@ -465,6 +513,7 @@ if __name__ == "__main__":
     test_storage_combine()
     test_storage_share_gpu()
     test_inplace_rule2()
+    test_inplace_rule2_Detection(100)
     test_inplace_rule3()
     test_alloc_seq_type()
     test_alloc_seq_type2()


### PR DESCRIPTION
For #1592 
The test case "test_mem_exceed()" in the file "test_pass_storage_rewrite.py" is made to show the bug of "allocation exceed bound of memory".

In our tests, if max_num_bits < 640, it will trigger the bug.

The CHECK_LE function is added in the file "storage_rewrite.cc L587". After that, the test case "test_alloc_seq()" and "test_alloc_seq_type2()" in the file "test_pass_storage_rewrite.py" are fixed by adding the memory register function.

Regards.