### PR TITLE
[NNVM] Bug fix Add missing check when deciding conv and injective ops are in the same group

### DIFF
--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -146,6 +146,7 @@ nnvm::Graph GraphFindFusibleGroups(nnvm::Graph g) {
     bool parent_out_ewise = false;
     bool parent_injective = false;
     for (const auto& e : inode.inputs) {
+      if (fuse_vec[e.node_id] != FuseRule::kFuseToMaster) continue;
       TOpPattern pt = pattern_vec[e.node_id];
       if (pt == kOutEWiseFusable) {
         parent_out_ewise = true;


### PR DESCRIPTION
Fix the bug found by @kazum in #1608. When an injective op's fuse type is kRealize, the change in #1608 should be nop, because the injective op will not be fused with conv anyway.

I added a check to make sure that injective op's fuse type is kFuseToMaster, which is the only relevant case when determining if conv and injective op are in the same group. A test case is added.

@tqchen @kazum please review. 