### PR TITLE
[AUTOTVM] Add minimum measurement time option

### DIFF
--- a/python/tvm/autotvm/measure/measure.py
+++ b/python/tvm/autotvm/measure/measure.py
@@ -48,6 +48,7 @@ class MeasureErrorNo(object):
 def measure_option(measure_func,
                    number=1,
                    repeat=1,
+                   min_milliseconds=0,
                    timeout=60,
                    n_parallel=1,
                    do_fork=True,
@@ -71,6 +72,14 @@ def measure_option(measure_func,
         In total, the generated code will be run (1 + number x repeat) times,
         where the first one is warm up. The returned result contains `repeat` costs,
         each of which is the average of `number` test run.
+    min_milliseconds : int, optional
+        Minimum measurement time in milliseconds.
+        When the run time of a measurement trial falls below this time, the
+        `number` parameter will be automatically increased.
+        Set this to improve the accuracy of perf measurement, e.g., when timers
+        are not precise enough to capture short-running tasks. This parameter is
+        also critical when devices need a certain minimum running time to "warm
+        up," such as GPUs that need time to reach a performance power state.
     timeout: int, optional
         Timeout for a whole batch. TimeoutError will be returned as the result if a
         task timeouts.
@@ -119,6 +128,7 @@ def measure_option(measure_func,
         'measure_func': measure_func,
         'number': number,
         'repeat': repeat,
+        'min_milliseconds': min_milliseconds,
         'timeout': timeout,
         'n_parallel': n_parallel,
         'do_fork': do_fork,

--- a/python/tvm/autotvm/measure/measure.py
+++ b/python/tvm/autotvm/measure/measure.py
@@ -48,7 +48,7 @@ class MeasureErrorNo(object):
 def measure_option(measure_func,
                    number=1,
                    repeat=1,
-                   min_milliseconds=0,
+                   min_repeat_ms=0,
                    timeout=60,
                    n_parallel=1,
                    do_fork=True,
@@ -72,8 +72,8 @@ def measure_option(measure_func,
         In total, the generated code will be run (1 + number x repeat) times,
         where the first one is warm up. The returned result contains `repeat` costs,
         each of which is the average of `number` test run.
-    min_milliseconds : int, optional
-        Minimum measurement time in milliseconds.
+    min_repeat_ms : float, optional
+        Minimum duration of a timer measurement in milliseconds.
         When the run time of a measurement trial falls below this time, the
         `number` parameter will be automatically increased.
         Set this to improve the accuracy of perf measurement, e.g., when timers
@@ -128,7 +128,7 @@ def measure_option(measure_func,
         'measure_func': measure_func,
         'number': number,
         'repeat': repeat,
-        'min_milliseconds': min_milliseconds,
+        'min_repeat_ms': min_repeat_ms,
         'timeout': timeout,
         'n_parallel': n_parallel,
         'do_fork': do_fork,

--- a/python/tvm/autotvm/measure/measure.py
+++ b/python/tvm/autotvm/measure/measure.py
@@ -66,12 +66,12 @@ def measure_option(measure_func,
         callable: It is a callable function for measurement.
                   See the return value of measure/measure_methods.py::rpc for example.
     number : int, optional
-        Number of times to do the measurement for average
+        Number of times to do measurement for average
     repeat : int, optional
         Number of times to repeat the measurement.
         In total, the generated code will be run (1 + number x repeat) times,
         where the first one is warm up. The returned result contains `repeat` costs,
-        each of which is the average of `number` test run.
+        each of which is the average of `number` tests run.
     min_repeat_ms : float, optional
         Minimum duration of a timer measurement in milliseconds.
         When the run time of a measurement trial falls below this time, the
@@ -84,12 +84,12 @@ def measure_option(measure_func,
         Timeout for a whole batch. TimeoutError will be returned as the result if a
         task timeouts.
     n_parallel: int, optional
-        The number of measurement task that can run in parallel.
+        The number of measurement tasks that can run in parallel.
         Set this according to the number of cpu cores (for compilation) and
         the number of devices you have (for measuring generate code).
     do_fork: bool, optional
-        Whether use multiprocessing (based on fork) for running measure jobs in parallel.
-        Set this to False if you want to debug (see trackback) or using fork is not suitable.
+        Whether to use multiprocessing (based on fork) for running measure jobs in parallel.
+        Set this to False if you want to debug (see traceback) or using fork is not suitable.
         NOTE: If this is False, parallel and timeout do not work.
     build_func: str or callable, optional
         'default': call default builder. This works for normal target (llvm, cuda)
@@ -102,7 +102,7 @@ def measure_option(measure_func,
         Whether check correctness after measurement. This will use llvm cpu target to generate
         reference output.
     replay_db : Database, optional
-        The database that we retrieve saved MeasureResult from.
+        The database that we retrieve the saved MeasureResult from.
 
     Returns
     -------

--- a/python/tvm/autotvm/measure/measure.py
+++ b/python/tvm/autotvm/measure/measure.py
@@ -23,8 +23,8 @@ class MeasureResult(namedtuple("MeasureResult", ["costs", "error_no", "all_cost"
     Parameters
     ----------
     costs: Array of float or Array of Exception
-        If no error occurs for this measurement, it is an array of measured running times.
-        If some error occurs during the measurement, it is an array of the exception objections.
+        If no error occurs during measurement, it is an array of measured running times.
+        If an error occurs during measurement, it is an array of the exception objections.
     error_no: int
         Denote error type, defined by MeasureErrorNo
     all_cost: float

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -219,7 +219,8 @@ def create_measure_batch(task, option):
                 if result.error_no == MeasureErrorNo.NO_ERROR:
                     measure_cost = np.mean(result.costs) * nonLocal.number * 1e3
                     if measure_cost < min_repeat_ms:
-                        nonLocal.number *= 2
+                        nonLocal.number = int(np.ceil(nonLocal.number *\
+                                                  min_repeat_ms/measure_cost))
                         remeasure = True
                         msg = "increasing number to {0:d} ({1:.3f}ms < {2:.3f}ms)".format(\
                         nonLocal.number, measure_cost, min_repeat_ms)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -1,8 +1,8 @@
 # pylint: disable=consider-using-enumerate,invalid-name,too-many-function-args
 """
 Functions that run on executor for measurement.
-These functions are responsible for building tvm module, uploading it to
-remote devices, recording the running time costs and checking the correctness of output
+These functions are responsible for building the tvm module, uploading it to
+remote devices, recording the running time costs, and checking the correctness of the output.
 """
 
 import logging

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -230,13 +230,13 @@ def create_measure_batch(task, option):
                         # applicable)
                         input_pack = measure_inputs[i*pack_size:(i+1)*pack_size]
                         new_future = executor.submit(measure_func,
-                                                    input_pack,
-                                                    build_func,
-                                                    build_kwargs,
-                                                    nonLocal.number,
-                                                    repeat,
-                                                    ref_input,
-                                                    ref_output)
+                                                     input_pack,
+                                                     build_func,
+                                                     build_kwargs,
+                                                     nonLocal.number,
+                                                     repeat,
+                                                     ref_input,
+                                                     ref_output)
                         result = new_future.get()
                     else:
                         break

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -216,15 +216,15 @@ def create_measure_batch(task, option):
         while True:
             remeasure = False
             for result in results:
-                measure_cost = np.mean(result.costs) * nonLocal.number * 1e3
-                if result.error_no == MeasureErrorNo.NO_ERROR and\
-                   measure_cost < min_repeat_ms:
-                    nonLocal.number *= 2
-                    remeasure = True
-                    msg = "increasing number to {0:d} ({1:.3f}ms < {2:.3f}ms)".format(\
-                    nonLocal.number, measure_cost, min_repeat_ms)
-                    logger.info(msg)
-                    break
+                if result.error_no == MeasureErrorNo.NO_ERROR:
+                    measure_cost = np.mean(result.costs) * nonLocal.number * 1e3
+                    if measure_cost < min_repeat_ms:
+                        nonLocal.number *= 2
+                        remeasure = True
+                        msg = "increasing number to {0:d} ({1:.3f}ms < {2:.3f}ms)".format(\
+                        nonLocal.number, measure_cost, min_repeat_ms)
+                        logger.info(msg)
+                        break
             if remeasure:
                 # note that measure_inputs here has already been filtered (if
                 # applicable)

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -113,7 +113,7 @@ def create_measure_batch(task, option):
 
     measure_func = option['measure_func']
     repeat = option['repeat']
-    min_milliseconds = option['min_milliseconds']
+    min_repeat_ms = option['min_repeat_ms']
     timeout, n_parallel, do_fork = option['timeout'], option['n_parallel'], option['do_fork']
     build_func = option['build_func']
     check_correctness = option['check_correctness']
@@ -218,11 +218,11 @@ def create_measure_batch(task, option):
             for result in results:
                 measure_cost = np.mean(result.costs) * nonLocal.number * 1e3
                 if result.error_no == MeasureErrorNo.NO_ERROR and\
-                   measure_cost < min_milliseconds:
+                   measure_cost < min_repeat_ms:
                     nonLocal.number *= 2
                     remeasure = True
-                    msg = "increasing number to {0:d} ({1:.3f}ms < {2:d}ms)".format(\
-                    nonLocal.number, measure_cost, min_milliseconds)
+                    msg = "increasing number to {0:d} ({1:.3f}ms < {2:.3f}ms)".format(\
+                    nonLocal.number, measure_cost, min_repeat_ms)
                     logger.info(msg)
                     break
             if remeasure:


### PR DESCRIPTION
One issue with measurement on fast devices is that we need to automatically adjust `number` so that the measured time is large enough for precise measurement. A minimum measured time is also important for properly warming up some devices, e.g., GPUs with power states.

This PR introduces a `min_milliseconds` parameter to `measure_option` to enforce a minimum trial time. If a measurement falls below this threshold, `number` is increased and we repeat the measurement (this increase persists over the lifetime of the `measure_batch` function).