### PR TITLE
[ANDROID_RPC] Remove `Start RPC` Button

### DIFF
--- a/apps/android_rpc/app/src/main/java/ml/dmlc/tvm/tvmrpc/MainActivity.java
+++ b/apps/android_rpc/app/src/main/java/ml/dmlc/tvm/tvmrpc/MainActivity.java
@@ -39,10 +39,8 @@ import android.app.NotificationManager;
 
 
 public class MainActivity extends AppCompatActivity {
-  private boolean skipRelaunch = true;
   // wait time before automatic restart of RPC Activity
   public static final int HANDLER_RESTART_DELAY = 5000;
-
 
   private void showDialog(String title, String msg) {
     AlertDialog.Builder builder = new AlertDialog.Builder(this);
@@ -91,7 +89,7 @@ public class MainActivity extends AppCompatActivity {
     final Runnable rPCStarter = new Runnable() {
         public void run() {
             if (switchPersistent.isChecked()) {
-              System.err.println("relaunching RPC activity in 5s...");
+              System.err.println("relaunching RPC activity...");
               Intent intent = ((MainActivity) context).updateRPCPrefs();
               startActivity(intent);
             }
@@ -116,19 +114,12 @@ public class MainActivity extends AppCompatActivity {
         if (isChecked) {
           System.err.println("automatic RPC restart enabled...");
           updateRPCPrefs();
+          setupRelaunch();
         } else {
           System.err.println("automatic RPC restart disabled...");
           updateRPCPrefs();
         }
       }
-    });
-
-    Button startRPC = findViewById(R.id.button_start_rpc);
-    startRPC.setOnClickListener(new View.OnClickListener() {
-        public void onClick(View v) {
-            Intent intent = ((MainActivity) context).updateRPCPrefs();
-            startActivity(intent);
-        }
     });
 
     enableInputView(true);
@@ -137,15 +128,8 @@ public class MainActivity extends AppCompatActivity {
   @Override
   protected void onResume() {
     System.err.println("MainActivity onResume...");
-    System.err.println("skipRelaunch: " + skipRelaunch);
-    // if this is the first time onResume is called, do nothing, otherwise we
-    // may double launch
-    if (!skipRelaunch) {
-        enableInputView(true);
-        setupRelaunch();
-    } else {
-        skipRelaunch = false;
-    }
+    enableInputView(true);
+    setupRelaunch();
     super.onResume();
   }
 

--- a/apps/android_rpc/app/src/main/res/layout/content_main.xml
+++ b/apps/android_rpc/app/src/main/res/layout/content_main.xml
@@ -78,15 +78,4 @@
             android:textOn="@string/switch_on" />
     </LinearLayout>
 
-    <LinearLayout
-        android:orientation="horizontal"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content">
-        <Button
-            android:id="@+id/button_start_rpc"
-            android:layout_height="wrap_content"
-            android:layout_width="wrap_content"
-            android:text="@string/start_rpc" />
-    </LinearLayout>
-
 </LinearLayout>

--- a/apps/android_rpc/app/src/main/res/values/strings.xml
+++ b/apps/android_rpc/app/src/main/res/values/strings.xml
@@ -9,11 +9,10 @@
     <string name="label_address">Address</string>
     <string name="label_port">Port</string>
     <string name="label_key">Key</string>
-    <string name="label_persistent">Keep RPC Alive</string>
+    <string name="label_persistent">Enable RPC</string>
 
     <string name="switch_on">Enabled</string>
     <string name="switch_off">Disabled</string>
 
-    <string name="start_rpc">Start RPC</string>
     <string name="stop_rpc">Stop RPC</string>
 </resources>


### PR DESCRIPTION
There seems to be an issue with Android RPC crashes that occur before the `MainActivity`'s `onResume` is called for the first time. When this happens, the application's automatic restart does not trigger even if automatic restart is enabled due to a check that prevents the RPC activity from being launched when the `MainActivity` comes on screen for the first time.

We remove this restriction and the `Start RPC` button; now the RPC activity will always automatically start (and restart) when the switch for `Enable RPC` is on.