### PR TITLE
[TEAM] New reviewer: nishi-t

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 ## Reviewers
 - [Masahiro Masuda](https://github.com/masahi)
 - [Kazutaka Morita](https://github.com/kazum)
+- [Tatsuya Nishiyama](https://github.com/nishi-t)
 - [Pariksheet Pinjari](https://github.com/PariksheetPinjari909)
 - [Siva](https://github.com/srkreddy1238)
 - [Alex Weaver](https://github.com/alex-weaver)
@@ -35,9 +36,6 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
   - To contributors: please add your name to the list.
 - [Qiao Zhang](https://github.com/zhangqiaorjc)
 - [Jian Weng](https://github.com/were)
-- [Masahiro Masuda](https://github.com/masahi)
 - [Haolong Zhang](https://github.com/haolongzhangm)
 - [Cody Hao Yu](https://github.com/comaniac)
 - [Chris Nuernberger](https://github.com/cnuernber)
-- [Tatsuya Nishiyama](https://github.com/nishi-t)
-- [Kazutaka Morita](https://github.com/kazum)


### PR DESCRIPTION
This PR welcomes @nishi-t  as a Reviewer of TVM stack. He contributes to various aspect of tvm, notably, the CUDA fp16 and int8 support, nnvm operators as well and mxnet/onnx frontend. He also reviewed changes for OpenCL  HLS support.

- [Tatsuya's commit history](https://github.com/dmlc/tvm/commits?author=nishi-t)
- [Code reviews](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Anishi-t)
- [Community forum summary](https://discuss.tvm.ai/u/nishi-t/summary)