### PR TITLE
Remove leading "./" from include paths

### DIFF
--- a/include/tvm/api_registry.h
+++ b/include/tvm/api_registry.h
@@ -7,9 +7,9 @@
 #ifndef TVM_API_REGISTRY_H_
 #define TVM_API_REGISTRY_H_
 
-#include "./base.h"
-#include "./packed_func_ext.h"
-#include "./runtime/registry.h"
+#include "base.h"
+#include "packed_func_ext.h"
+#include "runtime/registry.h"
 
 /*!
  * \brief Register an API function globally.

--- a/include/tvm/arithmetic.h
+++ b/include/tvm/arithmetic.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
-#include "./expr.h"
+#include "expr.h"
 
 namespace tvm {
 

--- a/include/tvm/attrs.h
+++ b/include/tvm/attrs.h
@@ -31,9 +31,9 @@
 #include <vector>
 #include <type_traits>
 #include <string>
-#include "./ir.h"
-#include "./base.h"
-#include "./packed_func_ext.h"
+#include "ir.h"
+#include "base.h"
+#include "packed_func_ext.h"
 
 namespace tvm {
 /*!

--- a/include/tvm/base.h
+++ b/include/tvm/base.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <memory>
 #include <functional>
-#include "./runtime/registry.h"
+#include "runtime/registry.h"
 
 namespace tvm {
 

--- a/include/tvm/buffer.h
+++ b/include/tvm/buffer.h
@@ -9,8 +9,8 @@
 #include <tvm/container.h>
 #include <string>
 
-#include "./base.h"
-#include "./expr.h"
+#include "base.h"
+#include "expr.h"
 
 namespace tvm {
 

--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -9,9 +9,9 @@
 #include <string>
 #include <vector>
 #include <utility>
-#include "./runtime/packed_func.h"
-#include "./schedule_pass.h"
-#include "./lowered_func.h"
+#include "runtime/packed_func.h"
+#include "schedule_pass.h"
+#include "lowered_func.h"
 
 namespace tvm {
 using namespace tvm::runtime;

--- a/include/tvm/c_dsl_api.h
+++ b/include/tvm/c_dsl_api.h
@@ -14,7 +14,7 @@
 #ifndef TVM_C_DSL_API_H_
 #define TVM_C_DSL_API_H_
 
-#include "./runtime/c_runtime_api.h"
+#include "runtime/c_runtime_api.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/tvm/codegen.h
+++ b/include/tvm/codegen.h
@@ -7,11 +7,11 @@
 #define TVM_CODEGEN_H_
 
 #include <string>
-#include "./base.h"
-#include "./expr.h"
-#include "./lowered_func.h"
-#include "./api_registry.h"
-#include "./runtime/packed_func.h"
+#include "base.h"
+#include "expr.h"
+#include "lowered_func.h"
+#include "api_registry.h"
+#include "runtime/packed_func.h"
 
 namespace tvm {
 /*! \brief namespace for lowlevel IR pass and codegen */

--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -11,8 +11,8 @@
 #include <ir/IRPrinter.h>
 #include <string>
 #include <algorithm>
-#include "./base.h"
-#include "./runtime/c_runtime_api.h"
+#include "base.h"
+#include "runtime/c_runtime_api.h"
 
 namespace tvm {
 

--- a/include/tvm/ir.h
+++ b/include/tvm/ir.h
@@ -10,9 +10,9 @@
 #include <ir/IR.h>
 #include <type_traits>
 #include <string>
-#include "./base.h"
-#include "./expr.h"
-#include "./runtime/util.h"
+#include "base.h"
+#include "expr.h"
+#include "runtime/util.h"
 
 namespace tvm {
 namespace ir {

--- a/include/tvm/ir_functor_ext.h
+++ b/include/tvm/ir_functor_ext.h
@@ -7,7 +7,7 @@
 #define TVM_IR_FUNCTOR_EXT_H_
 
 #include <tvm/ir_functor.h>
-#include "./ir.h"
+#include "ir.h"
 
 namespace tvm {
 namespace ir {

--- a/include/tvm/ir_mutator.h
+++ b/include/tvm/ir_mutator.h
@@ -8,8 +8,8 @@
 
 #include <tvm/ir_functor.h>
 #include <unordered_map>
-#include "./expr.h"
-#include "./ir.h"
+#include "expr.h"
+#include "ir.h"
 
 namespace tvm {
 namespace ir {

--- a/include/tvm/ir_operator.h
+++ b/include/tvm/ir_operator.h
@@ -7,8 +7,8 @@
 #define TVM_IR_OPERATOR_H_
 
 #include <algorithm>
-#include "./expr.h"
-#include "./ir.h"
+#include "expr.h"
+#include "ir.h"
 
 namespace tvm {
 

--- a/include/tvm/ir_pass.h
+++ b/include/tvm/ir_pass.h
@@ -14,10 +14,10 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
-#include "./expr.h"
-#include "./buffer.h"
-#include "./schedule.h"
-#include "./lowered_func.h"
+#include "expr.h"
+#include "buffer.h"
+#include "schedule.h"
+#include "lowered_func.h"
 
 namespace tvm {
 namespace ir {

--- a/include/tvm/ir_visitor.h
+++ b/include/tvm/ir_visitor.h
@@ -7,7 +7,7 @@
 #define TVM_IR_VISITOR_H_
 
 #include <tvm/ir_functor.h>
-#include "./ir.h"
+#include "ir.h"
 
 namespace tvm {
 namespace ir {

--- a/include/tvm/lowered_func.h
+++ b/include/tvm/lowered_func.h
@@ -11,9 +11,9 @@
 #include <ir/FunctionBase.h>
 #include <string>
 
-#include "./base.h"
-#include "./expr.h"
-#include "./tensor.h"
+#include "base.h"
+#include "expr.h"
+#include "tensor.h"
 
 namespace tvm {
 

--- a/include/tvm/operation.h
+++ b/include/tvm/operation.h
@@ -9,12 +9,12 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include "./expr.h"
-#include "./ir_operator.h"
-#include "./tensor.h"
-#include "./schedule.h"
-#include "./arithmetic.h"
-#include "./buffer.h"
+#include "expr.h"
+#include "ir_operator.h"
+#include "tensor.h"
+#include "schedule.h"
+#include "arithmetic.h"
+#include "buffer.h"
 
 namespace tvm {
 

--- a/include/tvm/packed_func_ext.h
+++ b/include/tvm/packed_func_ext.h
@@ -12,10 +12,10 @@
 #include <memory>
 #include <type_traits>
 
-#include "./base.h"
-#include "./expr.h"
-#include "./tensor.h"
-#include "./runtime/packed_func.h"
+#include "base.h"
+#include "expr.h"
+#include "tensor.h"
+#include "runtime/packed_func.h"
 
 namespace tvm {
 using runtime::TVMArgs;

--- a/include/tvm/runtime/c_backend_api.h
+++ b/include/tvm/runtime/c_backend_api.h
@@ -10,7 +10,7 @@
 #ifndef TVM_RUNTIME_C_BACKEND_API_H_
 #define TVM_RUNTIME_C_BACKEND_API_H_
 
-#include "./c_runtime_api.h"
+#include "c_runtime_api.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -7,8 +7,8 @@
 #define TVM_RUNTIME_DEVICE_API_H_
 
 #include <string>
-#include "./packed_func.h"
-#include "./c_runtime_api.h"
+#include "packed_func.h"
+#include "c_runtime_api.h"
 
 namespace tvm {
 namespace runtime {

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
-#include "./c_runtime_api.h"
+#include "c_runtime_api.h"
 
 namespace tvm {
 namespace runtime {
@@ -173,5 +173,5 @@ inline const ModuleNode* Module::operator->() const {
 }  // namespace runtime
 }  // namespace tvm
 
-#include "./packed_func.h"
+#include "packed_func.h"
 #endif  // TVM_RUNTIME_MODULE_H_

--- a/include/tvm/runtime/ndarray.h
+++ b/include/tvm/runtime/ndarray.h
@@ -9,8 +9,8 @@
 #include <atomic>
 #include <vector>
 #include <utility>
-#include "./c_runtime_api.h"
-#include "./serializer.h"
+#include "c_runtime_api.h"
+#include "serializer.h"
 
 namespace tvm {
 namespace runtime {

--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -14,9 +14,9 @@
 #include <limits>
 #include <memory>
 #include <type_traits>
-#include "./c_runtime_api.h"
-#include "./module.h"
-#include "./ndarray.h"
+#include "c_runtime_api.h"
+#include "module.h"
+#include "ndarray.h"
 
 namespace HalideIR {
 // Forward declare type for extensions

--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -27,7 +27,7 @@
 
 #include <string>
 #include <vector>
-#include "./packed_func.h"
+#include "packed_func.h"
 
 namespace tvm {
 namespace runtime {

--- a/include/tvm/runtime/serializer.h
+++ b/include/tvm/runtime/serializer.h
@@ -9,8 +9,8 @@
 
 #include <dmlc/io.h>
 #include <dmlc/serializer.h>
-#include "./c_runtime_api.h"
-#include "./ndarray.h"
+#include "c_runtime_api.h"
+#include "ndarray.h"
 
 namespace dmlc {
 namespace serializer {

--- a/include/tvm/runtime/util.h
+++ b/include/tvm/runtime/util.h
@@ -6,7 +6,7 @@
 #ifndef TVM_RUNTIME_UTIL_H_
 #define TVM_RUNTIME_UTIL_H_
 
-#include "./c_runtime_api.h"
+#include "c_runtime_api.h"
 
 namespace tvm {
 namespace runtime {

--- a/include/tvm/schedule.h
+++ b/include/tvm/schedule.h
@@ -7,10 +7,10 @@
 #define TVM_SCHEDULE_H_
 
 #include <string>
-#include "./base.h"
-#include "./expr.h"
-#include "./tensor.h"
-#include "./tensor_intrin.h"
+#include "base.h"
+#include "expr.h"
+#include "tensor.h"
+#include "tensor_intrin.h"
 
 namespace tvm {
 

--- a/include/tvm/schedule_pass.h
+++ b/include/tvm/schedule_pass.h
@@ -10,8 +10,8 @@
 #ifndef TVM_SCHEDULE_PASS_H_
 #define TVM_SCHEDULE_PASS_H_
 
-#include "./base.h"
-#include "./schedule.h"
+#include "base.h"
+#include "schedule.h"
 
 namespace tvm {
 namespace schedule {

--- a/include/tvm/target_info.h
+++ b/include/tvm/target_info.h
@@ -7,8 +7,8 @@
 #define TVM_TARGET_INFO_H_
 
 #include <string>
-#include "./base.h"
-#include "./expr.h"
+#include "base.h"
+#include "expr.h"
 
 namespace tvm {
 

--- a/include/tvm/tensor.h
+++ b/include/tvm/tensor.h
@@ -12,9 +12,9 @@
 #include <vector>
 #include <type_traits>
 
-#include "./base.h"
-#include "./expr.h"
-#include "./arithmetic.h"
+#include "base.h"
+#include "expr.h"
+#include "arithmetic.h"
 
 namespace tvm {
 

--- a/include/tvm/tensor_intrin.h
+++ b/include/tvm/tensor_intrin.h
@@ -7,8 +7,8 @@
 #define TVM_TENSOR_INTRIN_H_
 
 #include <string>
-#include "./tensor.h"
-#include "./buffer.h"
+#include "tensor.h"
+#include "buffer.h"
 
 namespace tvm {
 

--- a/include/tvm/tvm.h
+++ b/include/tvm/tvm.h
@@ -6,11 +6,11 @@
 #ifndef TVM_TVM_H_
 #define TVM_TVM_H_
 
-#include "./base.h"
-#include "./expr.h"
-#include "./ir_operator.h"
-#include "./tensor.h"
-#include "./operation.h"
-#include "./packed_func_ext.h"
+#include "base.h"
+#include "expr.h"
+#include "ir_operator.h"
+#include "tensor.h"
+#include "operation.h"
+#include "packed_func_ext.h"
 
 #endif  // TVM_TVM_H_

--- a/nnvm/include/nnvm/graph.h
+++ b/nnvm/include/nnvm/graph.h
@@ -12,9 +12,9 @@
 #include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
-#include "./base.h"
-#include "./node.h"
-#include "./symbolic.h"
+#include "base.h"
+#include "node.h"
+#include "symbolic.h"
 
 namespace nnvm {
 

--- a/nnvm/include/nnvm/graph_attr_types.h
+++ b/nnvm/include/nnvm/graph_attr_types.h
@@ -8,8 +8,8 @@
 
 #include <vector>
 #include <string>
-#include "./tuple.h"
-#include "./layout.h"
+#include "tuple.h"
+#include "layout.h"
 
 namespace nnvm {
 

--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -10,9 +10,9 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include "./base.h"
-#include "./op.h"
-#include "./c_api.h"
+#include "base.h"
+#include "op.h"
+#include "c_api.h"
 
 namespace nnvm {
 

--- a/nnvm/include/nnvm/op.h
+++ b/nnvm/include/nnvm/op.h
@@ -13,8 +13,8 @@
 #include <typeinfo>
 #include <limits>
 #include <functional>
-#include "./base.h"
-#include "./c_api.h"
+#include "base.h"
+#include "c_api.h"
 
 namespace nnvm {
 

--- a/nnvm/include/nnvm/op_attr_types.h
+++ b/nnvm/include/nnvm/op_attr_types.h
@@ -10,10 +10,10 @@
 #include <string>
 #include <utility>
 #include <functional>
-#include "./base.h"
-#include "./node.h"
-#include "./tuple.h"
-#include "./layout.h"
+#include "base.h"
+#include "node.h"
+#include "tuple.h"
+#include "layout.h"
 
 namespace nnvm {
 

--- a/nnvm/include/nnvm/pass.h
+++ b/nnvm/include/nnvm/pass.h
@@ -8,8 +8,8 @@
 
 #include <vector>
 #include <functional>
-#include "./base.h"
-#include "./graph.h"
+#include "base.h"
+#include "graph.h"
 
 namespace nnvm {
 

--- a/nnvm/include/nnvm/pass_functions.h
+++ b/nnvm/include/nnvm/pass_functions.h
@@ -13,9 +13,9 @@
 #include <string>
 #include <memory>
 #include <vector>
-#include "./base.h"
-#include "./pass.h"
-#include "./graph_attr_types.h"
+#include "base.h"
+#include "pass.h"
+#include "graph_attr_types.h"
 
 namespace nnvm {
 namespace pass {

--- a/nnvm/include/nnvm/symbolic.h
+++ b/nnvm/include/nnvm/symbolic.h
@@ -15,8 +15,8 @@
 #include <tuple>
 #include <utility>
 
-#include "./base.h"
-#include "./node.h"
+#include "base.h"
+#include "node.h"
 
 namespace nnvm {
 /*!

--- a/nnvm/include/nnvm/top/nn.h
+++ b/nnvm/include/nnvm/top/nn.h
@@ -11,7 +11,7 @@
 #include <nnvm/tuple.h>
 #include <nnvm/layout.h>
 #include <string>
-#include "./tensor.h"
+#include "tensor.h"
 
 namespace nnvm {
 namespace top {

--- a/nnvm/include/nnvm/tuple.h
+++ b/nnvm/include/nnvm/tuple.h
@@ -12,7 +12,7 @@
 #include <utility>
 #include <iostream>
 #include <string>
-#include "./base.h"
+#include "base.h"
 
 namespace nnvm {
 

--- a/nnvm/src/c_api/c_api_error.cc
+++ b/nnvm/src/c_api/c_api_error.cc
@@ -4,7 +4,7 @@
  * \brief C error handling
  */
 #include <dmlc/thread_local.h>
-#include "./c_api_common.h"
+#include "c_api_common.h"
 
 struct ErrorEntry {
   std::string last_error;

--- a/nnvm/src/c_api/c_api_graph.cc
+++ b/nnvm/src/c_api/c_api_graph.cc
@@ -9,7 +9,7 @@
 #include <nnvm/graph.h>
 #include <nnvm/pass.h>
 #include <dmlc/json.h>
-#include "./c_api_common.h"
+#include "c_api_common.h"
 
 using namespace nnvm;
 

--- a/nnvm/src/c_api/c_api_symbolic.cc
+++ b/nnvm/src/c_api/c_api_symbolic.cc
@@ -6,7 +6,7 @@
 #include <nnvm/c_api.h>
 #include <nnvm/op.h>
 #include <nnvm/symbolic.h>
-#include "./c_api_common.h"
+#include "c_api_common.h"
 
 using namespace nnvm;
 

--- a/nnvm/src/compiler/alter_op_layout.cc
+++ b/nnvm/src/compiler/alter_op_layout.cc
@@ -12,8 +12,8 @@
 #include <tvm/tvm.h>
 #include <algorithm>
 #include <functional>
-#include "./compile_engine.h"
-#include "./graph_transform.h"
+#include "compile_engine.h"
+#include "graph_transform.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/compile_engine.cc
+++ b/nnvm/src/compiler/compile_engine.cc
@@ -11,6 +11,9 @@
 #include <nnvm/pass_functions.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <mutex>
+#include <tuple>
+#include <vector>
+#include <limits>
 #include "graph_hash.h"
 #include "compile_engine.h"
 

--- a/nnvm/src/compiler/compile_engine.cc
+++ b/nnvm/src/compiler/compile_engine.cc
@@ -11,8 +11,8 @@
 #include <nnvm/pass_functions.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <mutex>
-#include "./graph_hash.h"
-#include "./compile_engine.h"
+#include "graph_hash.h"
+#include "compile_engine.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/compile_engine.h
+++ b/nnvm/src/compiler/compile_engine.h
@@ -18,7 +18,7 @@
 #include <tvm/lowered_func.h>
 #include <string>
 #include <utility>
-#include "./graph_hash.h"
+#include "graph_hash.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/fold_scale_axis.cc
+++ b/nnvm/src/compiler/fold_scale_axis.cc
@@ -9,8 +9,8 @@
 #include <nnvm/pass.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <nnvm/top/nn.h>
-#include "./pattern_util.h"
-#include "./graph_transform.h"
+#include "pattern_util.h"
+#include "graph_transform.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -14,6 +14,7 @@
 #include <nnvm/tuple.h>
 #include <tvm/lowered_func.h>
 #include <tvm/runtime/packed_func.h>
+#include <limits>
 
 #include "graph_fuse.h"
 #include "graph_runtime.h"

--- a/nnvm/src/compiler/graph_fuse.cc
+++ b/nnvm/src/compiler/graph_fuse.cc
@@ -15,9 +15,9 @@
 #include <tvm/lowered_func.h>
 #include <tvm/runtime/packed_func.h>
 
-#include "./graph_fuse.h"
-#include "./graph_runtime.h"
-#include "./pattern_util.h"
+#include "graph_fuse.h"
+#include "graph_runtime.h"
+#include "pattern_util.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/graph_hash.cc
+++ b/nnvm/src/compiler/graph_hash.cc
@@ -10,8 +10,8 @@
 #include <tvm/ir.h>
 #include <tvm/runtime/packed_func.h>
 #include <functional>
-#include "./node_attr.h"
-#include "./graph_hash.h"
+#include "node_attr.h"
+#include "graph_hash.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/graph_hash.cc
+++ b/nnvm/src/compiler/graph_hash.cc
@@ -10,6 +10,8 @@
 #include <tvm/ir.h>
 #include <tvm/runtime/packed_func.h>
 #include <functional>
+#include <vector>
+#include <algorithm>
 #include "node_attr.h"
 #include "graph_hash.h"
 

--- a/nnvm/src/compiler/graph_runtime.cc
+++ b/nnvm/src/compiler/graph_runtime.cc
@@ -4,7 +4,7 @@
  * \brief Interface code with TVM graph runtime.
 */
 #include <dmlc/memory_io.h>
-#include "./graph_runtime.h"
+#include "graph_runtime.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/compiler/packed_func_ext.cc
+++ b/nnvm/src/compiler/packed_func_ext.cc
@@ -9,7 +9,7 @@
 #include <nnvm/compiler/packed_func_ext.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <tvm/runtime/c_runtime_api.h>
-#include "./node_attr.h"
+#include "node_attr.h"
 #include "compile_engine.h"
 
 namespace tvm {

--- a/nnvm/src/compiler/simplify_inference.cc
+++ b/nnvm/src/compiler/simplify_inference.cc
@@ -9,8 +9,8 @@
 #include <nnvm/pass.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <nnvm/top/nn.h>
-#include "./graph_transform.h"
-#include "./pattern_util.h"
+#include "graph_transform.h"
+#include "pattern_util.h"
 
 namespace nnvm {
 namespace compiler {

--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -8,7 +8,7 @@
 #include <nnvm/graph_attr_types.h>
 #include <nnvm/op_attr_types.h>
 #include <memory>
-#include "./graph_algorithm.h"
+#include "graph_algorithm.h"
 
 namespace nnvm {
 namespace pass {

--- a/nnvm/src/top/elemwise_op_common.h
+++ b/nnvm/src/top/elemwise_op_common.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include <utility>
 #include <functional>
-#include "./op_common.h"
+#include "op_common.h"
 
 namespace nnvm {
 namespace top {

--- a/nnvm/src/top/nn/convolution.cc
+++ b/nnvm/src/top/nn/convolution.cc
@@ -12,7 +12,7 @@
 #include <tvm/packed_func_ext.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <tvm/tvm.h>
-#include "./nn_common.h"
+#include "nn_common.h"
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
 #include "topi/nn.h"

--- a/nnvm/src/top/nn/nn.cc
+++ b/nnvm/src/top/nn/nn.cc
@@ -12,7 +12,7 @@
 #include <nnvm/op_attr_types.h>
 #include <nnvm/compiler/op_attr_types.h>
 #include <nnvm/top/nn.h>
-#include "./nn_common.h"
+#include "nn_common.h"
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
 #include "topi/nn/dense.h"

--- a/nnvm/src/top/nn/pooling.cc
+++ b/nnvm/src/top/nn/pooling.cc
@@ -10,7 +10,7 @@
 #include <nnvm/compiler/op_attr_types.h>
 #include <nnvm/compiler/util.h>
 #include <nnvm/top/nn.h>
-#include "./nn_common.h"
+#include "nn_common.h"
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
 #include "topi/nn/pooling.h"

--- a/nnvm/src/top/nn/upsampling.cc
+++ b/nnvm/src/top/nn/upsampling.cc
@@ -11,7 +11,7 @@
 #include <nnvm/node.h>
 #include <nnvm/op_attr_types.h>
 #include <nnvm/top/nn.h>
-#include "./nn_common.h"
+#include "nn_common.h"
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
 #include "topi/elemwise.h"

--- a/src/arithmetic/canonical.cc
+++ b/src/arithmetic/canonical.cc
@@ -6,8 +6,8 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/arithmetic.h>
 #include <tvm/ir_pass.h>
-#include "./canonical.h"
-#include "./compute_expr.h"
+#include "canonical.h"
+#include "compute_expr.h"
 #include "arithmetic/Simplify.h"
 
 namespace tvm {

--- a/src/arithmetic/canonical.cc
+++ b/src/arithmetic/canonical.cc
@@ -6,6 +6,10 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/arithmetic.h>
 #include <tvm/ir_pass.h>
+#include <algorithm>
+#include <map>
+#include <limits>
+#include <vector>
 #include "canonical.h"
 #include "compute_expr.h"
 #include "arithmetic/Simplify.h"

--- a/src/arithmetic/detect_linear_equation.cc
+++ b/src/arithmetic/detect_linear_equation.cc
@@ -8,7 +8,7 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_functor_ext.h>
 #include <tvm/arithmetic.h>
-#include "./compute_expr.h"
+#include "compute_expr.h"
 
 namespace tvm {
 namespace arith {

--- a/src/arithmetic/int_set.cc
+++ b/src/arithmetic/int_set.cc
@@ -9,8 +9,8 @@
 #include <tvm/ir_functor_ext.h>
 #include <arithmetic/Interval.h>
 #include <unordered_map>
-#include "./compute_expr.h"
-#include "./int_set_internal.h"
+#include "compute_expr.h"
+#include "int_set_internal.h"
 
 namespace tvm {
 namespace arith {

--- a/src/arithmetic/modular.cc
+++ b/src/arithmetic/modular.cc
@@ -8,7 +8,7 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/arithmetic.h>
 #include <limits>
-#include "./int_set_internal.h"
+#include "int_set_internal.h"
 
 namespace tvm {
 namespace arith {

--- a/src/codegen/codegen_aocl.cc
+++ b/src/codegen/codegen_aocl.cc
@@ -5,8 +5,8 @@
 #include <tvm/build_module.h>
 #include <vector>
 #include <string>
-#include "./codegen_opencl.h"
-#include "./build_common.h"
+#include "codegen_opencl.h"
+#include "build_common.h"
 #include "../runtime/opencl/aocl/aocl_module.h"
 #include "../runtime/file_util.h"
 

--- a/src/codegen/codegen_c.cc
+++ b/src/codegen/codegen_c.cc
@@ -4,7 +4,7 @@
  */
 #include <iomanip>
 #include <cctype>
-#include "./codegen_c.h"
+#include "codegen_c.h"
 #include "../pass/ir_util.h"
 #include "../arithmetic/compute_expr.h"
 

--- a/src/codegen/codegen_c.h
+++ b/src/codegen/codegen_c.h
@@ -14,7 +14,7 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
-#include "./codegen_source_base.h"
+#include "codegen_source_base.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -7,7 +7,7 @@
 #include <tvm/packed_func_ext.h>
 #include <vector>
 #include <string>
-#include "./codegen_cuda.h"
+#include "codegen_cuda.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/codegen/codegen_cuda.h
+++ b/src/codegen/codegen_cuda.h
@@ -9,7 +9,7 @@
 #include <tvm/codegen.h>
 #include <tvm/packed_func_ext.h>
 #include <string>
-#include "./codegen_c.h"
+#include "codegen_c.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/codegen_metal.cc
+++ b/src/codegen/codegen_metal.cc
@@ -5,6 +5,7 @@
 #include <tvm/packed_func_ext.h>
 #include <vector>
 #include <string>
+#include <algorithm>
 #include "codegen_metal.h"
 #include "build_common.h"
 #include "../runtime/metal/metal_module.h"

--- a/src/codegen/codegen_metal.cc
+++ b/src/codegen/codegen_metal.cc
@@ -5,8 +5,8 @@
 #include <tvm/packed_func_ext.h>
 #include <vector>
 #include <string>
-#include "./codegen_metal.h"
-#include "./build_common.h"
+#include "codegen_metal.h"
+#include "build_common.h"
 #include "../runtime/metal/metal_module.h"
 #include "../runtime/thread_storage_scope.h"
 

--- a/src/codegen/codegen_metal.h
+++ b/src/codegen/codegen_metal.h
@@ -9,7 +9,7 @@
 #include <tvm/codegen.h>
 #include <tvm/packed_func_ext.h>
 #include <string>
-#include "./codegen_c.h"
+#include "codegen_c.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/codegen_opencl.cc
+++ b/src/codegen/codegen_opencl.cc
@@ -5,8 +5,8 @@
 #include <tvm/packed_func_ext.h>
 #include <vector>
 #include <string>
-#include "./codegen_opencl.h"
-#include "./build_common.h"
+#include "codegen_opencl.h"
+#include "build_common.h"
 #include "../runtime/thread_storage_scope.h"
 #include "../runtime/opencl/opencl_module.h"
 

--- a/src/codegen/codegen_opencl.h
+++ b/src/codegen/codegen_opencl.h
@@ -9,7 +9,7 @@
 #include <tvm/codegen.h>
 #include <tvm/packed_func_ext.h>
 #include <string>
-#include "./codegen_c.h"
+#include "codegen_c.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/codegen_opengl.cc
+++ b/src/codegen/codegen_opengl.cc
@@ -8,8 +8,8 @@
 #include <tvm/packed_func_ext.h>
 #include <vector>
 #include <string>
-#include "./codegen_opengl.h"
-#include "./build_common.h"
+#include "codegen_opengl.h"
+#include "build_common.h"
 #include "../runtime/thread_storage_scope.h"
 
 namespace tvm {

--- a/src/codegen/codegen_opengl.h
+++ b/src/codegen/codegen_opengl.h
@@ -9,7 +9,7 @@
 #include <tvm/codegen.h>
 #include <tvm/packed_func_ext.h>
 #include <string>
-#include "./codegen_c.h"
+#include "codegen_c.h"
 #include "../runtime/opengl/opengl_module.h"
 
 namespace tvm {

--- a/src/codegen/codegen_source_base.cc
+++ b/src/codegen/codegen_source_base.cc
@@ -2,7 +2,7 @@
  *  Copyright (c) 2017 by Contributors
  * \file codegen_source_base.cc
  */
-#include "./codegen_source_base.h"
+#include "codegen_source_base.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/codegen_vhls.cc
+++ b/src/codegen/codegen_vhls.cc
@@ -5,8 +5,8 @@
 #include <tvm/build_module.h>
 #include <vector>
 #include <string>
-#include "./codegen_vhls.h"
-#include "./build_common.h"
+#include "codegen_vhls.h"
+#include "build_common.h"
 #include "../runtime/opencl/sdaccel/sdaccel_module.h"
 
 namespace tvm {

--- a/src/codegen/codegen_vhls.h
+++ b/src/codegen/codegen_vhls.h
@@ -9,7 +9,7 @@
 #include <tvm/codegen.h>
 #include <tvm/packed_func_ext.h>
 #include <string>
-#include "./codegen_c.h"
+#include "codegen_c.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/intrin_rule.cc
+++ b/src/codegen/intrin_rule.cc
@@ -3,7 +3,7 @@
  * \file intrin_rule_default.cc
  * \brief Default intrinsic rules.
  */
-#include "./intrin_rule.h"
+#include "intrin_rule.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/intrin_rule_cuda.cc
+++ b/src/codegen/intrin_rule_cuda.cc
@@ -3,7 +3,7 @@
  * \file intrin_rule_cuda.cc
  * \brief CUDA intrinsic rules.
  */
-#include "./intrin_rule.h"
+#include "intrin_rule.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/intrin_rule_metal.cc
+++ b/src/codegen/intrin_rule_metal.cc
@@ -3,7 +3,7 @@
  * \file intrin_rule_metal.cc
  * \brief Metal intrinsic rules.
  */
-#include "./intrin_rule.h"
+#include "intrin_rule.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/intrin_rule_opencl.cc
+++ b/src/codegen/intrin_rule_opencl.cc
@@ -3,7 +3,7 @@
  * \file intrin_rule_opencl.cc
  * \brief OpenCL intrinsic rules.
  */
-#include "./intrin_rule.h"
+#include "intrin_rule.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/intrin_rule_opengl.cc
+++ b/src/codegen/intrin_rule_opengl.cc
@@ -3,7 +3,7 @@
  * \file intrin_rule_opencl.cc
  * \brief OpenCL intrinsic rules.
  */
-#include "./intrin_rule.h"
+#include "intrin_rule.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/intrin_rule_vhls.cc
+++ b/src/codegen/intrin_rule_vhls.cc
@@ -3,7 +3,7 @@
  * \file intrin_rule_vhls.cc
  * \brief VHLS intrinsic rules.
  */
-#include "./intrin_rule.h"
+#include "intrin_rule.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -8,7 +8,7 @@
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/registry.h>
-#include "./codegen_llvm.h"
+#include "codegen_llvm.h"
 #include "../build_common.h"
 #include "../codegen_source_base.h"
 #include "../../pass/ir_util.h"

--- a/src/codegen/llvm/codegen_arm.cc
+++ b/src/codegen/llvm/codegen_arm.cc
@@ -4,7 +4,7 @@
  * \brief ARM specific code generator
  */
 #ifdef TVM_LLVM_VERSION
-#include "./codegen_cpu.h"
+#include "codegen_cpu.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/llvm/codegen_cpu.cc
+++ b/src/codegen/llvm/codegen_cpu.cc
@@ -6,7 +6,7 @@
 
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/ir_pass.h>
-#include "./codegen_cpu.h"
+#include "codegen_cpu.h"
 #include "../../pass/ir_util.h"
 
 namespace tvm {

--- a/src/codegen/llvm/codegen_cpu.h
+++ b/src/codegen/llvm/codegen_cpu.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 #include <string>
-#include "./codegen_llvm.h"
+#include "codegen_llvm.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -7,8 +7,8 @@
 
 #include <tvm/runtime/device_api.h>
 #include <tvm/runtime/c_runtime_api.h>
-#include "./codegen_llvm.h"
-#include "./codegen_cpu.h"
+#include "codegen_llvm.h"
+#include "codegen_cpu.h"
 #include "../codegen_common.h"
 #include "../../pass/ir_util.h"
 #include "../../arithmetic/compute_expr.h"

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -15,7 +15,7 @@
 #include <utility>
 #include <vector>
 #include <string>
-#include "./llvm_common.h"
+#include "llvm_common.h"
 #include "../../runtime/thread_storage_scope.h"
 
 namespace tvm {

--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -6,7 +6,7 @@
 #ifdef TVM_LLVM_VERSION
 
 #include <tvm/runtime/device_api.h>
-#include "./codegen_llvm.h"
+#include "codegen_llvm.h"
 #include "../build_common.h"
 #include "../../pass/ir_util.h"
 #include "../../runtime/cuda/cuda_module.h"

--- a/src/codegen/llvm/intrin_rule_llvm.cc
+++ b/src/codegen/llvm/intrin_rule_llvm.cc
@@ -4,7 +4,7 @@
  */
 #ifdef TVM_LLVM_VERSION
 
-#include "./intrin_rule_llvm.h"
+#include "intrin_rule_llvm.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/llvm/intrin_rule_llvm.h
+++ b/src/codegen/llvm/intrin_rule_llvm.h
@@ -11,7 +11,7 @@
 #include <tvm/api_registry.h>
 #include <tvm/codegen.h>
 #include <string>
-#include "./llvm_common.h"
+#include "llvm_common.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/llvm/intrin_rule_rocm.cc
+++ b/src/codegen/llvm/intrin_rule_rocm.cc
@@ -4,7 +4,7 @@
  */
 #ifdef TVM_LLVM_VERSION
 
-#include "./intrin_rule_llvm.h"
+#include "intrin_rule_llvm.h"
 #include <tvm/ir.h>
 #include <tvm/expr.h>
 #include <tvm/api_registry.h>

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -6,7 +6,7 @@
 
 #include <tvm/base.h>
 #include <mutex>
-#include "./llvm_common.h"
+#include "llvm_common.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/llvm/llvm_module.cc
+++ b/src/codegen/llvm/llvm_module.cc
@@ -7,8 +7,8 @@
 #include <tvm/runtime/packed_func.h>
 #include <tvm/codegen.h>
 #include <mutex>
-#include "./llvm_common.h"
-#include "./codegen_llvm.h"
+#include "llvm_common.h"
+#include "codegen_llvm.h"
 #include "../../runtime/file_util.h"
 #include "../../runtime/module_util.h"
 

--- a/src/codegen/source_module.cc
+++ b/src/codegen/source_module.cc
@@ -4,7 +4,7 @@
  * \brief Source code module, only for viewing
  */
 #include <tvm/runtime/packed_func.h>
-#include "./codegen_source_base.h"
+#include "codegen_source_base.h"
 #include "../runtime/file_util.h"
 #include "../runtime/meta_data.h"
 

--- a/src/codegen/spirv/build_vulkan.cc
+++ b/src/codegen/spirv/build_vulkan.cc
@@ -8,7 +8,7 @@
 #include <dmlc/memory_io.h>
 #include <tvm/ir_pass.h>
 
-#include "./codegen_spirv.h"
+#include "codegen_spirv.h"
 #include "../build_common.h"
 #include "../../runtime/vulkan/vulkan_module.h"
 

--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -5,6 +5,7 @@
  */
 #include <tvm/ir.h>
 #include <tvm/ir_pass.h>
+#include <string>
 #include "../codegen_common.h"
 #include "codegen_spirv.h"
 

--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -6,7 +6,7 @@
 #include <tvm/ir.h>
 #include <tvm/ir_pass.h>
 #include "../codegen_common.h"
-#include "./codegen_spirv.h"
+#include "codegen_spirv.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/spirv/codegen_spirv.h
+++ b/src/codegen/spirv/codegen_spirv.h
@@ -12,7 +12,7 @@
 
 #include <vector>
 
-#include "./ir_builder.h"
+#include "ir_builder.h"
 #include "../../runtime/thread_storage_scope.h"
 
 namespace tvm {

--- a/src/codegen/spirv/ir_builder.cc
+++ b/src/codegen/spirv/ir_builder.cc
@@ -3,7 +3,7 @@
  * \file ir_builder.cc
  * \brief IRBuilder for SPIRV block
  */
-#include "./ir_builder.h"
+#include "ir_builder.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/stackvm/codegen_stackvm.cc
+++ b/src/codegen/stackvm/codegen_stackvm.cc
@@ -5,7 +5,7 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/packed_func_ext.h>
 #include <limits>
-#include "./codegen_stackvm.h"
+#include "codegen_stackvm.h"
 #include "../../runtime/stackvm/stackvm_module.h"
 
 namespace tvm {

--- a/src/codegen/verilog/codegen_verilog.cc
+++ b/src/codegen/verilog/codegen_verilog.cc
@@ -6,7 +6,7 @@
 #include <cctype>
 #include <sstream>
 #include <iostream>
-#include "./codegen_verilog.h"
+#include "codegen_verilog.h"
 #include "../../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/codegen/verilog/codegen_verilog.h
+++ b/src/codegen/verilog/codegen_verilog.h
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include "./verilog_ir.h"
+#include "verilog_ir.h"
 #include "../codegen_source_base.h"
 
 namespace tvm {

--- a/src/codegen/verilog/verilog_ir.cc
+++ b/src/codegen/verilog/verilog_ir.cc
@@ -5,6 +5,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_mutator.h>
+#include <utility>
 #include "verilog_ir.h"
 #include "../../arithmetic/compute_expr.h"
 

--- a/src/codegen/verilog/verilog_ir.cc
+++ b/src/codegen/verilog/verilog_ir.cc
@@ -5,7 +5,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_mutator.h>
-#include "./verilog_ir.h"
+#include "verilog_ir.h"
 #include "../../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/codegen/verilog/verilog_module.cc
+++ b/src/codegen/verilog/verilog_module.cc
@@ -6,7 +6,7 @@
 #include <tvm/runtime/packed_func.h>
 #include <tvm/codegen.h>
 #include <mutex>
-#include "./codegen_verilog.h"
+#include "codegen_verilog.h"
 #include "../../runtime/file_util.h"
 #include "../../runtime/meta_data.h"
 

--- a/src/codegen/verilog/vpi_device_api.cc
+++ b/src/codegen/verilog/vpi_device_api.cc
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #include <map>
 #include <queue>
-#include "./vpi_session.h"
+#include "vpi_session.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/codegen/verilog/vpi_session.cc
+++ b/src/codegen/verilog/vpi_session.cc
@@ -4,7 +4,7 @@
  * \brief IPC session call to verilog simulator via VPI.
  */
 #include <tvm/api_registry.h>
-#include "./vpi_session.h"
+#include "vpi_session.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/contrib/nnpack/convolution.cc
+++ b/src/contrib/nnpack/convolution.cc
@@ -6,7 +6,7 @@
 #include <tvm/runtime/util.h>
 #include <dmlc/logging.h>
 #include <nnpack.h>
-#include "./nnpack_utils.h"
+#include "nnpack_utils.h"
 
 namespace tvm {
 namespace contrib {

--- a/src/contrib/nnpack/fully_connected.cc
+++ b/src/contrib/nnpack/fully_connected.cc
@@ -6,7 +6,7 @@
 #include <tvm/runtime/util.h>
 #include <dmlc/logging.h>
 #include <nnpack.h>
-#include "./nnpack_utils.h"
+#include "nnpack_utils.h"
 
 namespace tvm {
 namespace contrib {

--- a/src/contrib/nnpack/nnpack_utils.cc
+++ b/src/contrib/nnpack/nnpack_utils.cc
@@ -2,7 +2,7 @@
  *  Copyright (c) 2017 by Contributors
  * \file Use external nnpack library call.
  */
-#include "./nnpack_utils.h"
+#include "nnpack_utils.h"
 
 namespace tvm {
 namespace contrib {

--- a/src/contrib/random/random.cc
+++ b/src/contrib/random/random.cc
@@ -8,9 +8,9 @@
 #include <dmlc/thread_local.h>
 #include <algorithm>
 #ifndef _LIBCPP_SGX_CONFIG
-#include "./mt_random_engine.cc"
+#include "mt_random_engine.cc"
 #else
-#include "./sgx_random_engine.cc"
+#include "sgx_random_engine.cc"
 #endif
 
 #define DLPACK_INTEGER_TYPE_SWITCH(type, DType, ...)    \

--- a/src/op/compute_op.cc
+++ b/src/op/compute_op.cc
@@ -9,6 +9,7 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_pass.h>
 #include <unordered_set>
+#include <string>
 #include "compute_op.h"
 #include "op_util.h"
 #include "../schedule/message_passing.h"

--- a/src/op/compute_op.cc
+++ b/src/op/compute_op.cc
@@ -9,8 +9,8 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_pass.h>
 #include <unordered_set>
-#include "./compute_op.h"
-#include "./op_util.h"
+#include "compute_op.h"
+#include "op_util.h"
 #include "../schedule/message_passing.h"
 
 namespace tvm {

--- a/src/op/cross_thread_reduction.cc
+++ b/src/op/cross_thread_reduction.cc
@@ -4,8 +4,8 @@
  * \file cross_thread_reduction.cc
  */
 #include <tvm/ir_pass.h>
-#include "./compute_op.h"
-#include "./op_util.h"
+#include "compute_op.h"
+#include "op_util.h"
 
 namespace tvm {
 using namespace ir;

--- a/src/op/extern_op.cc
+++ b/src/op/extern_op.cc
@@ -7,7 +7,7 @@
 #include <tvm/arithmetic.h>
 #include <tvm/ir.h>
 #include <unordered_set>
-#include "./op_util.h"
+#include "op_util.h"
 
 namespace tvm {
 using namespace ir;

--- a/src/op/op_util.cc
+++ b/src/op/op_util.cc
@@ -7,6 +7,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/operation.h>
 #include <tvm/ir_mutator.h>
+#include <string>
 #include "op_util.h"
 #include "../schedule/message_passing.h"
 #include "../arithmetic/compute_expr.h"

--- a/src/op/op_util.cc
+++ b/src/op/op_util.cc
@@ -7,7 +7,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/operation.h>
 #include <tvm/ir_mutator.h>
-#include "./op_util.h"
+#include "op_util.h"
 #include "../schedule/message_passing.h"
 #include "../arithmetic/compute_expr.h"
 

--- a/src/op/scan_op.cc
+++ b/src/op/scan_op.cc
@@ -6,7 +6,7 @@
 #include <tvm/operation.h>
 #include <tvm/ir.h>
 #include <tvm/ir_pass.h>
-#include "./op_util.h"
+#include "op_util.h"
 #include "../schedule/graph.h"
 
 namespace tvm {

--- a/src/op/tensorize.cc
+++ b/src/op/tensorize.cc
@@ -7,8 +7,8 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/ir_pass.h>
 #include <tvm/api_registry.h>
-#include "./op_util.h"
-#include "./compute_op.h"
+#include "op_util.h"
+#include "compute_op.h"
 #include "../schedule/message_passing.h"
 #include "../arithmetic/compute_expr.h"
 

--- a/src/pass/arg_binder.cc
+++ b/src/pass/arg_binder.cc
@@ -6,8 +6,8 @@
 #include <tvm/ir.h>
 #include <tvm/ir_pass.h>
 #include <tvm/runtime/device_api.h>
-#include "./ir_util.h"
-#include "./arg_binder.h"
+#include "ir_util.h"
+#include "arg_binder.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/pass/coproc_sync.cc
+++ b/src/pass/coproc_sync.cc
@@ -8,8 +8,8 @@
 #include <tvm/ir_visitor.h>
 #include <unordered_map>
 #include <unordered_set>
-#include "./ir_util.h"
-#include "./storage_access.h"
+#include "ir_util.h"
+#include "storage_access.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/inject_double_buffer.cc
+++ b/src/pass/inject_double_buffer.cc
@@ -7,7 +7,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_mutator.h>
-#include "./ir_util.h"
+#include "ir_util.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/pass/ir_mutator.cc
+++ b/src/pass/ir_mutator.cc
@@ -5,7 +5,7 @@
 #include <tvm/ir.h>
 #include <tvm/ir_mutator.h>
 #include <tvm/packed_func_ext.h>
-#include "./ir_util.h"
+#include "ir_util.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/ir_util.cc
+++ b/src/pass/ir_util.cc
@@ -3,7 +3,7 @@
  * \file ir_util.cc
  * \brief Helper functions to construct and compose IR nodes.
  */
-#include "./ir_util.h"
+#include "ir_util.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/lift_attr_scope.cc
+++ b/src/pass/lift_attr_scope.cc
@@ -7,7 +7,7 @@
  */
 #include <tvm/ir_pass.h>
 #include <tvm/ir_mutator.h>
-#include "./ir_util.h"
+#include "ir_util.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/lower_intrin.cc
+++ b/src/pass/lower_intrin.cc
@@ -8,7 +8,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/api_registry.h>
 #include <unordered_set>
-#include "./ir_util.h"
+#include "ir_util.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/lower_thread_allreduce.cc
+++ b/src/pass/lower_thread_allreduce.cc
@@ -7,7 +7,7 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/ir_pass.h>
 #include <unordered_set>
-#include "./ir_util.h"
+#include "ir_util.h"
 #include "../arithmetic/compute_expr.h"
 #include "../runtime/thread_storage_scope.h"
 

--- a/src/pass/lower_tvm_builtin.cc
+++ b/src/pass/lower_tvm_builtin.cc
@@ -7,7 +7,7 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/ir_pass.h>
 #include <unordered_set>
-#include "./ir_util.h"
+#include "ir_util.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/pass/lower_warp_memory.cc
+++ b/src/pass/lower_warp_memory.cc
@@ -13,7 +13,7 @@
 #include <tvm/ir_visitor.h>
 #include <tvm/ir_pass.h>
 #include <unordered_set>
-#include "./ir_util.h"
+#include "ir_util.h"
 #include "../arithmetic/compute_expr.h"
 #include "../runtime/thread_storage_scope.h"
 

--- a/src/pass/make_api.cc
+++ b/src/pass/make_api.cc
@@ -12,8 +12,8 @@
 #include <utility>
 #include <unordered_set>
 
-#include "./ir_util.h"
-#include "./arg_binder.h"
+#include "ir_util.h"
+#include "arg_binder.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/pass/narrow_channel_access.cc
+++ b/src/pass/narrow_channel_access.cc
@@ -11,7 +11,7 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/arithmetic.h>
 #include <tvm/channel.h>
-#include "./ir_util.h"
+#include "ir_util.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/split_pipeline.cc
+++ b/src/pass/split_pipeline.cc
@@ -11,7 +11,7 @@
 #include <tvm/channel.h>
 #include <unordered_map>
 #include <unordered_set>
-#include "./ir_util.h"
+#include "ir_util.h"
 
 namespace tvm {
 namespace ir {

--- a/src/pass/storage_access.cc
+++ b/src/pass/storage_access.cc
@@ -5,8 +5,8 @@
 #include <tvm/ir_pass.h>
 #include <tvm/ir_mutator.h>
 #include <tvm/target_info.h>
-#include "./ir_util.h"
-#include "./storage_access.h"
+#include "ir_util.h"
+#include "storage_access.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/pass/storage_access.cc
+++ b/src/pass/storage_access.cc
@@ -5,6 +5,7 @@
 #include <tvm/ir_pass.h>
 #include <tvm/ir_mutator.h>
 #include <tvm/target_info.h>
+#include <string>
 #include "ir_util.h"
 #include "storage_access.h"
 #include "../arithmetic/compute_expr.h"

--- a/src/pass/storage_flatten.cc
+++ b/src/pass/storage_flatten.cc
@@ -14,8 +14,8 @@
 #include <tvm/target_info.h>
 #include <tvm/runtime/device_api.h>
 #include <unordered_map>
-#include "./ir_util.h"
-#include "./arg_binder.h"
+#include "ir_util.h"
+#include "arg_binder.h"
 #include "../arithmetic/compute_expr.h"
 #include "../runtime/thread_storage_scope.h"
 

--- a/src/pass/storage_rewrite.cc
+++ b/src/pass/storage_rewrite.cc
@@ -12,7 +12,7 @@
 #include <map>
 #include <unordered_set>
 #include <unordered_map>
-#include "./ir_util.h"
+#include "ir_util.h"
 #include "../arithmetic/compute_expr.h"
 #include "../runtime/thread_storage_scope.h"
 

--- a/src/pass/storage_sync.cc
+++ b/src/pass/storage_sync.cc
@@ -8,8 +8,8 @@
 #include <tvm/ir_visitor.h>
 #include <unordered_map>
 #include <unordered_set>
-#include "./ir_util.h"
-#include "./storage_access.h"
+#include "ir_util.h"
+#include "storage_access.h"
 #include "../runtime/thread_storage_scope.h"
 
 namespace tvm {

--- a/src/runtime/c_dsl_api.cc
+++ b/src/runtime/c_dsl_api.cc
@@ -5,8 +5,8 @@
  */
 #include <tvm/runtime/registry.h>
 #include <tvm/c_dsl_api.h>
-#include "./dsl_api.h"
-#include "./runtime_base.h"
+#include "dsl_api.h"
+#include "runtime_base.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <string>
 #include <cstdlib>
-#include "./runtime_base.h"
+#include "runtime_base.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/cpu_device_api.cc
+++ b/src/runtime/cpu_device_api.cc
@@ -8,7 +8,7 @@
 #include <tvm/runtime/device_api.h>
 #include <cstdlib>
 #include <cstring>
-#include "./workspace_pool.h"
+#include "workspace_pool.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -8,7 +8,7 @@
 #include <dmlc/thread_local.h>
 #include <tvm/runtime/registry.h>
 #include <cuda_runtime.h>
-#include "./cuda_common.h"
+#include "cuda_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/cuda/cuda_module.cc
+++ b/src/runtime/cuda/cuda_module.cc
@@ -2,7 +2,7 @@
  *  Copyright (c) 2017 by Contributors
  * \file cuda_module.cc
  */
-#include "./cuda_module.h"
+#include "cuda_module.h"
 
 #include <tvm/runtime/registry.h>
 #include <cuda.h>
@@ -11,7 +11,7 @@
 #include <array>
 #include <string>
 #include <mutex>
-#include "./cuda_common.h"
+#include "cuda_common.h"
 #include "../pack_args.h"
 #include "../thread_storage_scope.h"
 #include "../meta_data.h"

--- a/src/runtime/dso_module.cc
+++ b/src/runtime/dso_module.cc
@@ -6,7 +6,7 @@
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/packed_func.h>
-#include "./module_util.h"
+#include "module_util.h"
 
 #if defined(_WIN32)
 #include <windows.h>

--- a/src/runtime/file_util.cc
+++ b/src/runtime/file_util.cc
@@ -7,7 +7,7 @@
 #include <tvm/runtime/serializer.h>
 #include <fstream>
 
-#include "./file_util.h"
+#include "file_util.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/file_util.cc
+++ b/src/runtime/file_util.cc
@@ -6,6 +6,7 @@
 #include <dmlc/logging.h>
 #include <tvm/runtime/serializer.h>
 #include <fstream>
+#include <vector>
 
 #include "file_util.h"
 

--- a/src/runtime/file_util.h
+++ b/src/runtime/file_util.h
@@ -7,7 +7,7 @@
 #define TVM_RUNTIME_FILE_UTIL_H_
 
 #include <string>
-#include "./meta_data.h"
+#include "meta_data.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -8,6 +8,9 @@
 #include <dmlc/memory_io.h>
 #include <dmlc/json.h>
 #include <numeric>
+#include <algorithm>
+#include <vector>
+#include <functional>
 #include "graph_runtime.h"
 
 namespace tvm {

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -8,7 +8,7 @@
 #include <dmlc/memory_io.h>
 #include <dmlc/json.h>
 #include <numeric>
-#include "./graph_runtime.h"
+#include "graph_runtime.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/meta_data.h
+++ b/src/runtime/meta_data.h
@@ -11,7 +11,7 @@
 #include <tvm/runtime/packed_func.h>
 #include <string>
 #include <vector>
-#include "./runtime_base.h"
+#include "runtime_base.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/metal/metal_device_api.mm
+++ b/src/runtime/metal/metal_device_api.mm
@@ -4,7 +4,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <dmlc/thread_local.h>
-#include "./metal_common.h"
+#include "metal_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/metal/metal_module.mm
+++ b/src/runtime/metal/metal_module.mm
@@ -8,8 +8,8 @@
 #include <array>
 #include <string>
 #include <mutex>
-#include "./metal_module.h"
-#include "./metal_common.h"
+#include "metal_module.h"
+#include "metal_common.h"
 #include "../pack_args.h"
 #include "../thread_storage_scope.h"
 #include "../meta_data.h"

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -9,7 +9,7 @@
 #include <unordered_set>
 #include <cstring>
 #ifndef _LIBCPP_SGX_CONFIG
-#include "./file_util.h"
+#include "file_util.h"
 #endif
 
 namespace tvm {

--- a/src/runtime/module_util.cc
+++ b/src/runtime/module_util.cc
@@ -8,6 +8,7 @@
 #endif
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/registry.h>
+#include <string>
 #include "module_util.h"
 
 namespace tvm {

--- a/src/runtime/module_util.cc
+++ b/src/runtime/module_util.cc
@@ -8,7 +8,7 @@
 #endif
 #include <tvm/runtime/module.h>
 #include <tvm/runtime/registry.h>
-#include "./module_util.h"
+#include "module_util.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -7,7 +7,7 @@
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/c_runtime_api.h>
 #include <tvm/runtime/device_api.h>
-#include "./runtime_base.h"
+#include "runtime_base.h"
 
 // deleter for arrays used by DLPack exporter
 extern "C" void NDArrayDLPackDeleter(DLManagedTensor* tensor);

--- a/src/runtime/opencl/aocl/aocl_device_api.cc
+++ b/src/runtime/opencl/aocl/aocl_device_api.cc
@@ -4,7 +4,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <dmlc/thread_local.h>
-#include "./aocl_common.h"
+#include "aocl_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opencl/aocl/aocl_module.cc
+++ b/src/runtime/opencl/aocl/aocl_module.cc
@@ -7,8 +7,8 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
-#include "./aocl_common.h"
-#include "./aocl_module.h"
+#include "aocl_common.h"
+#include "aocl_module.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -4,7 +4,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <dmlc/thread_local.h>
-#include "./opencl_common.h"
+#include "opencl_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opencl/opencl_module.cc
+++ b/src/runtime/opencl/opencl_module.cc
@@ -7,8 +7,8 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
-#include "./opencl_common.h"
-#include "./opencl_module.h"
+#include "opencl_common.h"
+#include "opencl_module.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opencl/sdaccel/sdaccel_device_api.cc
+++ b/src/runtime/opencl/sdaccel/sdaccel_device_api.cc
@@ -4,7 +4,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <dmlc/thread_local.h>
-#include "./sdaccel_common.h"
+#include "sdaccel_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opencl/sdaccel/sdaccel_module.cc
+++ b/src/runtime/opencl/sdaccel/sdaccel_module.cc
@@ -7,8 +7,8 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
-#include "./sdaccel_common.h"
-#include "./sdaccel_module.h"
+#include "sdaccel_common.h"
+#include "sdaccel_module.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opengl/opengl_device_api.cc
+++ b/src/runtime/opengl/opengl_device_api.cc
@@ -4,8 +4,8 @@
  */
 #include <tvm/runtime/registry.h>
 #include <cstring>
-#include "./opengl_common.h"
-#include "./opengl_module.h"
+#include "opengl_common.h"
+#include "opengl_module.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/opengl/opengl_module.cc
+++ b/src/runtime/opengl/opengl_module.cc
@@ -4,8 +4,8 @@
  */
 #include <tvm/runtime/registry.h>
 #include <utility>
-#include "./opengl_common.h"
-#include "./opengl_module.h"
+#include "opengl_common.h"
+#include "opengl_module.h"
 #include "../pack_args.h"
 #include "../thread_storage_scope.h"
 #include "../file_util.h"

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -10,7 +10,7 @@
 #include <mutex>
 #include <memory>
 #include <array>
-#include "./runtime_base.h"
+#include "runtime_base.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/rocm/rocm_device_api.cc
+++ b/src/runtime/rocm/rocm_device_api.cc
@@ -10,7 +10,7 @@
 #include <tvm/runtime/registry.h>
 #include <hip/hip_runtime_api.h>
 #include <hsa/hsa.h>
-#include "./rocm_common.h"
+#include "rocm_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -8,8 +8,8 @@
 #include <array>
 #include <string>
 #include <mutex>
-#include "./rocm_module.h"
-#include "./rocm_common.h"
+#include "rocm_module.h"
+#include "rocm_common.h"
 #include "../pack_args.h"
 #include "../thread_storage_scope.h"
 #include "../meta_data.h"

--- a/src/runtime/rpc/rpc_device_api.cc
+++ b/src/runtime/rpc/rpc_device_api.cc
@@ -5,7 +5,7 @@
 #include <dmlc/logging.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/device_api.h>
-#include "./rpc_session.h"
+#include "rpc_session.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/rpc/rpc_event_impl.cc
+++ b/src/runtime/rpc/rpc_event_impl.cc
@@ -5,7 +5,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <memory>
-#include "./rpc_session.h"
+#include "rpc_session.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/rpc/rpc_module.cc
+++ b/src/runtime/rpc/rpc_module.cc
@@ -6,7 +6,7 @@
 #include <tvm/runtime/registry.h>
 #include <memory>
 #include <cstring>
-#include "./rpc_session.h"
+#include "rpc_session.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -11,7 +11,7 @@
 #include <array>
 #include <string>
 #include <chrono>
-#include "./rpc_session.h"
+#include "rpc_session.h"
 #include "../../common/ring_buffer.h"
 
 namespace tvm {

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -11,6 +11,8 @@
 #include <array>
 #include <string>
 #include <chrono>
+#include <vector>
+#include <utility>
 #include "rpc_session.h"
 #include "../../common/ring_buffer.h"
 

--- a/src/runtime/rpc/rpc_socket_impl.cc
+++ b/src/runtime/rpc/rpc_socket_impl.cc
@@ -5,7 +5,7 @@
  */
 #include <tvm/runtime/registry.h>
 #include <memory>
-#include "./rpc_session.h"
+#include "rpc_session.h"
 #include "../../common/socket.h"
 
 namespace tvm {

--- a/src/runtime/sgx/trusted/runtime.cc
+++ b/src/runtime/sgx/trusted/runtime.cc
@@ -12,9 +12,9 @@
 #include "../../system_lib_module.cc"
 #include "../../thread_pool.cc"
 #include "../../workspace_pool.cc"
-#include "./ecall_registry.h"
-#include "./runtime.h"
-#include "./threading_backend.cc"
+#include "ecall_registry.h"
+#include "runtime.h"
+#include "threading_backend.cc"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/stackvm/stackvm.cc
+++ b/src/runtime/stackvm/stackvm.cc
@@ -7,7 +7,7 @@
 #include <tvm/runtime/util.h>
 #include <tvm/runtime/c_backend_api.h>
 #include <algorithm>
-#include "./stackvm.h"
+#include "stackvm.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/stackvm/stackvm_module.cc
+++ b/src/runtime/stackvm/stackvm_module.cc
@@ -5,7 +5,7 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/module.h>
 #include <dmlc/memory_io.h>
-#include "./stackvm_module.h"
+#include "stackvm_module.h"
 #include "../file_util.h"
 #include "../module_util.h"
 

--- a/src/runtime/stackvm/stackvm_module.h
+++ b/src/runtime/stackvm/stackvm_module.h
@@ -8,7 +8,7 @@
 
 #include <tvm/runtime/packed_func.h>
 #include <string>
-#include "./stackvm.h"
+#include "stackvm.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/system_lib_module.cc
+++ b/src/runtime/system_lib_module.cc
@@ -6,7 +6,7 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/c_backend_api.h>
 #include <mutex>
-#include "./module_util.h"
+#include "module_util.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/vulkan/vulkan_device_api.cc
+++ b/src/runtime/vulkan/vulkan_device_api.cc
@@ -5,7 +5,7 @@
 #include <tvm/runtime/registry.h>
 #include <dmlc/thread_local.h>
 #include <cstring>
-#include "./vulkan_common.h"
+#include "vulkan_common.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/runtime/vulkan/vulkan_module.cc
+++ b/src/runtime/vulkan/vulkan_module.cc
@@ -8,8 +8,8 @@
 #include <array>
 #include <string>
 #include <mutex>
-#include "./vulkan_common.h"
-#include "./vulkan_module.h"
+#include "vulkan_common.h"
+#include "vulkan_module.h"
 #include "../pack_args.h"
 #include "../thread_storage_scope.h"
 #include "../meta_data.h"

--- a/src/runtime/workspace_pool.cc
+++ b/src/runtime/workspace_pool.cc
@@ -3,7 +3,7 @@
  * \file workspace_pool.h
  * \brief Workspace pool utility.
  */
-#include "./workspace_pool.h"
+#include "workspace_pool.h"
 
 namespace tvm {
 namespace runtime {

--- a/src/schedule/bound.cc
+++ b/src/schedule/bound.cc
@@ -9,8 +9,8 @@
 #include <tvm/ir_pass.h>
 #include <unordered_map>
 #include <unordered_set>
-#include "./graph.h"
-#include "./message_passing.h"
+#include "graph.h"
+#include "message_passing.h"
 #include "../runtime/thread_storage_scope.h"
 
 namespace tvm {

--- a/src/schedule/graph.cc
+++ b/src/schedule/graph.cc
@@ -8,7 +8,7 @@
 #include <tvm/operation.h>
 #include <unordered_set>
 #include <unordered_map>
-#include "./graph.h"
+#include "graph.h"
 
 namespace tvm {
 namespace schedule {

--- a/src/schedule/message_passing.cc
+++ b/src/schedule/message_passing.cc
@@ -6,7 +6,7 @@
 #include <tvm/arithmetic.h>
 #include <tvm/ir.h>
 #include <tvm/ir_pass.h>
-#include "./message_passing.h"
+#include "message_passing.h"
 #include "../arithmetic/compute_expr.h"
 
 namespace tvm {

--- a/src/schedule/schedule_dataflow_rewrite.cc
+++ b/src/schedule/schedule_dataflow_rewrite.cc
@@ -7,7 +7,7 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/ir_pass.h>
 #include <unordered_set>
-#include "./message_passing.h"
+#include "message_passing.h"
 #include "../pass/ir_util.h"
 #include "../arithmetic/compute_expr.h"
 

--- a/src/schedule/schedule_lang.cc
+++ b/src/schedule/schedule_lang.cc
@@ -6,7 +6,7 @@
 #include <tvm/operation.h>
 #include <tvm/ir_mutator.h>
 #include <unordered_set>
-#include "./graph.h"
+#include "graph.h"
 
 namespace tvm {
 

--- a/src/schedule/schedule_ops.cc
+++ b/src/schedule/schedule_ops.cc
@@ -11,7 +11,7 @@
 #include <utility>
 #include <unordered_map>
 #include <unordered_set>
-#include "./graph.h"
+#include "graph.h"
 #include "../op/op_util.h"
 #include "../pass/ir_util.h"
 

--- a/verilog/tvm_vpi.cc
+++ b/verilog/tvm_vpi.cc
@@ -8,6 +8,8 @@
 #include <cstdlib>
 #include <memory>
 #include <queue>
+#include <string>
+#include <vector>
 #include "tvm_vpi.h"
 #include "../src/common/pipe.h"
 

--- a/verilog/tvm_vpi.cc
+++ b/verilog/tvm_vpi.cc
@@ -8,7 +8,7 @@
 #include <cstdlib>
 #include <memory>
 #include <queue>
-#include "./tvm_vpi.h"
+#include "tvm_vpi.h"
 #include "../src/common/pipe.h"
 
 namespace tvm {

--- a/vta/hardware/xilinx/src/vta.cc
+++ b/vta/hardware/xilinx/src/vta.cc
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "./vta.h"
+#include "vta.h"
 
 void fetch(
   uint32_t insn_count,

--- a/vta/include/vta/runtime.h
+++ b/vta/include/vta/runtime.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#include "./driver.h"
+#include "driver.h"
 
 #define VTA_MEMCPY_H2D 1
 #define VTA_MEMCPY_D2H 2

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -6,7 +6,7 @@
 
 #include <vta/driver.h>
 #include <thread>
-#include "./pynq_driver.h"
+#include "pynq_driver.h"
 
 
 void* VTAMemAlloc(size_t size, int cached) {

--- a/vta/tests/hardware/common/test_lib.cc
+++ b/vta/tests/hardware/common/test_lib.cc
@@ -4,7 +4,7 @@
  * \brief Test library for the VTA design simulation and driver tests.
  */
 
-#include "./test_lib.h"
+#include "test_lib.h"
 
 #ifdef NO_SIM
 #ifdef VTA_TARGET_PYNQ


### PR DESCRIPTION
It seems that CMake cannot resolve header file dependencies for `#include "./path.h"` style of include lines.  This patch removes all the leading "./" from include paths systematically with the bellow command.
```
find jvm/ nnvm/ tests/ dlpack/ topi/ web/ vta/ src/ verilog/ apps/ include/ -type f | \
    xargs sed -i 's%#include "./%#include "%'
```

See also https://discuss.tvm.ai/t/handle-header-file-dependencies-with-cmake/720