### PR TITLE
[AUTOTVM] Fix local executor

### DIFF
--- a/python/tvm/autotvm/measure/local_executor.py
+++ b/python/tvm/autotvm/measure/local_executor.py
@@ -133,7 +133,7 @@ class LocalExecutor(executor.Executor):
         if not self.do_fork:
             return LocalFutureNoFork(func(*args, **kwargs))
 
-        queue = Queue(1)
+        queue = Queue(2)
         process = Process(target=timeout_monitor,
                           args=(queue, self.timeout, func, args, kwargs))
         process.start()


### PR DESCRIPTION
The old queue size is too small. It will stall the executor due to race condition.
