### PR TITLE
[CODEGEN][AOCL] Add math intrinsic rules

### DIFF
--- a/docs/deploy/aocl_fpga.md
+++ b/docs/deploy/aocl_fpga.md
@@ -12,7 +12,7 @@ We use two python scripts for this tutorial.
 import tvm
 
 tgt_host="llvm"
-tgt="aocl -device=s5_ref -mattr=emulator"
+tgt="aocl_sw_emu"
 
 n = tvm.var("n")
 A = tvm.placeholder((n,), name='A')
@@ -38,7 +38,7 @@ import tvm
 import numpy as np
 import os
 
-tgt="aocl -device=s5_ref -mattr=emulator"
+tgt="aocl_sw_emu"
 
 fadd = tvm.module.load("myadd.so")
 fadd_dev = tvm.module.load("myadd.aocx")

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -115,6 +115,7 @@ class TVMContext(ctypes.Structure):
         'cl': 4,
         'opencl': 4,
         'aocl' : 5,
+        'aocl_emu' : 5,
         'sdaccel': 6,
         'vulkan': 7,
         'metal': 8,

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -115,7 +115,7 @@ class TVMContext(ctypes.Structure):
         'cl': 4,
         'opencl': 4,
         'aocl' : 5,
-        'aocl_emu' : 5,
+        'aocl_sw_emu' : 5,
         'sdaccel': 6,
         'vulkan': 7,
         'metal': 8,

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -92,7 +92,7 @@ Target CreateTarget(const std::string& target_name,
     t->device_type = kDLOpenCL;
     t->keys_array.push_back(ir::StringImm::make("sdaccel"));
     t->keys_array.push_back(ir::StringImm::make("hls"));
-  } else if (target_name == "aocl" || target_name == "aocl_emu") {
+  } else if (target_name == "aocl" || target_name == "aocl_sw_emu") {
     t->device_type = kDLAOCL;
     t->keys_array.push_back(ir::StringImm::make("aocl"));
     t->keys_array.push_back(ir::StringImm::make("hls"));

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -92,7 +92,7 @@ Target CreateTarget(const std::string& target_name,
     t->device_type = kDLOpenCL;
     t->keys_array.push_back(ir::StringImm::make("sdaccel"));
     t->keys_array.push_back(ir::StringImm::make("hls"));
-  } else if (target_name == "aocl") {
+  } else if (target_name == "aocl" || target_name == "aocl_emu") {
     t->device_type = kDLAOCL;
     t->keys_array.push_back(ir::StringImm::make("aocl"));
     t->keys_array.push_back(ir::StringImm::make("hls"));

--- a/src/codegen/codegen_aocl.cc
+++ b/src/codegen/codegen_aocl.cc
@@ -56,7 +56,7 @@ TVM_REGISTER_API("codegen.build_aocl")
     *rv = BuildAOCL(args[0], args[1], false);
   });
 
-TVM_REGISTER_API("codegen.build_aocl_emu")
+TVM_REGISTER_API("codegen.build_aocl_sw_emu")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
     *rv = BuildAOCL(args[0], args[1], true);
   });

--- a/src/codegen/codegen_aocl.cc
+++ b/src/codegen/codegen_aocl.cc
@@ -31,17 +31,16 @@ runtime::Module BuildAOCL(Array<LoweredFunc> funcs, std::string target_str) {
   runtime::SaveBinaryToFile("aocl.cl", code.c_str());
 
   // Compile the .cl file.
-  Target target = Target::create(target_str);
-  if (target->device_name == "") {
-    LOG(FATAL) << "AOCL device name not specified in build target.";
-  }
   std::string cmd = "aoc aocl.cl";
+  Target target = Target::create(target_str);
+  if (target->device_name != "") {
+    cmd += " -board=" + target->device_name;
+  }
   for (std::string option : target->options()) {
     if (option == "-mattr=emulator") {
       cmd += " -march=emulator";
     }
   }
-  cmd += " -board=" + target->device_name;
   if (system(cmd.c_str()) != 0) {
     LOG(FATAL) << "OpenCL offline compilation error.";
   }

--- a/src/codegen/intrin_rule_aocl.cc
+++ b/src/codegen/intrin_rule_aocl.cc
@@ -1,0 +1,48 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file intrin_rule_aocl.cc
+ * \brief AOCL intrinsic rules.
+ */
+#include "intrin_rule.h"
+
+namespace tvm {
+namespace codegen {
+namespace intrin {
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.floor")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.ceil")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.trunc")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.fabs")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.round")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.exp")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.log")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.tanh")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.sqrt")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.pow")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.popcount")
+.set_body(DispatchExtern<Direct>);
+
+
+}  // namespace intrin
+}  // namespace codegen
+}  // namespace tvm

--- a/src/codegen/intrin_rule_aocl.cc
+++ b/src/codegen/intrin_rule_aocl.cc
@@ -43,6 +43,40 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.popcount")
 .set_body(DispatchExtern<Direct>);
 
 
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.floor")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.ceil")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.trunc")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.fabs")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.round")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.exp")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.log")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.tanh")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.sqrt")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.pow")
+.set_body(DispatchExtern<Direct>);
+
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.popcount")
+.set_body(DispatchExtern<Direct>);
+
+
 }  // namespace intrin
 }  // namespace codegen
 }  // namespace tvm

--- a/src/codegen/intrin_rule_aocl.cc
+++ b/src/codegen/intrin_rule_aocl.cc
@@ -43,37 +43,37 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl.popcount")
 .set_body(DispatchExtern<Direct>);
 
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.floor")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.floor")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.ceil")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.ceil")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.trunc")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.trunc")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.fabs")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.fabs")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.round")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.round")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.exp")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.exp")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.log")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.log")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.tanh")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.tanh")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.sqrt")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.sqrt")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.pow")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.pow")
 .set_body(DispatchExtern<Direct>);
 
-TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_emu.popcount")
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.aocl_sw_emu.popcount")
 .set_body(DispatchExtern<Direct>);
 
 

--- a/tests/python/integration/test_ewise_fpga.py
+++ b/tests/python/integration/test_ewise_fpga.py
@@ -44,7 +44,7 @@ def test_exp():
     if "AWS_PLATFORM" in os.environ:
         check_device("sdaccel -device=" + os.environ.get("AWS_PLATFORM"))
 
-    check_device("aocl -device=s5_ref -mattr=emulator")
+    check_device("aocl -mattr=emulator")
 
 def test_multi_kernel():
     # graph
@@ -82,7 +82,7 @@ def test_multi_kernel():
             d.asnumpy(), a.asnumpy() * 2 + b.asnumpy(), rtol=1e-5)
 
     check_device("sdaccel")
-    check_device("aocl -device=s5_ref -mattr=emulator")
+    check_device("aocl -mattr=emulator")
 
 
 if __name__ == "__main__":

--- a/tests/python/integration/test_ewise_fpga.py
+++ b/tests/python/integration/test_ewise_fpga.py
@@ -44,7 +44,7 @@ def test_exp():
     if "AWS_PLATFORM" in os.environ:
         check_device("sdaccel -device=" + os.environ.get("AWS_PLATFORM"))
 
-    check_device("aocl_emu")
+    check_device("aocl_sw_emu")
 
 def test_multi_kernel():
     # graph
@@ -82,7 +82,7 @@ def test_multi_kernel():
             d.asnumpy(), a.asnumpy() * 2 + b.asnumpy(), rtol=1e-5)
 
     check_device("sdaccel")
-    check_device("aocl_emu")
+    check_device("aocl_sw_emu")
 
 
 if __name__ == "__main__":

--- a/tests/python/integration/test_ewise_fpga.py
+++ b/tests/python/integration/test_ewise_fpga.py
@@ -44,7 +44,7 @@ def test_exp():
     if "AWS_PLATFORM" in os.environ:
         check_device("sdaccel -device=" + os.environ.get("AWS_PLATFORM"))
 
-    check_device("aocl -mattr=emulator")
+    check_device("aocl_emu")
 
 def test_multi_kernel():
     # graph
@@ -82,7 +82,7 @@ def test_multi_kernel():
             d.asnumpy(), a.asnumpy() * 2 + b.asnumpy(), rtol=1e-5)
 
     check_device("sdaccel")
-    check_device("aocl -mattr=emulator")
+    check_device("aocl_emu")
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_math.py
+++ b/topi/tests/python/test_topi_math.py
@@ -39,7 +39,8 @@ def test_ewise():
             foo(a, b)
             np.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5, atol=1e-5)
 
-        for device in ['cuda', 'opencl', 'metal', 'rocm', 'vulkan', 'llvm', 'nvptx', 'sdaccel']:
+        for device in ['cuda', 'opencl', 'metal', 'rocm', 'vulkan', 'llvm', 'nvptx', 'sdaccel',
+                       'aocl -mattr=emulator']:
             check_device(device)
 
 

--- a/topi/tests/python/test_topi_math.py
+++ b/topi/tests/python/test_topi_math.py
@@ -40,7 +40,7 @@ def test_ewise():
             np.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5, atol=1e-5)
 
         for device in ['cuda', 'opencl', 'metal', 'rocm', 'vulkan', 'llvm', 'nvptx', 'sdaccel',
-                       'aocl_emu']:
+                       'aocl_sw_emu']:
             check_device(device)
 
 

--- a/topi/tests/python/test_topi_math.py
+++ b/topi/tests/python/test_topi_math.py
@@ -40,7 +40,7 @@ def test_ewise():
             np.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5, atol=1e-5)
 
         for device in ['cuda', 'opencl', 'metal', 'rocm', 'vulkan', 'llvm', 'nvptx', 'sdaccel',
-                       'aocl -mattr=emulator']:
+                       'aocl_emu']:
             check_device(device)
 
 


### PR DESCRIPTION
This PR adds math intrinsic rules for AOCL.

In addition, to simplify an AOCL target name for emulation, I made the `-device` parameter of the AOCL target optional.