### PR TITLE
[FRONTEND][TENSORFLOW] fix the convertion of sum and add testcase for it

### DIFF
--- a/nnvm/python/nnvm/frontend/tensorflow.py
+++ b/nnvm/python/nnvm/frontend/tensorflow.py
@@ -445,8 +445,7 @@ def _sum():
     def _impl(inputs, attr, params):
         axis = params.pop(inputs[1].list_output_names()[0]).asnumpy()
         # convert to tuple for preventing invalid parameter format error
-        if isinstance(axis, np.ndarray):
-            axis = tuple(axis)
+        axis = tuple(axis)
         return AttrCvt(
             op_name='sum',
             extras={'axis': axis},

--- a/nnvm/python/nnvm/frontend/tensorflow.py
+++ b/nnvm/python/nnvm/frontend/tensorflow.py
@@ -444,6 +444,9 @@ def _lrn():
 def _sum():
     def _impl(inputs, attr, params):
         axis = params.pop(inputs[1].list_output_names()[0]).asnumpy()
+        # convert to tuple for preventing invalid parameter format error
+        if isinstance(axis, np.ndarray):
+            axis = tuple(axis)
         return AttrCvt(
             op_name='sum',
             extras={'axis': axis},

--- a/nnvm/tests/python/frontend/tensorflow/test_forward.py
+++ b/nnvm/tests/python/frontend/tensorflow/test_forward.py
@@ -331,22 +331,26 @@ def test_forward_sigmoid():
     _test_sigmoid(np.random.uniform(size=(3, 4, 4, 3)).astype('float32'))
 
 #######################################################################
-# Argmin/Argmax
-# -------------
+# Reduce
+# ------
 
-def _test_argx(func, data, **kwargs):
-
+def _test_reduce(func, data, output_type=None, **kwargs):
     with tf.Graph().as_default():
         inp = array_ops.placeholder(shape=data.shape, dtype=data.dtype, name="c0")
-        func(inp, name="argx0", **kwargs, output_type=tf.int32)
+        if output_type is None:
+            func(inp, name="reducex0", **kwargs)
+        else:
+            func(inp, name="reducex0", output_type=output_type, **kwargs)
 
-        compare_tf_with_tvm(data, 'c0:0', 'argx0:0')
 
-def test_forward_argminmax():
+        compare_tf_with_tvm(data, 'c0:0', 'reducex0:0')
+
+def test_forward_reduce():
     for axis in [None,0,1,2]:
         data = np.random.uniform(size=(8,4,9)).astype('float32')
-        _test_argx(tf.argmax, data=data, axis=axis)
-        _test_argx(tf.argmin, data=data, axis=axis)
+        _test_reduce(tf.argmax, data=data, output_type="int32", axis=axis)
+        _test_reduce(tf.argmin, data=data, output_type="int32", axis=axis)
+        _test_reduce(tf.reduce_sum, data=data, axis=axis)
 
 #######################################################################
 # Variable
@@ -825,8 +829,7 @@ def _test_l2_normalize(ishape, eps, axis):
         nn.l2_normalize(in1,
                         axis=axis,
                         epsilon=eps,
-                        name=None,
-                        dim=None)
+                        name=None)
 
         compare_tf_with_tvm(inp_array, 'Placeholder:0', 'l2_normalize:0')
 
@@ -843,7 +846,7 @@ if __name__ == '__main__':
     test_forward_reshape()
     test_forward_squeeze()
     test_forward_sigmoid()
-    test_forward_argminmax()
+    test_forward_reduce()
     if tf.__version__ == '1.4.1':
         _test_forward_concat_v2()
     test_forward_multi_input()


### PR DESCRIPTION
This PR fixes invalid parameter error caused by `reduce_sum` when `reduce_sum`'s axis option is not specified or it is multiple axes.
