### PR TITLE
[CUDA][TVM] fix constructing invalid command line string for nvcc

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -59,10 +59,11 @@ def compile_cuda(code,
     cmd = ["nvcc"]
     cmd += ["--%s" % target, "-O3"]
     cmd += ["-arch", arch]
-    cmd += ["-o", file_target]
 
     if options:
-        cmd += options
+        cmd += [options]
+
+    cmd += ["-o", file_target]
     cmd += [temp_code]
 
     proc = subprocess.Popen(

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -28,7 +28,7 @@ def compile_cuda(code,
     arch : str
         The architecture
 
-    options : str or str list
+    options : str or list of str
         The additional options
 
     path_target : str, optional
@@ -66,7 +66,7 @@ def compile_cuda(code,
         elif isinstance(options, list):
             cmd += options
         else:
-            raise ValueError("options must be str or str list")
+            raise ValueError("options must be str or list of str")
 
     cmd += ["-o", file_target]
     cmd += [temp_code]

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -28,7 +28,7 @@ def compile_cuda(code,
     arch : str
         The architecture
 
-    options : str
+    options : str or str list
         The additional options
 
     path_target : str, optional
@@ -61,7 +61,12 @@ def compile_cuda(code,
     cmd += ["-arch", arch]
 
     if options:
-        cmd += [options]
+        if isinstance(options, str):
+            cmd += [options]
+        elif isinstance(options, list):
+            cmd += options
+        else:
+            raise ValueError("options must be str or str list")
 
     cmd += ["-o", file_target]
     cmd += [temp_code]


### PR DESCRIPTION
This PR fixes the following problem:

- `options` append to `cmd` as char list
- nvcc raises an error (`No input files specified`) when any string (`options` in this case) exists between output filename and input filename 