### PR TITLE
[DOC] Fix incorrect doc in conv2d_nhwc_python

### DIFF
--- a/topi/python/topi/testing/conv2d_nhwc_python.py
+++ b/topi/python/topi/testing/conv2d_nhwc_python.py
@@ -13,7 +13,7 @@ def conv2d_nhwc_python(a_np, w_np, stride, padding):
         4-D with shape [batch, in_height, in_width, in_channel]
 
     w_np : numpy.ndarray
-        4-D with shape [num_filter, filter_height, filter_width, in_channel]
+        4-D with shape [filter_height, filter_width, in_channel, num_filter]
 
     stride : int or a list/tuple of two ints
         Stride size, or [stride_height, stride_width]


### PR DESCRIPTION
According to [this](https://github.com/vinx13/tvm/blob/32d788d9a993485328327f246ff3195b5ed41744/topi/python/topi/testing/conv2d_nhwc_python.py#L30), we expect the layout here to be `HW channel_in channel_out`
cc @masahi 
