### PR TITLE
Support AOCL on SoC FPGA boards

### DIFF
--- a/docs/deploy/aocl_fpga.md
+++ b/docs/deploy/aocl_fpga.md
@@ -98,5 +98,6 @@ python build.py
 Copy generated `aocl.aocx` file to the SoC FPGA board, then, on the board,
 ```
 aocl program /dev/acl0 aocl.aocx
+python build.py
 python run.py
 ```

--- a/docs/deploy/aocl_fpga.md
+++ b/docs/deploy/aocl_fpga.md
@@ -3,7 +3,7 @@ AOCL Backend Example
 
 TVM supports Intel FPGA SDK for OpenCL also known as AOCL.  Here is a tutorial for how to use TVM with AOCL.
 
-***Note***: This feature is still experimental.  We cannot use AOCL to deploy an end to end neural networks for now.  In addition, we only tested compilation for emulation mode of AOCL.
+***Note***: This feature is still experimental.  We cannot use AOCL to deploy an end to end neural networks for now.
 
 We use two python scripts for this tutorial.
 
@@ -71,10 +71,8 @@ Setup
 ```
 - Setup TVM with AOCL and OpenCL enabled.
 
-Emulation
----------
-
-- Run software emulation
+Run Software Emulation
+----------------------
 ```
 export CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA=1
 
@@ -82,11 +80,23 @@ python build.py
 python run.py
 ```
 
-- Run on FPGA devices (not tested)
-    - Change tgt value to "aocl -device=s5_ref" on build.py and run.py
+Run with PCI-E FPGA Cards
+-------------------------
+In build.py and run.py, change tgt value to "aocl".
 ```
-unset CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA
-
 python build.py
+python run.py
+```
+
+Run with SoC FPGA Boards
+------------------------
+In build.py and run.py, change tgt value to "aocl".
+On x86_64 host,
+```
+python build.py
+```
+Copy generated `aocl.aocx` file to the SoC FPGA board, then, on the board,
+```
+aocl program /dev/acl0 aocl.aocx
 python run.py
 ```

--- a/src/codegen/codegen_aocl.cc
+++ b/src/codegen/codegen_aocl.cc
@@ -28,6 +28,10 @@ runtime::Module BuildAOCL(Array<LoweredFunc> funcs, std::string target_str,
     code = (*f)(code).operator std::string();
   }
 
+  // We want to call "aoc" compiler only when we're running on a x86_64 host.
+  // On ARM SoC hosts, we must use "aocl.aocx" file which is precompiled on
+  // x86_64 hosts.
+#if defined(__x86_64__) || defined(_M_X64)
   // Write a .cl file.
   runtime::SaveBinaryToFile("aocl.cl", code.c_str());
 
@@ -45,6 +49,7 @@ runtime::Module BuildAOCL(Array<LoweredFunc> funcs, std::string target_str,
   if (system(cmd.c_str()) != 0) {
     LOG(FATAL) << "OpenCL offline compilation error.";
   }
+#endif
 
   // Read .aocx file
   std::string aocxbin;


### PR DESCRIPTION
This PR makes it possible for Intel's SoC FPGA boards to run TVM with Intel FPGA SDK for OpenCL enabled.  I checked on a DE10-Nano board.