### PR TITLE
CI Failure Fix Issue #1681 

### DIFF
--- a/tutorials/nnvm/from_darknet.py
+++ b/tutorials/nnvm/from_darknet.py
@@ -39,7 +39,7 @@ CFG_NAME = MODEL_NAME + '.cfg'
 WEIGHTS_NAME = MODEL_NAME + '.weights'
 REPO_URL = 'https://github.com/siju-samuel/darknet/blob/master/'
 CFG_URL = REPO_URL + 'cfg/' + CFG_NAME + '?raw=true'
-WEIGHTS_URL = REPO_URL + 'weights/' + WEIGHTS_NAME + '?raw=true'
+WEIGHTS_URL = 'https://pjreddie.com/media/files/' + WEIGHTS_NAME
 
 download(CFG_URL, CFG_NAME)
 download(WEIGHTS_URL, WEIGHTS_NAME)


### PR DESCRIPTION
#1681 
The recent changes in tutorial is with PR # https://github.com/dmlc/tvm/pull/1501 broken the link for downloading the weights file, leading to this CI failure.


Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from others in the community.
