### PR TITLE
expose SaveToFile symbol on windows

### DIFF
--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -103,7 +103,7 @@ class ModuleNode {
    * \param file_name The file to be saved to.
    * \param format The format of the file.
    */
-  virtual void SaveToFile(const std::string& file_name,
+  TVM_DLL virtual void SaveToFile(const std::string& file_name,
                           const std::string& format);
   /*!
    * \brief Save the module to binary stream.

--- a/include/tvm/runtime/module.h
+++ b/include/tvm/runtime/module.h
@@ -104,7 +104,7 @@ class ModuleNode {
    * \param format The format of the file.
    */
   TVM_DLL virtual void SaveToFile(const std::string& file_name,
-                          const std::string& format);
+                                  const std::string& format);
   /*!
    * \brief Save the module to binary stream.
    * \param stream The binary stream to save to.


### PR DESCRIPTION
This pr is to expose the SaveToFile symbol on windows platform for tvm libs, same as other interface like SaveToBinary.
