### PR TITLE
Add dist to python/.gitignore

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,3 @@
 build
+dist
 *.cpp


### PR DESCRIPTION
`python` folder contains `setup.py` file which allows to generate `.egg` file by running
```
$ cd python
$ python setup.py bdist_egg
```
This command generates `.egg` file in `dist` folder.
`dist` folder should be ignored by `git`