### PR TITLE
Heterogeneous Runtime

### DIFF
--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -31,7 +31,7 @@ from .tensor_intrin import decl_tensor_intrin
 from .node import register_node
 from .ndarray import register_extension
 from .schedule import create_schedule
-from .build_module import build, lower, build_config
+from .build_module import build, lower, build_config, combine_modules
 from .tag import tag_scope
 
 # Contrib initializers

--- a/python/tvm/__init__.py
+++ b/python/tvm/__init__.py
@@ -31,7 +31,7 @@ from .tensor_intrin import decl_tensor_intrin
 from .node import register_node
 from .ndarray import register_extension
 from .schedule import create_schedule
-from .build_module import build, lower, build_config, combine_modules
+from .build_module import build, lower, build_config
 from .tag import tag_scope
 
 # Contrib initializers

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -386,7 +386,7 @@ def build(sch,
           name="default_function",
           binds=None,
           postpone_host_codegen=False):
-    """Build a function with arguments as signiture. Code will be generated
+    """Build a function with arguments as signature. Code will be generated
     for a device specified by the target. For homogeneous execution, a module
     that contains both host and device code is returned. For heterogeneous
     execution, a list of lowered functions for the host and a module containing

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -427,8 +427,11 @@ def build(sch,
 
     Returns
     -------
-    f : Function, or pair of functions
-       The result function.
+    ret : tvm.module, or (list of LoweredFunc, tvm.module) tuple
+        A module that combines both host and device code is returned when
+        postpone_host_codegen is not set. Otherwise, a list of lowered
+        functions for the host and a module contains only device code are
+        returned.
 
     Note
     ----

--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -1,28 +1,28 @@
 """Minimum graph runtime that executes graph containing TVM PackedFunc."""
 import numpy as np
+import tvm
 
 from .._ffi.base import string_types
 from .._ffi.function import get_global_func
+from .._ffi.runtime_ctypes import TVMContext
 from ..rpc import base as rpc_base
 from .. import ndarray as nd
 
-
 def create(graph_json_str, libmod, ctx):
     """Create a runtime executor module given a graph and module.
-
     Parameters
     ----------
     graph_json_str : str or graph class
         The graph to be deployed in json format output by nnvm graph.
         The graph can only contain one operator(tvm_op) that
         points to the name of PackedFunc in the libmod.
-
     libmod : tvm.Module
         The module of the corresponding function
-
-    ctx : TVMContext
-        The context to deploy the module, can be local or remote.
-
+    ctx : TVMContext or list of TVMContext
+        The context to deploy the module. It can be local or remote when there
+        is only one TVMContext. Otherwise, the first context in the list will
+        be used as this purpose. All context should be given for heterogeneous
+        execution.
     Returns
     -------
     graph_module : GraphModule
@@ -33,17 +33,54 @@ def create(graph_json_str, libmod, ctx):
             graph_json_str = graph_json_str._tvm_graph_json()
         except AttributeError:
             raise ValueError("Type %s is not supported" % type(graph_json_str))
-    device_type = ctx.device_type
-    device_id = ctx.device_id
-    if device_type >= rpc_base.RPC_SESS_MASK:
+    if isinstance(ctx, TVMContext):
+        ctx = [ctx]
+    elif not isinstance(ctx, (list, tuple)):
+        raise ValueError("ctx has to be the type of TVMContext or a list of "
+                         "TVMCTVMContext")
+    has_cpu = False
+    for i, cur_ctx in enumerate(ctx):
+        if not isinstance(cur_ctx, TVMContext):
+            raise ValueError("ctx has to be the type of TVMContext or a list "
+                             "of TVMCTVMContext")
+        if cur_ctx.device_type == tvm.cpu(0).device_type:
+            has_cpu = True
+        elif cur_ctx.device_type >= rpc_base.RPC_SESS_MASK:
+            ctx[0], ctx[i] = ctx[i], ctx[0]
+
+    num_devices = len(ctx)
+    device_types = []
+    device_ids = []
+    for cur_ctx in ctx:
+        device_types.append(cur_ctx.device_type)
+        device_ids.append(cur_ctx.device_id)
+
+    if device_types[0] >= rpc_base.RPC_SESS_MASK:
+        if num_devices > 1:
+            raise ValueError("RPC hasn't been supported for heterogeneous "
+                             "execution yet.")
         assert libmod.type_key == "rpc"
-        assert rpc_base._SessTableIndex(libmod) == ctx._rpc_sess._tbl_index
+        assert rpc_base._SessTableIndex(libmod) == ctx[0]._rpc_sess._tbl_index
         hmod = rpc_base._ModuleHandle(libmod)
-        fcreate = ctx._rpc_sess.get_function("tvm.graph_runtime.remote_create")
-        device_type = device_type % rpc_base.RPC_SESS_MASK
-        return GraphModule(fcreate(graph_json_str, hmod, device_type, device_id), ctx)
+        fcreate = ctx[0]._rpc_sess.get_function("tvm.graph_runtime.remote_create")
+        device_types[0] = device_types[0] % rpc_base.RPC_SESS_MASK
+        return GraphModule(fcreate(graph_json_str, hmod, device_types[0],
+                                   device_ids[0]), ctx[0])
+
+    # Assume CPU is the host processor when there are multiple devices on
+    # a hardware platform.
+    if (num_devices > 1) and (not has_cpu):
+        raise RuntimeError(
+            "CPU should be the host processor for heterogenous execution, but"
+            " not found in ctx.")
+
+    device_type_arr = (ctypes.c_int * num_devices)(*device_types)
+    void_dt_arr = ctypes.cast(device_type_arr, ctypes.c_void_p)
+    device_id_arr = (ctypes.c_int * num_devices)(*device_ids)
+    void_di_arr = ctypes.cast(device_id_arr, ctypes.c_void_p)
     fcreate = get_global_func("tvm.graph_runtime.create")
-    return GraphModule(fcreate(graph_json_str, libmod, device_type, device_id), ctx)
+    return GraphModule(fcreate(graph_json_str, libmod, void_dt_arr,
+                               void_di_arr, num_devices), ctx[0])
 
 
 class GraphModule(object):
@@ -69,6 +106,7 @@ class GraphModule(object):
     ctx : TVMContext
         The context this module is under
     """
+
     def __init__(self, module, ctx):
         self.module = module
         self._set_input = module["set_input"]
@@ -177,7 +215,8 @@ class GraphModule(object):
         if hasattr(self, '_debug_get_output'):
             self._debug_get_output(node, out)
         else:
-            raise RuntimeError("Please compile runtime with USE_GRAPH_RUNTIME_DEBUG = 0")
+            raise RuntimeError(
+                "Please compile runtime with USE_GRAPH_RUNTIME_DEBUG = 0")
         return out
 
     def load_params(self, params_bytes):

--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -38,41 +38,29 @@ def create(graph_json_str, libmod, ctx):
     elif not isinstance(ctx, (list, tuple)):
         raise ValueError("ctx has to be the type of TVMContext or a list of "
                          "TVMCTVMContext")
-    cpu_ctx_index = -1
     for i, cur_ctx in enumerate(ctx):
         if not isinstance(cur_ctx, TVMContext):
             raise ValueError("ctx has to be the type of TVMContext or a list "
-                             "of TVMCTVMContext")
-        if cur_ctx.device_type == tvm.cpu(0).device_type:
-            cpu_ctx_index = i
-        elif cur_ctx.device_type >= rpc_base.RPC_SESS_MASK:
+                             "of TVMContext")
+        if cur_ctx.device_type == tvm.cpu(0).device_type or \
+           cur_ctx.device_type >= rpc_base.RPC_SESS_MASK:
             ctx[0], ctx[i] = ctx[i], ctx[0]
 
-    num_devices = len(ctx)
-    device_types = []
-    device_ids = []
-    for cur_ctx in ctx:
-        device_types.append(cur_ctx.device_type)
-        device_ids.append(cur_ctx.device_id)
-
-    if device_types[0] >= rpc_base.RPC_SESS_MASK:
+    # ctx[0] is used as the primary/fallback context. All other ones are used
+    # as device context for heterogeneous execution.
+    device_type_id = [x for c in ctx[1:] for x in [c.device_type, c.device_id]]
+    if ctx[0].device_type >= rpc_base.RPC_SESS_MASK:
         assert libmod.type_key == "rpc"
         assert rpc_base._SessTableIndex(libmod) == ctx[0]._rpc_sess._tbl_index
         hmod = rpc_base._ModuleHandle(libmod)
         fcreate = ctx[0]._rpc_sess.get_function("tvm.graph_runtime.remote_create")
-        device_types[0] = device_types[0] % rpc_base.RPC_SESS_MASK
-        return GraphModule(fcreate(graph_json_str, hmod, num_devices,
-                                   *device_types, *device_ids), ctx[0])
+        device_type = ctx[0].device_type % rpc_base.RPC_SESS_MASK
+        return GraphModule(fcreate(graph_json_str, hmod, device_type,
+                                   ctx[0].device_id, *device_type_id), ctx[0])
 
-    # Assume CPU is the host processor when there are multiple devices on
-    # a hardware platform.
-    if (num_devices > 1) and (cpu_ctx_index < 0):
-        raise RuntimeError(
-            "CPU should be the host processor for heterogenous execution, but"
-            " not found in ctx.")
     fcreate = get_global_func("tvm.graph_runtime.create")
-    return GraphModule(fcreate(graph_json_str, libmod, num_devices,
-                               *device_types, *device_ids), ctx[cpu_ctx_index])
+    return GraphModule(fcreate(graph_json_str, libmod, ctx[0].device_type,
+                               ctx[0].device_id, *device_type_id), ctx[0])
 
 
 class GraphModule(object):

--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -63,12 +63,10 @@ def create(graph_json_str, libmod, ctx):
     if num_rpc_ctx == len(ctx):
         hmod = rpc_base._ModuleHandle(libmod)
         fcreate = ctx[0]._rpc_sess.get_function("tvm.graph_runtime.remote_create")
-        return GraphModule(fcreate(graph_json_str, hmod, device_type_id[0],
-                                   device_type_id[1], *device_type_id[2:]))
+        return GraphModule(fcreate(graph_json_str, hmod, *device_type_id))
 
     fcreate = get_global_func("tvm.graph_runtime.create")
-    return GraphModule(fcreate(graph_json_str, libmod, device_type_id[0],
-                               device_type_id[1], *device_type_id[2:]))
+    return GraphModule(fcreate(graph_json_str, libmod, *device_type_id))
 
 
 class GraphModule(object):

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -739,7 +739,7 @@ TVM_REGISTER_GLOBAL("tvm.graph_runtime.remote_create")
       void* mhandle = args[1];
       TVMContext ctx;
       int dev_type = args[2];
-      ctx.device_type = static_cast<DLDeviceType>(dev_type); 
+      ctx.device_type = static_cast<DLDeviceType>(dev_type);
       ctx.device_id = args[3];
       std::vector<TVMContext> contexts{ctx};
       *rv = GraphRuntimeCreate(args[0],

--- a/tests/python/unittest/test_runtime_heterogeneous.py
+++ b/tests/python/unittest/test_runtime_heterogeneous.py
@@ -9,7 +9,7 @@ import topi
 
 def get_simplex_graph(host_dev_type, device_dev_type):
     r""" Return the hand-crafted json object where only one copy node is
-    inserted. Tis node copies data from the target device to cpu.
+    inserted. This node copies data from the target device to cpu.
     The network is constructed as following:
                  A    B
                   \  /

--- a/tests/python/unittest/test_runtime_heterogeneous.py
+++ b/tests/python/unittest/test_runtime_heterogeneous.py
@@ -1,0 +1,413 @@
+# pylint: disable=too-many-locals
+"""Unit tests for heterogeneous runtime"""
+import json
+import numpy as np
+
+import tvm
+from tvm.contrib import graph_runtime, util
+import topi
+
+def get_simplex_graph(host_dev_type, device_dev_type):
+    r""" Return the hand-crafted json object where only one copy node is
+    inserted. Tis node copies data from the target device to cpu.
+    The network is constructed as following:
+                 A    B
+                  \  /
+             elemwise_add  (gpu)
+                     \
+                     copy      C
+                       \      /
+                     elemwise_sub  (cpu)
+
+    Parameters
+    ----------
+    host_dev_type : int
+        The device type of the host processor, e.g. cpu.
+    device_dev_type : int
+        The device type of the device processor, e.g. gpu, opencl, etc.
+
+    Returns
+    -------
+    json : json
+        A json encoded object.
+    """
+    # Construct each node in the graph.
+    var_a = {"op": "null", "name": "A", "device_type": device_dev_type,
+             "inputs": []}
+    var_b = {"op": "null", "name": "B", "device_type": device_dev_type,
+             "inputs": []}
+    elemwise_add = {
+        "op": "tvm_op", "name": "elemwise_add", "device_type": device_dev_type,
+        "attrs": {
+            "flatten_data": "1",
+            "func_name": "elemwise_add",
+            "num_inputs": "2",
+            "num_outputs": "1"
+        },
+        "inputs": [[0, 0, 0], [1, 0, 0]]
+    }
+    copy = {
+        "op": "device_copy_op",
+        "name": "__copy_add_to_sub",
+        "device_type": host_dev_type,
+        "attrs": {
+            "flatten_data": "0",
+            "func_name": "__copy",
+            "num_inputs": "1",
+            "num_outputs": "1"
+        },
+        "inputs": [[2, 0, 0]]
+    }
+    var_c = {"op": "null", "name": "C", "device_type": host_dev_type,
+             "inputs": []}
+    elemwise_sub = {
+        "op": "tvm_op", "name": "elemwise_sub",
+        "device_type": host_dev_type,
+        "attrs": {
+            "flatten_data": "0",
+            "func_name": "elemwise_sub",
+            "num_inputs": "2",
+            "num_outputs": "1"
+        },
+        "inputs": [[3, 0, 0], [4, 0, 0]]
+    }
+
+    # Group the nodes.
+    nodes = [var_a, var_b, elemwise_add, copy, var_c, elemwise_sub]
+    arg_nodes = [0, 1, 4]
+    node_row_ptr = [0, 1, 2, 3, 4, 5, 6]
+    heads = [[5, 0, 0]]
+    shape = (4,)
+    attrs = {
+        "storage_id": ["list_int", [3, 4, 0, 1, 5, 2]],
+        "shape": ["list_shape", [shape, shape, shape, shape, shape, shape]],
+        "device_type": ["list_int", [device_dev_type, device_dev_type,
+                                     device_dev_type, host_dev_type,
+                                     host_dev_type, host_dev_type]],
+        "dtype": ["list_int", [0, 0, 0, 0, 0, 0]],
+        "dltype": ["list_str", ["float32", "float32", "float32",
+                                "float32", "float32", "float32"]]
+    }
+
+    # Construct the graph.
+    graph = {"nodes": nodes,
+             "arg_nodes": arg_nodes,
+             "node_row_ptr": node_row_ptr,
+             "heads": heads,
+             "attrs": attrs}
+    return json.dumps(graph)
+
+
+def test_simplex_data_transferring():
+    r"""
+    Test the heterogeneous execution of a simple network where data
+    transferring is from the target device to the host processor at runtime.
+    The host processor is always assumed to be cpu, and the device varies.
+    """
+    host = "cpu"
+    target_host = "llvm"
+    host_ctx = tvm.context(host)
+    if not tvm.module.enabled(target_host):
+        print("Skip test because llvm is not enabled.")
+        return
+
+    def check_device(device, target_device):
+        if not tvm.module.enabled(target_device):
+            print("Skip test because {} is not enabled.".format(target_device))
+            return
+
+        device_ctx = tvm.context(device)
+        graph = get_simplex_graph(host_ctx.device_type, device_ctx.device_type)
+        shape = (4,)
+
+        # Create module for add whose target is the device.
+        tensor_a = tvm.placeholder(shape, name="A")
+        tensor_b = tvm.placeholder(shape, name="B")
+        elemwise_add = tvm.compute(shape, lambda *i: tensor_a(*i)
+                                   + tensor_b(*i), name="elemwise_add")
+        target = topi.cpp.TEST_create_target(device)
+        schedule_add = topi.cpp.cuda.schedule_injective(target, [elemwise_add])
+        lower_add = tvm.lower(schedule_add, [tensor_a, tensor_b, elemwise_add],
+                              name="elemwise_add")
+        lib_add, host_funcs_add = tvm.build(lower_add, target=target_device,
+                                            name="elemwise_add",
+                                            postpone_host_codegen=True)
+
+        # Insert copy. Neither compute nor schedule is required for the copy
+        # node. The compute will be performed at runtime which is just data
+        # copy from the input to the output.
+        tensor_copy = tvm.placeholder(shape, name="__copy")
+
+        # Create module for sub whose target is the host.
+        tensor_c = tvm.placeholder(shape, name="C")
+        elemwise_sub = tvm.compute(shape, lambda *i: tensor_copy(*i)
+                                   - tensor_c(*i), name="elemwise_sub")
+        schedule_sub = tvm.create_schedule(elemwise_sub.op)
+        lower_sub = tvm.lower(schedule_sub, [tensor_copy, tensor_c,
+                                             elemwise_sub],
+                              name="elemwise_sub")
+
+        lib_sub, host_funcs_sub = tvm.build(lower_sub, target=target_host,
+                                            name="elemwise_sub",
+                                            postpone_host_codegen=True)
+        host_funcs = host_funcs_add + host_funcs_sub
+        combined_mod = tvm.combine_modules(host_funcs, [lib_add, lib_sub],
+                                           target_host=target_host)
+
+        ctx = [host_ctx, device_ctx]
+        mod = graph_runtime.create(graph, combined_mod, ctx)
+        params = {}
+        params["A"] = tensor_a = np.random.uniform(
+            size=shape).astype(tensor_a.dtype)
+        params["B"] = tensor_b = np.random.uniform(
+            size=shape).astype(tensor_b.dtype)
+        params["C"] = tensor_c = np.random.uniform(
+            size=shape).astype(tensor_c.dtype)
+        mod.set_input(**params)
+        mod.run()
+        out = mod.get_output(0, tvm.nd.empty(shape))
+        np.testing.assert_equal(
+            out.asnumpy(), (tensor_a + tensor_b) - tensor_c)
+
+    dev_tar = {"gpu": "cuda", "opencl": "opencl"}
+    for device, target in dev_tar.items():
+        check_device(device, target)
+
+
+def get_duplex_graph(host_dev_type, device_dev_type):
+    r""" Return the hand-crafted json object where two copy nodes are inserted.
+    Data transferring happens back-and-forth between the target device and CPU.
+    The network is constructed as following:
+                 A    B
+                  \  /
+             elemwise_add  (gpu)
+                     \
+                     copy        C
+                       \        /
+                      elemwise_sub  (cpu)
+                         \
+                         copy          D
+                           \          /
+                           elemwise_add  (gpu)
+
+    Parameters
+    ----------
+    host_dev_type : int
+        The device type of the host processor, e.g. cpu.
+    device_dev_type : int
+        The device type of the device processor, e.g. gpu, opencl, etc.
+
+    Returns
+    -------
+    json : json
+        A json encoded object.
+    """
+    # Construct each node in the graph.
+    var_a = {"op": "null", "name": "A", "device_type": device_dev_type,
+             "inputs": []}
+    var_b = {"op": "null", "name": "B", "device_type": device_dev_type,
+             "inputs": []}
+    elemwise_add0 = {
+        "op": "tvm_op", "name": "elemwise_add0", "device_type":
+        device_dev_type,
+        "attrs": {
+            "flatten_data": "1",
+            "func_name": "elemwise_add0",
+            "num_inputs": "2",
+            "num_outputs": "1"
+        },
+        "inputs": [[0, 0, 0], [1, 0, 0]]
+    }
+    copy_add_sub = {
+        "op": "device_copy_op",
+        "name": "__copy_add_to_sub",
+        "device_type": host_dev_type,
+        "attrs": {
+            "flatten_data": "0",
+            "func_name": "__copy",
+            "num_inputs": "1",
+            "num_outputs": "1"
+        },
+        "inputs": [[2, 0, 0]]
+    }
+    var_c = {"op": "null", "name": "C", "device_type": host_dev_type,
+             "inputs": []}
+    elemwise_sub = {
+        "op": "tvm_op", "name": "elemwise_sub",
+        "device_type": host_dev_type,
+        "attrs": {
+            "flatten_data": "0",
+            "func_name": "elemwise_sub",
+            "num_inputs": "2",
+            "num_outputs": "1"
+        },
+        "inputs": [[3, 0, 0], [4, 0, 0]]
+    }
+    copy_sub_add = {
+        "op": "device_copy_op",
+        "name": "__copy_sub_to_add",
+        "device_type": device_dev_type,
+        "attrs": {
+            "flatten_data": "0",
+            "func_name": "__copy",
+            "num_inputs": "1",
+            "num_outputs": "1"
+        },
+        "inputs": [[5, 0, 0]]
+    }
+    var_d = {"op": "null", "name": "D", "device_type": device_dev_type,
+             "inputs": []}
+    elemwise_add1 = {
+        "op": "tvm_op", "name": "elemwise_add1",
+        "device_type": device_dev_type,
+        "attrs": {
+            "flatten_data": "0",
+            "func_name": "elemwise_add1",
+            "num_inputs": "2",
+            "num_outputs": "1"
+        },
+        "inputs": [[6, 0, 0], [7, 0, 0]]
+    }
+
+    # Group the nodes.
+    nodes = [var_a, var_b, elemwise_add0, copy_add_sub, var_c, elemwise_sub,
+             copy_sub_add, var_d, elemwise_add1]
+    arg_nodes = [0, 1, 4, 7]
+    node_row_ptr = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    heads = [[8, 0, 0]]
+    shape = (4,)
+    attrs = {
+        "storage_id": ["list_int", [4, 5, 0, 1, 6, 2, 0, 7, 3]],
+        "shape": ["list_shape", [shape, shape, shape, shape, shape, shape,
+                                 shape, shape, shape]],
+        "device_type": ["list_int", [device_dev_type, device_dev_type,
+                                device_dev_type,
+                                host_dev_type, host_dev_type, host_dev_type,
+                                device_dev_type, device_dev_type,
+                                device_dev_type]],
+        "dtype": ["list_int", [0, 0, 0, 0, 0, 0, 0, 0, 0]],
+        "dltype": ["list_str", ["float32", "float32", "float32",
+                                "float32", "float32", "float32",
+                                "float32", "float32", "float32"]]
+    }
+
+    # Construct the graph.
+    graph = {"nodes": nodes,
+             "arg_nodes": arg_nodes,
+             "node_row_ptr": node_row_ptr,
+             "heads": heads,
+             "attrs": attrs}
+    return json.dumps(graph)
+
+
+def test_duplex_data_transferring():
+    r"""
+    Test the heterogeneous execution of a simple network where data
+    transferring occurs back-and-forth between the target device and host
+    processor.
+    The host processor is always assumed to be cpu, and the target device
+    varies.
+    """
+    host = "cpu"
+    target_host = "llvm"
+    host_ctx = tvm.context(host)
+    if not tvm.module.enabled(target_host):
+        print("Skip test because llvm is not enabled.")
+        return
+
+    def check_device(device, target_device):
+        if not tvm.module.enabled(target_device):
+            print("Skip test because {} is not enabled.".format(target_device))
+            return
+
+        device_ctx = tvm.context(device)
+        graph = get_duplex_graph(host_ctx.device_type, device_ctx.device_type)
+        shape = (4,)
+
+        # Insert copy nodes for data transferring between add and sub nodes.
+        # Transfers data from gpu to cpu.
+        copy_add_sub = tvm.placeholder(shape, name="__copy0")
+        # Transfers data from cpu to gpu.
+        copy_sub_add = tvm.placeholder(shape, name="__copy1")
+
+        # Create a module containing adds on the device.
+        tensor_a = tvm.placeholder(shape, name="A")
+        tensor_b = tvm.placeholder(shape, name="B")
+        tensor_d = tvm.placeholder(shape, name="D")
+        elemwise_add0 = tvm.compute(shape, lambda *i: tensor_a(*i)
+                                    + tensor_b(*i), name="elemwise_add0")
+        elemwise_add1 = tvm.compute(shape, lambda *i: copy_sub_add(*i)
+                                    + tensor_d(*i), name="elemwise_add1")
+        target = topi.cpp.TEST_create_target(device)
+        add_schedule0 = topi.cpp.cuda.schedule_injective(
+            target, [elemwise_add0])
+        lower_add0 = tvm.lower(
+            add_schedule0, [tensor_a, tensor_b, elemwise_add0],
+            name="elemwise_add0")
+        add_schedule1 = topi.cpp.cuda.schedule_injective(
+            target, [elemwise_add1])
+        lower_add1 = tvm.lower(
+            add_schedule1, [tensor_d, copy_sub_add, elemwise_add1],
+            name="elemwise_add1")
+        lib_add, host_funcs_add = tvm.build([lower_add0, lower_add1],
+                                            target=target_device,
+                                            postpone_host_codegen=True)
+
+        # Create module for sub whose target is the host.
+        tensor_c = tvm.placeholder(shape, name="C")
+        elemwise_sub = tvm.compute(shape, lambda *i: copy_add_sub(*i)
+                                   - tensor_c(*i), name="elemwise_sub")
+        sub_schedule = tvm.create_schedule(elemwise_sub.op)
+        lower_sub = tvm.lower(sub_schedule, [copy_add_sub, tensor_c,
+                                             elemwise_sub],
+                              name="elemwise_sub")
+        lib_sub, host_funcs_sub = tvm.build(lower_sub, target=target_host,
+                                            postpone_host_codegen=True)
+        host_funcs = host_funcs_add + host_funcs_sub
+
+        combined_mod = tvm.combine_modules(host_funcs, [lib_add, lib_sub],
+                                           target_host=target_host)
+        ctx = [host_ctx, device_ctx]
+        params = {}
+        params["A"] = tensor_a = np.random.uniform(
+            size=shape).astype(tensor_a.dtype)
+        params["B"] = tensor_b = np.random.uniform(
+            size=shape).astype(tensor_b.dtype)
+        params["C"] = tensor_c = np.random.uniform(
+            size=shape).astype(tensor_c.dtype)
+        params["D"] = tensor_d = np.random.uniform(
+            size=shape).astype(tensor_d.dtype)
+
+        def check_verify():
+            mod = graph_runtime.create(graph, combined_mod, ctx)
+            mod.set_input(**params)
+            mod.run()
+            out = mod.get_output(0, tvm.nd.empty(shape))
+            np.testing.assert_equal(
+                out.asnumpy(), tensor_a + tensor_b - tensor_c + tensor_d)
+
+        def check_load_module():
+            temp = util.tempdir()
+            path_lib = temp.relpath("deploy.so")
+            combined_mod.export_library(path_lib)
+            with open(temp.relpath("deploy.json"), "w") as out_file:
+                out_file.write(graph)
+            loaded_lib = tvm.module.load(path_lib)
+            loaded_graph = open(temp.relpath("deploy.json")).read()
+            mod = graph_runtime.create(loaded_graph, loaded_lib, ctx)
+            mod.set_input(**params)
+            mod.run()
+            out = mod.get_output(0, tvm.nd.empty(shape))
+            np.testing.assert_equal(
+                out.asnumpy(), tensor_a + tensor_b - tensor_c + tensor_d)
+
+        check_verify()
+        check_load_module()
+
+    dev_tar = {"gpu": "cuda", "opencl": "opencl"}
+    for device, target in dev_tar.items():
+        check_device(device, target)
+
+if __name__ == "__main__":
+    test_simplex_data_transferring()
+    test_duplex_data_transferring()

--- a/tests/python/unittest/test_runtime_heterogeneous.py
+++ b/tests/python/unittest/test_runtime_heterogeneous.py
@@ -45,7 +45,7 @@ def get_simplex_graph(host_dev_type, device_dev_type):
         "inputs": [[0, 0, 0], [1, 0, 0]]
     }
     copy = {
-        "op": "device_copy_op",
+        "op": "tvm_op",
         "name": "__copy_add_to_sub",
         "attrs": {
             "flatten_data": "0",
@@ -167,7 +167,7 @@ def test_simplex_data_transferring():
         np.testing.assert_equal(
             out.asnumpy(), (tensor_a + tensor_b) - tensor_c)
 
-    dev_tar = {"gpu": "cuda", "opencl": "opencl"}
+    dev_tar = {"cuda": "cuda", "opencl": "opencl"}
     for device, target in dev_tar.items():
         check_device(device, target)
 
@@ -214,7 +214,7 @@ def get_duplex_graph(host_dev_type, device_dev_type):
         "inputs": [[0, 0, 0], [1, 0, 0]]
     }
     copy_add_sub = {
-        "op": "device_copy_op",
+        "op": "tvm_op",
         "name": "__copy_add_to_sub",
         "attrs": {
             "flatten_data": "0",
@@ -236,7 +236,7 @@ def get_duplex_graph(host_dev_type, device_dev_type):
         "inputs": [[3, 0, 0], [4, 0, 0]]
     }
     copy_sub_add = {
-        "op": "device_copy_op",
+        "op": "tvm_op",
         "name": "__copy_sub_to_add",
         "attrs": {
             "flatten_data": "0",
@@ -396,7 +396,7 @@ def test_duplex_data_transferring():
         check_verify()
         check_load_module()
 
-    dev_tar = {"gpu": "cuda", "opencl": "opencl"}
+    dev_tar = {"cuda": "cuda", "opencl": "opencl"}
     for device, target in dev_tar.items():
         check_device(device, target)
 


### PR DESCRIPTION
This is the first part of the PR #1688. 

This PR only focuses on making the runtime be able to take heterogeneous graphs. Changes are mainly made for graph runtime c++ and python interfaces.  Meanwhile, to test the execution, I manually created two simple graphs containing only addition, subtraction, and copy nodes. One test, test_simplex_data_transferring tests data transferring from GPU to CPU at runtime. The other one, test_duplex_data_transferring tests duplex data transferring back-and-forth between GPU and CPU. 

A new column, `device_type`, is added to the json file, which indicates which device a node should be scheduled to. In this PR this column is manually created as part of a graph json file. This field will be also used to annotate the graph node in the compiler PR. The serialization of this column is similar to that of the dtype column in the current json file. Loading/Saveing json API need to be modified slightly to support this field.

Tested the functionality on a MacBook with Intel CPU and Intel Graphics GPU for using the generated module in memory and exporting/importing it from the disk.

The next PR will focus on the compiler part to generate heterogeneous binaries to feed in the runtime. Major changes will be needed for the compiler.build interface. Another issue is the removal of `with target` statements in the high-level build interface. 
