### PR TITLE
Allow inplace memory optimization for different data type

### DIFF
--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -198,8 +198,7 @@ size_t AllocMemory(const Graph& ret, const IndexedGraph& idx,
             sid_in >= 0 &&
             ((storage_ref_count[sid_in] == 1 && !ignore_all_inputs) || identity[ipair]) &&
             entry_ref_count[eid_out] > 0 &&
-            shape_vec[eid_out].Size() == shape_vec[eid_in].Size() &&
-            dtype_vec[eid_out] == dtype_vec[eid_in]) {
+            shape_vec[eid_out].Size() == shape_vec[eid_in].Size()) {
           // inplace optimization
           taken[kv.first] = true;
           storage[eid_out] = sid_in;

--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -7,30 +7,32 @@
 #include <nnvm/pass.h>
 #include <nnvm/graph_attr_types.h>
 #include <nnvm/op_attr_types.h>
+#include <nnvm/top/tensor.h>
 #include <memory>
 #include "graph_algorithm.h"
 
 namespace nnvm {
 namespace pass {
 namespace {
+  using namespace nnvm::top;
 // Return bytes of data flag.
 static int GetDTypeSize(int type_flag) {
   switch (type_flag) {
-    case 3:  // uint8
-    case 5:  // int8
+    case kUint8:
+    case kInt8:
       return 1;
-    case 2:  // float16
-    case 7:  // int16
-    case 8:  // uint16
+    case kFloat16:
+    case kInt16:
+    case kUint16:
       return 2;
 
-    case 0:  // float32
-    case 4:  // int32
-    case 9:  // uint32
+    case kFloat32:
+    case kInt32:
+    case kUint32:
       return 4;
-    case 1:   // float64
-    case 6:   // int64
-    case 10:  // uint64
+    case kFloat64:
+    case kInt64:
+    case kUint64:
       return 8;
     default:
       LOG(FATAL) << "unknown type_flag=" << type_flag;

--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -201,7 +201,8 @@ size_t AllocMemory(const Graph& ret, const IndexedGraph& idx,
             ((storage_ref_count[sid_in] == 1 && !ignore_all_inputs) || identity[ipair]) &&
             entry_ref_count[eid_out] > 0 &&
             shape_vec[eid_out].Size() == shape_vec[eid_in].Size() &&
-            GetTVMType(dtype_vec[eid_out]).bits() == GetTVMType(dtype_vec[eid_in]).bits()) {
+             (dtype_vec[eid_out] == dtype_vec[eid_in] ||
+             GetTVMType(dtype_vec[eid_out]).bits() == GetTVMType(dtype_vec[eid_in]).bits())) {
           // inplace optimization
           taken[kv.first] = true;
           storage[eid_out] = sid_in;

--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -25,7 +25,6 @@ static int GetDTypeSize(int type_flag) {
     case kInt16:
     case kUint16:
       return 2;
-
     case kFloat32:
     case kInt32:
     case kUint32:

--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -9,10 +9,12 @@
 #include <nnvm/op_attr_types.h>
 #include <memory>
 #include "graph_algorithm.h"
+#include "../compiler/compile_engine.h"
 
 namespace nnvm {
 namespace pass {
 namespace {
+using namespace nnvm::compiler;
 
 // simple graph based allocator.
 class GraphAllocator {
@@ -198,7 +200,8 @@ size_t AllocMemory(const Graph& ret, const IndexedGraph& idx,
             sid_in >= 0 &&
             ((storage_ref_count[sid_in] == 1 && !ignore_all_inputs) || identity[ipair]) &&
             entry_ref_count[eid_out] > 0 &&
-            shape_vec[eid_out].Size() == shape_vec[eid_in].Size()) {
+            shape_vec[eid_out].Size() == shape_vec[eid_in].Size() &&
+            GetTVMType(dtype_vec[eid_out]).bits() == GetTVMType(dtype_vec[eid_in]).bits()) {
           // inplace optimization
           taken[kv.first] = true;
           storage[eid_out] = sid_in;


### PR DESCRIPTION
@tqchen Sorry I messed up previous PR, so I closed that and recreate this clean one for review. For example, for quantized relu, it may inplace convert data from int8 to uint8. We should support this kind of operation.