### PR TITLE
Added a helper function that dumps expr to std output

### DIFF
--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -230,6 +230,13 @@ using Domain = Array<Range>;
 
 // print functions for expr
 TVM_DLL std::ostream& operator<<(std::ostream& os, const NodeRef& n);  // NOLINT(*)
+
+/*!
+ * \brief Dump the node to stderr, used for debug purposes.
+ * \param node The input node
+ */
+TVM_DLL void Dump(const NodeRef& node);
+
 // definition of Node.
 /*!
  * \brief An iteration variable representing an iteration

--- a/src/lang/expr.cc
+++ b/src/lang/expr.cc
@@ -47,6 +47,10 @@ std::ostream& operator<<(std::ostream& os, const NodeRef& n) {  // NOLINT(*)
   return os;
 }
 
+void Dump(const NodeRef& n) {
+  std::cerr << n << "\n";
+}
+
 Var var(const std::string& name_hint, Type t) {
   return Var(name_hint, t);
 }


### PR DESCRIPTION
Added a helper function dump_expr that prints an expr to the
standard output stream. It could be useful for debugging
in GDB etc.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from others in the community.
