### PR TITLE
[TEAM] were -> Reviewer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 - [Siva](https://github.com/srkreddy1238)
 - [Alex Weaver](https://github.com/alex-weaver)
 - [Yao Wang](https://github.com/kevinthesun)
+- [Jian Weng](https://github.com/were)
 - [Eddie Yan](https://github.com/eqy)
 - [Joshua Z. Zhang](https://github.com/zhreshold)
 
@@ -35,7 +36,6 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 - [Full List of Contributors](https://github.com/dmlc/tvm/graphs/contributors)
   - To contributors: please add your name to the list.
 - [Qiao Zhang](https://github.com/zhangqiaorjc)
-- [Jian Weng](https://github.com/were)
 - [Haolong Zhang](https://github.com/haolongzhangm)
 - [Cody Hao Yu](https://github.com/comaniac)
 - [Chris Nuernberger](https://github.com/cnuernber)


### PR DESCRIPTION
This PR welcomes @were as a Reviewer of TVM stack. @were have deep expertise in the low-level IR and compiler passes. He initiated the hybrid script module of TVM and contributed tutorials on how to hack on the low-level compilers. He also helped to review the AutoTVM PR.

- [Commit history](https://github.com/dmlc/tvm/commits?author=were)
- [Code reviews](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=is%3Apr+reviewed-by%3Awere)
- [Community forum summary](https://discuss.tvm.ai/u/were/summary)