### PR TITLE
[Keras] fix weight shape in dilated conv

### DIFF
--- a/nnvm/python/nnvm/frontend/keras.py
+++ b/nnvm/python/nnvm/frontend/keras.py
@@ -155,6 +155,8 @@ def _convert_convolution(insym, keras_layer, symtab):
         dilation = [keras_layer.dilation_rate[0], keras_layer.dilation_rate[1]]
     else:
         dilation = [keras_layer.dilation_rate, keras_layer.dilation_rate]
+    dilated_kernel_h = (kernel_h - 1) * dilation[0] + 1
+    dilated_kernel_w = (kernel_w - 1) * dilation[1] + 1
     stride_h, stride_w = keras_layer.strides
     params = {'weight': symtab.new_const(weight),
               'kernel_size': [kernel_h, kernel_w],
@@ -176,8 +178,8 @@ def _convert_convolution(insym, keras_layer, symtab):
     elif keras_layer.padding == 'same':
         in_h = keras_layer.input_shape[1]
         in_w = keras_layer.input_shape[2]
-        pad_t, pad_b = _get_pad_pair(in_h, kernel_h, stride_h)
-        pad_l, pad_r = _get_pad_pair(in_w, kernel_w, stride_w)
+        pad_t, pad_b = _get_pad_pair(in_h, dilated_kernel_h, stride_h)
+        pad_l, pad_r = _get_pad_pair(in_w, dilated_kernel_w, stride_w)
         if pad_t == pad_b and pad_l == pad_r:
             params['padding'] = (pad_t, pad_l)
         else:

--- a/nnvm/python/nnvm/frontend/keras.py
+++ b/nnvm/python/nnvm/frontend/keras.py
@@ -58,8 +58,10 @@ def _convert_activation(insym, keras_layer, _):
         return _get_elu(insym, alpha)
     elif act_type == 'selu':
         # Alpha, Gamma values, obtained from  https://arxiv.org/abs/1706.02515
-        alpha = keras_layer.alpha if hasattr(keras_layer, "alpha") else 1.67326324235437728481704299
-        gamma = keras_layer.gamma if hasattr(keras_layer, "gamma") else 1.05070098735548049341933498
+        alpha = keras_layer.alpha if hasattr(keras_layer, "alpha") \
+            else 1.6732632423543772848170429916717
+        gamma = keras_layer.gamma if hasattr(keras_layer, "gamma") \
+            else 1.0507009873554804934193349852946
         return gamma * _get_elu(insym, alpha)
     elif act_type == 'relu6':
         return _sym.clip(insym, a_min=0, a_max=6)

--- a/nnvm/python/nnvm/frontend/keras.py
+++ b/nnvm/python/nnvm/frontend/keras.py
@@ -58,8 +58,8 @@ def _convert_activation(insym, keras_layer, _):
         return _get_elu(insym, alpha)
     elif act_type == 'selu':
         # Alpha, Gamma values, obtained from  https://arxiv.org/abs/1706.02515
-        alpha = keras_layer.alpha if hasattr(keras_layer, "alpha") else 1.6732
-        gamma = keras_layer.gamma if hasattr(keras_layer, "gamma") else 1.0507
+        alpha = keras_layer.alpha if hasattr(keras_layer, "alpha") else 1.67326324235437728481704299
+        gamma = keras_layer.gamma if hasattr(keras_layer, "gamma") else 1.05070098735548049341933498
         return gamma * _get_elu(insym, alpha)
     elif act_type == 'relu6':
         return _sym.clip(insym, a_min=0, a_max=6)

--- a/nnvm/python/nnvm/frontend/keras.py
+++ b/nnvm/python/nnvm/frontend/keras.py
@@ -155,8 +155,6 @@ def _convert_convolution(insym, keras_layer, symtab):
         dilation = [keras_layer.dilation_rate[0], keras_layer.dilation_rate[1]]
     else:
         dilation = [keras_layer.dilation_rate, keras_layer.dilation_rate]
-    kernel_h = (kernel_h - 1) * dilation[0] + 1
-    kernel_w = (kernel_w - 1) * dilation[1] + 1
     stride_h, stride_w = keras_layer.strides
     params = {'weight': symtab.new_const(weight),
               'kernel_size': [kernel_h, kernel_w],

--- a/nnvm/tests/python/frontend/keras/test_forward.py
+++ b/nnvm/tests/python/frontend/keras/test_forward.py
@@ -95,25 +95,20 @@ def test_forward_pool():
     verify_keras_frontend(keras_model)
 
 
-def test_forward_transpose_conv():
+def test_forward_conv():
     data = keras.layers.Input(shape=(32,32,3))
-    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2,2), padding='same')(data)
-    x = keras.layers.DepthwiseConv2D(kernel_size=(3,3), padding='same')(x)
-    x = keras.layers.Conv2DTranspose(filters=64, kernel_size=(3,3), padding='valid')(x)
-    x = keras.layers.GlobalMaxPooling2D()(x)
-    keras_model = keras.models.Model(data, x)
-    verify_keras_frontend(keras_model)
-
-
-def test_forward_separable_conv():
-    data = keras.layers.Input(shape=(32,32,3))
-    x = keras.layers.SeparableConv2D(filters=10, kernel_size=(3,3),
-        padding='same', activation='relu')(data)
-    x = keras.layers.BatchNormalization(scale=True, center=False,
-        beta_initializer='uniform', gamma_initializer='uniform')(x)
-    x = keras.layers.GlobalAveragePooling2D()(x)
-    keras_model = keras.models.Model(data, x)
-    verify_keras_frontend(keras_model)
+    conv_funcs = [keras.layers.Conv2D(filters=10, kernel_size=(3,3),
+                                      strides=(2,2), padding='same'),
+                  keras.layers.Conv2D(filters=10, kernel_size=(3,3),
+                                      dilation_rate=(2,2), padding='same'),
+                  keras.layers.DepthwiseConv2D(kernel_size=(3,3), padding='same'),
+                  keras.layers.Conv2DTranspose(filters=10, kernel_size=(3,3), padding='valid'),
+                  keras.layers.SeparableConv2D(filters=10, kernel_size=(3,3), padding='same')]
+    for conv_func in conv_funcs:
+        x = conv_func(data)
+        x = keras.layers.GlobalMaxPooling2D()(x)
+        keras_model = keras.models.Model(data, x)
+        verify_keras_frontend(keras_model)
 
 
 def test_forward_upsample():
@@ -239,8 +234,7 @@ if __name__ == '__main__':
     test_forward_activations()
     test_forward_dense()
     test_forward_pool()
-    test_forward_transpose_conv()
-    test_forward_separable_conv()
+    test_forward_conv()
     test_forward_upsample()
     test_forward_reshape()
     test_forward_crop()

--- a/nnvm/tests/python/frontend/keras/test_forward.py
+++ b/nnvm/tests/python/frontend/keras/test_forward.py
@@ -73,10 +73,10 @@ def test_forward_elemwise_add():
     keras_model = keras.models.Model(data, y)
     verify_keras_frontend(keras_model)
 
+
 def test_forward_dense():
-    data = keras.layers.Input(shape=(32,32,3))
-    x = keras.layers.MaxPooling2D(pool_size=(2,2))(data)
-    x = keras.layers.Flatten()(x)
+    data = keras.layers.Input(shape=(32,32,1))
+    x = keras.layers.Flatten()(data)
     x = keras.layers.Dropout(0.5)(x)
     x = keras.layers.Dense(10, activation='relu', kernel_initializer='uniform')(x)
     keras_model = keras.models.Model(data, x)
@@ -84,7 +84,7 @@ def test_forward_dense():
 
 
 def test_forward_pool():
-    data = keras.layers.Input(shape=(2,2,1))
+    data = keras.layers.Input(shape=(32,32,1))
     # maxpool
     x = keras.layers.MaxPooling2D((3, 3), strides=(1, 1), padding='same')(data)
     keras_model = keras.models.Model(data, x)
@@ -106,7 +106,7 @@ def test_forward_conv():
                   keras.layers.SeparableConv2D(filters=10, kernel_size=(3,3), padding='same')]
     for conv_func in conv_funcs:
         x = conv_func(data)
-        x = keras.layers.GlobalMaxPooling2D()(x)
+        x = keras.layers.GlobalAveragePooling2D()(x)
         keras_model = keras.models.Model(data, x)
         verify_keras_frontend(keras_model)
 
@@ -117,6 +117,7 @@ def test_forward_upsample():
     x = keras.layers.GlobalAveragePooling2D()(x)
     keras_model = keras.models.Model(data, x)
     verify_keras_frontend(keras_model)
+
 
 def test_forward_reshape():
     data = keras.layers.Input(shape=(32,32,3))
@@ -163,6 +164,7 @@ def test_forward_mobilenet():
         input_shape=(224,224,3), classes=1000)
     verify_keras_frontend(keras_model)
 
+
 def test_forward_activations():
     data = keras.layers.Input(shape=(32,32,3))
     weights = np.random.rand(1, 32, 32, 3)
@@ -182,9 +184,10 @@ def test_forward_activations():
                  keras.layers.Activation('linear')]
     for act_func in act_funcs:
         x = act_func(data)
-        x = keras.layers.GlobalMaxPooling2D()(x)
+        x = keras.layers.GlobalAveragePooling2D()(x)
         keras_model = keras.models.Model(data, x)
         verify_keras_frontend(keras_model)
+
 
 def test_forward_multi_inputs():
     data1 = keras.layers.Input(shape=(32,32,3))


### PR DESCRIPTION
The weight shape of dilated conv passed from frontend to nnvm compiler should be the original h and w, not including inserted zeros.