### PR TITLE
[NNVM][KERAS] Fix keras model converter and improve tutorial

### DIFF
--- a/nnvm/python/nnvm/frontend/keras.py
+++ b/nnvm/python/nnvm/frontend/keras.py
@@ -180,7 +180,10 @@ def _convert_convolution(insym, keras_layer, symtab):
         in_w = keras_layer.input_shape[2]
         pad_t, pad_b = _get_pad_pair(in_h, kernel_h, stride_h)
         pad_l, pad_r = _get_pad_pair(in_w, kernel_w, stride_w)
-        insym = _sym.pad(data=insym, pad_width=((0, 0), (0, 0), (pad_t, pad_b), (pad_l, pad_r)))
+        if pad_t == pad_b and pad_l == pad_r:
+            params['padding'] = (pad_t, pad_l)
+        else:
+            insym = _sym.pad(data=insym, pad_width=((0, 0), (0, 0), (pad_t, pad_b), (pad_l, pad_r)))
     else:
         raise TypeError("Unsupported padding type : {}".format(keras_layer.padding))
     if is_deconv:

--- a/tutorials/autotvm/tune_conv2d_cuda.py
+++ b/tutorials/autotvm/tune_conv2d_cuda.py
@@ -169,14 +169,16 @@ task = autotvm.task.create(conv2d_no_batching,
                            target='cuda')
 print(task.config_space)
 
-# use local gpu, measure 10 times for every config to reduce variance
+# Use local gpu, measure 10 times for every config to reduce variance
 # The timeout of compiling a program is 10 seconds, the timeout for running is 4 seconds
 measure_option = autotvm.measure_option(
     builder=autotvm.LocalBuilder(),
     runner=autotvm.LocalRunner(repeat=3, min_repeat_ms=100, timeout=4)
 )
 
-# begin tuning, log records to file `conv2d.log`
+# Begin tuning, log records to file `conv2d.log`
+# During tuning we will also try many invalid configs, so you are expected to
+# see many error reports. As long as you can see non-zero GFLOPS, it is okay.
 tuner = autotvm.tuner.XGBTuner(task)
 tuner.tune(n_trial=20,
            measure_option=measure_option,

--- a/tutorials/nnvm/deploy_ssd.py
+++ b/tutorials/nnvm/deploy_ssd.py
@@ -94,8 +94,7 @@ m.set_input(**params)
 # execute
 m.run()
 # get outputs
-_, oshape = compiler.graph_util.infer_shape(graph, shape={"data": dshape})
-tvm_output = m.get_output(0, tvm.nd.empty(tuple(oshape[0]), dtype))
+tvm_output = m.get_output(0)
 
 
 ######################################################################

--- a/tutorials/nnvm/from_coreml.py
+++ b/tutorials/nnvm/from_coreml.py
@@ -8,9 +8,11 @@ This article is an introductory tutorial to deploy CoreML models with NNVM.
 For us to begin with, coremltools module is required to be installed.
 
 A quick solution is to install via pip
-```bash
-pip install -U coremltools --user
-```
+
+.. code-block:: bash
+
+    pip install -U coremltools --user
+
 or please refer to official site
 https://github.com/apple/coremltools
 """
@@ -65,7 +67,8 @@ x = image[np.newaxis, :]
 import nnvm.compiler
 target = 'cuda'
 shape_dict = {'image': x.shape}
-graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
+with nnvm.compiler.build_config(opt_level=3):
+    graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
 
 ######################################################################
 # Execute on TVM
@@ -81,14 +84,13 @@ m.set_input(**params)
 # execute
 m.run()
 # get outputs
-output_shape = (1000,)
-tvm_output = m.get_output(0, tvm.nd.empty(output_shape, dtype)).asnumpy()
-top1 = np.argmax(tvm_output)
+tvm_output = m.get_output(0)
+top1 = np.argmax(tvm_output.asnumpy()[0])
 
 #####################################################################
 # Look up synset name
 # -------------------
-# Look up prdiction top 1 index in 1000 class synset.
+# Look up prediction top 1 index in 1000 class synset.
 synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '4d0b62f3d01426887599d4f7ede23ee5/raw/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',

--- a/tutorials/nnvm/from_coreml.py
+++ b/tutorials/nnvm/from_coreml.py
@@ -67,7 +67,7 @@ x = image[np.newaxis, :]
 import nnvm.compiler
 target = 'cuda'
 shape_dict = {'image': x.shape}
-with nnvm.compiler.build_config(opt_level=3):
+with nnvm.compiler.build_config(opt_level=2, add_pass=['AlterOpLayout']):
     graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
 
 ######################################################################

--- a/tutorials/nnvm/from_darknet.py
+++ b/tutorials/nnvm/from_darknet.py
@@ -106,7 +106,7 @@ print("Running the test image...")
 m.run()
 # get outputs
 out_shape = (net.outputs,)
-tvm_out = m.get_output(0).asnumpy()
+tvm_out = m.get_output(0).asnumpy().flatten()
 
 # do the detection and bring up the bounding boxes
 thresh = 0.24

--- a/tutorials/nnvm/from_keras.py
+++ b/tutorials/nnvm/from_keras.py
@@ -9,12 +9,12 @@ For us to begin with, keras should be installed.
 Tensorflow is also required since it's used as the default backend of keras.
 
 A quick solution is to install via pip
-```
-pip install -U keras --user
-```
-```
-pip install -U tensorflow --user
-```
+
+.. code-block:: bash
+
+    pip install -U keras --user
+    pip install -U tensorflow --user
+
 or please refer to official site
 https://keras.io/#installation
 """
@@ -45,7 +45,7 @@ weights_url = ''.join(['https://github.com/fchollet/deep-learning-models/release
 weights_file = 'resnet50_weights.h5'
 download(weights_url, weights_file)
 keras_resnet50 = keras.applications.resnet50.ResNet50(include_top=True, weights=None,
-	input_shape=(224,224,3), classes=1000)
+                                                      input_shape=(224, 224, 3), classes=1000)
 keras_resnet50.load_weights('resnet50_weights.h5')
 
 ######################################################################
@@ -75,8 +75,8 @@ sym, params = nnvm.frontend.from_keras(keras_resnet50)
 # compile the model
 target = 'cuda'
 shape_dict = {'input_1': data.shape}
-with nnvm.compiler.build_config(opt_level=2):
-	graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
+with nnvm.compiler.build_config(opt_level=3):
+    graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
 
 ######################################################################
 # Execute on TVM
@@ -91,14 +91,13 @@ m.set_input(**params)
 # execute
 m.run()
 # get outputs
-out_shape = (1000,)
-tvm_out = m.get_output(0, tvm.nd.empty(out_shape, 'float32')).asnumpy()
-top1_tvm = np.argmax(tvm_out)
+tvm_out = m.get_output(0)
+top1_tvm = np.argmax(tvm_out.asnumpy()[0])
 
 #####################################################################
 # Look up synset name
 # -------------------
-# Look up prdiction top 1 index in 1000 class synset.
+# Look up prediction top 1 index in 1000 class synset.
 synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '4d0b62f3d01426887599d4f7ede23ee5/raw/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',

--- a/tutorials/nnvm/from_mxnet.py
+++ b/tutorials/nnvm/from_mxnet.py
@@ -10,9 +10,11 @@ This article is an introductory tutorial to deploy mxnet models with NNVM.
 For us to begin with, mxnet module is required to be installed.
 
 A quick solution is
-```
-pip install mxnet --user
-```
+
+.. code-block:: bash
+
+    pip install mxnet --user
+
 or please refer to offical installation guide.
 https://mxnet.incubator.apache.org/versions/master/install/index.html
 """
@@ -70,7 +72,8 @@ sym = nnvm.sym.softmax(sym)
 import nnvm.compiler
 target = 'cuda'
 shape_dict = {'data': x.shape}
-graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
+with nnvm.compiler.build_config(opt_level=3):
+    graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
 
 ######################################################################
 # Execute the portable graph on TVM
@@ -86,8 +89,8 @@ m.set_input(**params)
 # execute
 m.run()
 # get outputs
-tvm_output = m.get_output(0, tvm.nd.empty((1000,), dtype))
-top1 = np.argmax(tvm_output.asnumpy())
+tvm_output = m.get_output(0)
+top1 = np.argmax(tvm_output.asnumpy()[0])
 print('TVM prediction top-1:', top1, synset[top1])
 
 ######################################################################

--- a/tutorials/nnvm/from_onnx.py
+++ b/tutorials/nnvm/from_onnx.py
@@ -8,9 +8,11 @@ This article is an introductory tutorial to deploy ONNX models with NNVM.
 For us to begin with, onnx module is required to be installed.
 
 A quick solution is to install protobuf compiler, and
-```bash
-pip install onnx --user
-```
+
+.. code-block:: bash
+
+    pip install onnx --user
+
 or please refer to offical site.
 https://github.com/onnx/onnx
 """
@@ -69,7 +71,8 @@ target = 'cuda'
 # assume first input name is data
 input_name = sym.list_input_names()[0]
 shape_dict = {input_name: x.shape}
-graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
+with nnvm.compiler.build_config(opt_level=3):
+    graph, lib, params = nnvm.compiler.build(sym, target, shape_dict, params=params)
 
 ######################################################################
 # Execute on TVM

--- a/tutorials/nnvm/from_tensorflow.py
+++ b/tutorials/nnvm/from_tensorflow.py
@@ -5,9 +5,7 @@ This article is an introductory tutorial to deploy tensorflow models with TVM.
 
 For us to begin with, tensorflow python module is required to be installed.
 
-A quick solution is to install tensorflow from
-
-https://www.tensorflow.org/install
+Please refer to https://www.tensorflow.org/install
 """
 
 # tvm and nnvm

--- a/tutorials/nnvm_quick_start.py
+++ b/tutorials/nnvm_quick_start.py
@@ -49,8 +49,8 @@ image_shape = (3, 224, 224)
 data_shape = (batch_size,) + image_shape
 out_shape = (batch_size, num_class)
 
-net, params = nnvm.testing.resnet.get_workload(layers=18,
-        batch_size=batch_size, image_shape=image_shape)
+net, params = nnvm.testing.resnet.get_workload(
+    layers=18, batch_size=batch_size, image_shape=image_shape)
 print(net.debug_str())
 
 ######################################################################
@@ -117,7 +117,7 @@ print(out.asnumpy().flatten()[0:10])
 from tvm.contrib import util
 
 temp = util.tempdir()
-path_lib = temp.relpath("deploy_lib.so")
+path_lib = temp.relpath("deploy_lib.tar")
 lib.export_library(path_lib)
 with open(temp.relpath("deploy_graph.json"), "w") as fo:
     fo.write(graph.json())
@@ -136,6 +136,4 @@ input_data = tvm.nd.array(np.random.uniform(size=data_shape).astype("float32"))
 module = graph_runtime.create(loaded_json, loaded_lib, tvm.gpu(0))
 module.load_params(loaded_params)
 module.run(data=input_data)
-
-out = module.get_output(0, out=tvm.nd.empty(out_shape))
-
+out = module.get_output(0).asnumpy()


### PR DESCRIPTION
In the current converter a single conv2d with padding in keras will be expanded into two nnvm symbols (sym.pad + sym.conv2d). This can harm the performance and result in some mismatches when using TopHub.
This pr fixes this.