### PR TITLE
[WIP] Buffer strides are required by tensorize

### DIFF
--- a/python/tvm/schedule.py
+++ b/python/tvm/schedule.py
@@ -139,6 +139,9 @@ class Buffer(NodeBase):
         begin = (begin,) if isinstance(begin, (int, _expr.Expr)) else begin
         return _api_internal._BufferVStore(self, begin, value)
 
+    def make_stride_view(self):
+        return _api_internal._BufferMakeStrideView(self)
+
 
 @register_node
 class Split(NodeBase):

--- a/python/tvm/tensor_intrin.py
+++ b/python/tvm/tensor_intrin.py
@@ -79,7 +79,7 @@ def decl_tensor_intrin(op,
         buf = (binds[t] if t in binds else
                _api.decl_buffer(t.shape, t.dtype, t.op.name,
                                 data_alignment=cfg.data_alignment,
-                                offset_factor=cfg.offset_factor))
+                                offset_factor=cfg.offset_factor).make_stride_view())
         binds_list.append(buf)
 
     body = fcompute(binds_list[:len(inputs)], binds_list[len(inputs):])

--- a/src/api/api_lang.cc
+++ b/src/api/api_lang.cc
@@ -220,6 +220,12 @@ TVM_REGISTER_API("_BufferVStore")
         .vstore(args[1], args[2]);
   });
 
+TVM_REGISTER_API("_BufferMakeStrideView")
+.set_body([](TVMArgs args,  TVMRetValue* ret) {
+    *ret = args[0].operator Buffer()
+        .MakeStrideView();
+  });
+
 TVM_REGISTER_API("_Tensor")
 .set_body([](TVMArgs args,  TVMRetValue* ret) {
     *ret = TensorNode::make(args[0],


### PR DESCRIPTION
If strides are not specified, the `vload`, `vstore` stuff will calculate buffer offset as https://github.com/dmlc/tvm/blob/master/src/lang/buffer.cc#L227-L239, but in tensorize, the tensor/buffer is passed from outside, with start address already includes the axes in the intrinsic, thus results the incorrect offset.

For example,
```python
def intrinc(in, outs):
  data = tvm.placeholder((d2,d3), dtype='uint8', name='data')
  data.vload([i2, i3])

Input = tvm.placeholder((d1, d2, d3))
s[Input].tensorize(Input.axis[1], intrinc) 
```
then the start offset passed to `intrinc` is `(i1 * d2 + 0) * d3 + 0`, without strides, `vload` will (incorrectly) return offset `((i1 * d2 + 0) * d3 + i2) * d3 + i3`

It is confusing to users to understand, in most cases, tensorize results will be incorrect without binding a buffer with strides.

Will come with test case and doc improvements.