### PR TITLE
[RUNTIME] Fix negative storage id at runtime for models compiled by older version

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -459,6 +459,16 @@ void GraphRuntime::SetupStorage() {
     vtype.push_back(tvm::runtime::String2TVMType(s_type));
   }
   data_entry_.resize(num_node_entries());
+  int max_id = 0;
+  for (size_t i = 0; i < attrs_.shape.size(); ++i) {
+    max_id = std::max(attrs_.storage_id[i] + 1, max_id);
+  }
+  for (uint32_t nid : input_nodes_) {
+    if (attrs_.storage_id[this->entry_id(nid, 0)] < 0) {
+      attrs_.storage_id[this->entry_id(nid, 0)] = max_id++;
+    }
+  }
+
   // size of each storage pool entry
   std::vector<size_t> pool_entry_bytes;
   // Find the maximum space size.


### PR DESCRIPTION
The change in runtime done by #990 broke models compiled by older version of tvm and nnvm. In older version of nnvm, storage ids for parameter nodes are all -1, and they are replaced by positive numbers at runtime. But #990 removed the id replacement at runtime and moved it to compile time. So running old models with a new runtime will cause seg fault, because storage ids are still -1.

This patch fix this issue. @tqchen please review. This is for backward compatibility, to avoid recompiling all models compiled by older tvm and nnvm for new runtime. 
   