### PR TITLE
[TOPI] Fix reduce behavior to be consistent with numpy

### DIFF
--- a/topi/include/topi/reduction.h
+++ b/topi/include/topi/reduction.h
@@ -95,9 +95,6 @@ inline Array<Expr> MakeReduceTargetShape(const std::vector<int>& real_axis,
         target_shape.push_back(data->shape[i]);
       }
     }
-    if (target_shape.size() == 0) {
-      target_shape.push_back(1);
-    }
   }
   return target_shape;
 }

--- a/topi/tests/python/test_topi_reduce.py
+++ b/topi/tests/python/test_topi_reduce.py
@@ -72,7 +72,6 @@ def verify_reduce_map_ele(in_shape, axis, keepdims, type="sum", dtype="float32")
             out_npy = _my_npy_argmin(in_npy_map, axis=axis, keepdims=keepdims)
         else:
             raise NotImplementedError
-        out_npy = np.atleast_1d(out_npy)
         data_tvm = tvm.nd.array(in_npy, ctx=ctx)
         out_tvm = tvm.nd.empty(shape=out_npy.shape, ctx=ctx, dtype=out_dtype)
         for _ in range(1):

--- a/topi/tests/python_cpp/test_topi_reduce.py
+++ b/topi/tests/python_cpp/test_topi_reduce.py
@@ -77,7 +77,6 @@ def verify_reduce_map_ele(in_shape, axis, keepdims, type="sum"):
             out_npy = in_npy_map.prod(axis=axis, keepdims=keepdims)
         else:
             raise NotImplementedError
-        out_npy = np.atleast_1d(out_npy)
         data_tvm = tvm.nd.array(in_npy, ctx=ctx)
         out_tvm = tvm.nd.empty(shape=out_npy.shape, ctx=ctx, dtype=out_dtype)
         for _ in range(1):


### PR DESCRIPTION
fix behavior inconsistency bought by #1628 

As a general principle, the behavior of topi should be consistent with numpy, and we should be consistent with numpy in future API designs

cc @yuruofeifei @yizhi 