### PR TITLE
Adding source types to C++ reduce functions to pass the type check for Tensorize

### DIFF
--- a/src/lang/ir_operator.cc
+++ b/src/lang/ir_operator.cc
@@ -9,7 +9,7 @@
 namespace tvm {
 
 Expr sum(Expr source, Array<IterVar> rdom) {
-  Var x("x"), y("y");
+  Var x("x", source.type()), y("y", source.type());
   Expr result = ir::Add::make(x, y);
   Expr identity_element = make_zero(source.type());
   ir::CommReducer combiner =
@@ -18,7 +18,7 @@ Expr sum(Expr source, Array<IterVar> rdom) {
 }
 
 Expr max(Expr source, Array<IterVar> rdom) {
-  Var x("x"), y("y");
+  Var x("x", source.type()), y("y", source.type());
   Expr result = ir::Max::make(x, y);
   Expr identity_element = source.type().min();
   ir::CommReducer combiner =
@@ -27,7 +27,7 @@ Expr max(Expr source, Array<IterVar> rdom) {
 }
 
 Expr min(Expr source, Array<IterVar> rdom) {
-  Var x("x"), y("y");
+  Var x("x", source.type()), y("y", source.type());
   Expr result = ir::Min::make(x, y);
   Expr identity_element = source.type().max();
   ir::CommReducer combiner =
@@ -36,7 +36,7 @@ Expr min(Expr source, Array<IterVar> rdom) {
 }
 
 Expr prod(Expr source, Array<IterVar> rdom) {
-  Var x("x"), y("y");
+  Var x("x", source.type()), y("y", source.type());
   Expr result = ir::Mul::make(x, y);
   Expr identity_element = make_one(source.type());
   ir::CommReducer combiner =


### PR DESCRIPTION
*Issue*
If the compute function uses reduce functions like sum, min and max from C++ APIs (as used for Pool operator), the datatypes default to INT32. This fails tensorize which performs a deep IR equality comparison. 

*Fix*
Use the source datatype instead of using the default ones.

*How to Test*
I am adding this script which fails in the absence of the fix. The script is not doing anything meaningful. So, please let me know if it makes any sense to add it to testing suite. Currently, I am pasting it here. 

```
import tvm
from topi.nn.pooling import pool

def intrin_pool():
    A = tvm.placeholder((64, 16, 16), name='A')
    kh = tvm.reduce_axis((0, 3), name='kh')
    kw = tvm.reduce_axis((0, 3), name='kw')
    P = tvm.compute((64, 14, 14),
                    lambda c, oh, ow: tvm.max(A[c, oh + kh, ow + kw],
                                      axis=[kh, kw]),
                    name='p')

    def intrin_func(ins, outs):
        dinp = ins[0]
        dout = outs[0]
        return tvm.call_packed("op", dinp, dout)

    with tvm.build_config(offset_factor=1):
        return tvm.decl_tensor_intrin(P.op, intrin_func)

if __name__ == '__main__':
    A = tvm.placeholder((1, 64, 16, 16), name='A')
    P = pool(data=A, kernel=(3, 3), stride=(1, 1), padding=(0, 0, 0, 0),
             pool_type='max')
    s = tvm.create_schedule(P.op)

    ## Compute function of Pool
    n, oh, ow, c = P.op.axis
    pool = intrin_pool()
    s[P].tensorize(oh, pool)
    tvm.lower(s, [A, P])
```

@yzhliu 