### PR TITLE
[Relay] Expose TypeRelation in Python

### DIFF
--- a/include/tvm/relay/type.h
+++ b/include/tvm/relay/type.h
@@ -229,6 +229,8 @@ class TypeRelationNode : public TypeConstraintNode {
 
   void VisitAttrs(tvm::AttrVisitor* v) final {
     v->Visit("name", &name);
+    v->Visit("func_", &name);
+    v->Visit("args", &args);
   }
 
   TVM_DLL static TypeRelation make(std::string name, TypeRelationFn func_, Array<Type> args);

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -21,6 +21,7 @@ Kind = ty.Kind
 TypeParam = ty.TypeParam
 TypeConstraint = ty.TypeConstraint
 FuncType = ty.FuncType
+TypeRelation = ty.TypeRelation
 
 # Expr
 Constant = expr.Constant

--- a/python/tvm/relay/ty.py
+++ b/python/tvm/relay/ty.py
@@ -111,12 +111,13 @@ class TypeRelation(Type):
         ----------
         name: the name of the relation
 
-        func: a function on types describing the relation,
+        func_: a function on types describing the relation,
               which takes a list of argument types and
               the number of argument types and returns
               a new list of types satisfying the relation
+              (possibly does not work in Python front-end)
 
-        args: the type arguemnts to the type function
+        args: the type arguments to the type function (list of types)
         """
         self.__init_handle_by_constructor__(_make.TypeRelation, name, func, args)
 

--- a/python/tvm/relay/ty.py
+++ b/python/tvm/relay/ty.py
@@ -94,6 +94,34 @@ class TypeConstraint(Type):
 
 
 @register_relay_node
+class TypeRelation(Type):
+    """A class representing an opaque input-output relation on types, see
+    tvm/relay/type.h for more details.
+
+    The relation takes as arguments types that must satisfy the intended
+    relation: Since some of the types may be incomplete, the fact that
+    the types satisfy the given relation may be used in later phases of
+    type checking to produce a concrete type.
+    """
+
+    def __init__(self, name, func, args):
+        """Constructs a TypeRelation.
+
+        Parameters
+        ----------
+        name: the name of the relation
+
+        func: a function on types describing the relation,
+              which takes a list of argument types and
+              the number of argument types and returns
+              a new list of types satisfying the relation
+
+        args: the type arguemnts to the type function
+        """
+        self.__init_handle_by_constructor__(_make.TypeRelation, name, func, args)
+
+
+@register_relay_node
 class TupleType(Type):
     """A tuple type in Relay, see tvm/relay/type.h for more details.
 

--- a/python/tvm/relay/ty.py
+++ b/python/tvm/relay/ty.py
@@ -94,7 +94,7 @@ class TypeConstraint(Type):
 
 
 @register_relay_node
-class TypeRelation(Type):
+class TypeRelation(TypeConstraint):
     """A class representing an opaque input-output relation on types, see
     tvm/relay/type.h for more details.
 

--- a/python/tvm/relay/ty.pyi
+++ b/python/tvm/relay/ty.pyi
@@ -95,6 +95,34 @@ class TypeConstraint(Type):
 
 
 @register_relay_node
+class TypeRelation(Type):
+    """A class representing an opaque input-output relation on types, see
+    tvm/relay/type.h for more details.
+
+    The relation takes as arguments types that must satisfy the intended
+    relation: Since some of the types may be incomplete, the fact that
+    the types satisfy the given relation may be used in later phases of
+    type checking to produce a concrete type.
+    """
+
+    def __init__(self, name, func, args):
+        """Constructs a TypeRelation.
+
+        Parameters
+        ----------
+        name: the name of the relation
+
+        func: a function on types describing the relation,
+              which takes a list of argument types and
+              the number of argument types and returns
+              a new list of types satisfying the relation
+
+        args: the type arguemnts to the type function
+        """
+        self.__init_handle_by_constructor__(_make.TypeRelation, name, func, args)
+
+
+@register_relay_node
 class TupleType(Type):
     """A tuple type in Relay, see tvm/relay/type.h for more details.
 

--- a/python/tvm/relay/ty.pyi
+++ b/python/tvm/relay/ty.pyi
@@ -95,7 +95,7 @@ class TypeConstraint(Type):
 
 
 @register_relay_node
-class TypeRelation(Type):
+class TypeRelation(TypeConstraint):
     """A class representing an opaque input-output relation on types, see
     tvm/relay/type.h for more details.
 

--- a/python/tvm/relay/ty.pyi
+++ b/python/tvm/relay/ty.pyi
@@ -112,12 +112,13 @@ class TypeRelation(Type):
         ----------
         name: the name of the relation
 
-        func: a function on types describing the relation,
+        func_: a function on types describing the relation,
               which takes a list of argument types and
               the number of argument types and returns
               a new list of types satisfying the relation
+              (possibly does not work in Python front-end)
 
-        args: the type arguemnts to the type function
+        args: the type arguments to the type function (list of types)
         """
         self.__init_handle_by_constructor__(_make.TypeRelation, name, func, args)
 

--- a/src/relay/pass/kind_check.cc
+++ b/src/relay/pass/kind_check.cc
@@ -45,8 +45,7 @@ struct KindChecker : TypeVisitor<> {
       return true;
     }
 
-    return t.as<TensorTypeNode>() || t.as<BaseTensorTypeNode>()
-      || t.as<TupleTypeNode>() || t.as<FuncTypeNode>();
+    return t.as_derived<BaseTensorTypeNode>() || t.as<TupleTypeNode>() || t.as<FuncTypeNode>();
   }
 
   void VisitType_(const TupleTypeNode* op) override {

--- a/src/relay/pass/kind_check.cc
+++ b/src/relay/pass/kind_check.cc
@@ -60,11 +60,19 @@ struct KindChecker : TypeVisitor<> {
   }
 
   void VisitType_(const FuncTypeNode* op) override {
-    // func types should only take normal types for arguments
-    // and only return a normal type
+    // Func types should only take normal types for arguments
+    // and only return a normal type. They should also have
+    // well-formed constraints
     for (const Type& t : op->arg_types) {
       this->VisitType(t);
       valid = valid && IsTypeKind(t);
+      if (!valid) {
+        return;
+      }
+    }
+
+    for (const TypeConstraint& tc : op->type_constraints) {
+      this->VisitType(tc);
       if (!valid) {
         return;
       }

--- a/tests/python/relay/test_check_kind.py
+++ b/tests/python/relay/test_check_kind.py
@@ -21,8 +21,10 @@ def test_func_kind():
     dtype = 'float32'
     tensor_type = relay.TensorType(shape, dtype)
 
+    tr = relay.TypeRelation('relation', None, tvm.convert([tp1, tensor_type]))
+
     type_params = tvm.convert([tp1, tp2])
-    type_constraints = tvm.convert([])
+    type_constraints = tvm.convert([tr])
     arg_types = tvm.convert([tp1, tensor_type])
     ret_type = relay.TupleType(tvm.convert([tp2, tensor_type]))
 
@@ -86,6 +88,15 @@ def test_func_with_invalid_tuple():
     ret_type = relay.TupleType(tvm.convert([tp1, tp1, tp1]))
 
     tf = relay.FuncType(tvm.convert([]), ret_type, tvm.convert([tp1]), tvm.convert([]))
+    assert not check_kind(tf)
+
+def test_func_with_invalid_relation():
+    tp1 = relay.TypeParam('tp1', relay.Kind.Type)
+    tp2 = relay.TypeParam('tp2', relay.Kind.Shape)
+
+    tr = relay.TypeRelation('relation', None, tvm.convert([tp2]))
+
+    tf = relay.FuncType(tvm.convert([tp1]), tp1, tvm.convert([tp1, tp2]), tvm.convert([tr]))
     assert not check_kind(tf)
 
 def test_tuple_with_invalid_func():

--- a/tests/python/relay/test_check_kind.py
+++ b/tests/python/relay/test_check_kind.py
@@ -29,6 +29,16 @@ def test_func_kind():
     tf = relay.FuncType(arg_types, ret_type, type_params, type_constraints)
     assert check_kind(tf)
 
+def test_type_relation_kind():
+    # only have type kinds for arguments
+    tp = relay.TypeParam('tp', relay.Kind.Type)
+    tt = relay.TensorType(tvm.convert([1, 2, 3]), 'float32')
+    tf = relay.FuncType(tvm.convert([]), tt, tvm.convert([]), tvm.convert([]))
+    args = tvm.convert([tp, tf, tt])
+
+    tr = relay.TypeRelation('relation', None, args)
+    assert check_kind(tr)
+
 def test_invalid_tuple_kinds():
     tp1 = relay.TypeParam('tp1', relay.Kind.Shape)
     tp2 = relay.TypeParam('tp2', relay.Kind.BaseType)
@@ -50,6 +60,15 @@ def test_invalid_func_kind():
 
     tf = relay.FuncType(arg_types, ret_type, type_params, type_constraints)
     assert not check_kind(tf)
+
+def test_invalid_relation_kind():
+    tp1 = relay.TypeParam('tp1', relay.Kind.Shape)
+    tp2 = relay.TypeParam('tp2', relay.Kind.BaseType)
+    tp3 = relay.TypeParam('tp3', relay.Kind.ShapeVar)
+    args = tvm.convert([tp1, tp2, tp3])
+
+    tr = relay.TypeRelation('relation', None, args)
+    assert not check_kind(tr)
 
 def test_func_with_invalid_ret_type():
     tp1 = relay.TypeParam('tp1', relay.Kind.Type)

--- a/tests/python/relay/test_ir_nodes.py
+++ b/tests/python/relay/test_ir_nodes.py
@@ -58,6 +58,17 @@ def test_tuple_type():
     assert tup_ty.fields == fields
 
 
+def test_type_relation():
+    name = 'relation'
+    func = None # not clear if this can be specified in the Python end
+    args = tvm.convert([relay.TypeParam('tp', relay.Kind.Type),
+                        relay.TensorType(tvm.convert([1, 2, 3]), 'float32')
+    ])
+
+    tr = relay.TypeRelation(name, func, args)
+    assert tr.name == name
+    assert tr.args == args
+
 def test_constant():
     arr = tvm.nd.array(10)
     const = relay.Constant(arr)


### PR DESCRIPTION
These changes ensure that the type relation class is exposed in Relay's Python front-end, with a couple of tiny bug fixes as well.

Slight issue is that of the `TypeRelationFun` (`func_`): I do not know how it can be set or read in Python or if it should be exposed in the Python representation.