### PR TITLE
[Relay][DOC] Add `docs/dev/relay_add_op.rst` to `docs/dev/index.rst`

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -11,3 +11,4 @@ In this part of documentation, we share the rationale for the specific choices m
    nnvm_json_spec
    nnvm_overview
    hybrid_script
+   relay_add_op


### PR DESCRIPTION
This is a one-liner patch which adds relay docs into the index tree...

Related PR: #1778 