### PR TITLE
Change error.h path in doc.h

### DIFF
--- a/src/relay/ir/doc.h
+++ b/src/relay/ir/doc.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <ostream>
 #include <map>
-#include "error.h"
+#include <tvm/relay/error.h>
 
 namespace tvm {
 namespace relay {


### PR DESCRIPTION
Fixes a bug likely caused by a discrepancy between gcc and clang where the compiler fails to resolve `error.h` during the build process.