### PR TITLE
Change cat image extension to png to match its download URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ perf
 *.h5
 synset.txt
 cat.jpg
+cat.png
 docs.tgz
 cat.png
 *.mlmodel

--- a/nnvm/tests/python/frontend/coreml/model_zoo/__init__.py
+++ b/nnvm/tests/python/frontend/coreml/model_zoo/__init__.py
@@ -25,7 +25,7 @@ def get_resnet50():
 
 def get_cat_image():
     url = 'https://gist.githubusercontent.com/zhreshold/bcda4716699ac97ea44f791c24310193/raw/fa7ef0e9c9a5daea686d6473a62aacd1a5885849/cat.png'
-    dst = 'cat.jpg'
+    dst = 'cat.png'
     real_dst = os.path.abspath(os.path.join(os.path.dirname(__file__), dst))
     download(url, real_dst)
     img = Image.open(real_dst).resize((224, 224))

--- a/tutorials/nnvm/deploy_model_on_mali_gpu.py
+++ b/tutorials/nnvm/deploy_model_on_mali_gpu.py
@@ -91,7 +91,7 @@ block = get_model('resnet18_v1', pretrained=True)
 ######################################################################
 # In order to test our model, here we download an image of cat and
 # transform its format.
-img_name = 'cat.jpg'
+img_name = 'cat.png'
 download('https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true', img_name)
 image = Image.open(img_name).resize((224, 224))
 

--- a/tutorials/nnvm/deploy_model_on_rasp.py
+++ b/tutorials/nnvm/deploy_model_on_rasp.py
@@ -88,7 +88,7 @@ block = get_model('resnet18_v1', pretrained=True)
 ######################################################################
 # In order to test our model, here we download an image of cat and
 # transform its format.
-img_name = 'cat.jpg'
+img_name = 'cat.png'
 download('https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true', img_name)
 image = Image.open(img_name).resize((224, 224))
 

--- a/tutorials/nnvm/from_keras.py
+++ b/tutorials/nnvm/from_keras.py
@@ -56,8 +56,8 @@ from PIL import Image
 from matplotlib import pyplot as plt
 from keras.applications.resnet50 import preprocess_input
 img_url = 'https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true'
-download(img_url, 'cat.jpg')
-img = Image.open('cat.jpg').resize((224, 224))
+download(img_url, 'cat.png')
+img = Image.open('cat.png').resize((224, 224))
 plt.imshow(img)
 plt.show()
 # input preprocess

--- a/tutorials/nnvm/from_mxnet.py
+++ b/tutorials/nnvm/from_mxnet.py
@@ -33,7 +33,7 @@ from mxnet.gluon.utils import download
 from PIL import Image
 from matplotlib import pyplot as plt
 block = get_model('resnet18_v1', pretrained=True)
-img_name = 'cat.jpg'
+img_name = 'cat.png'
 synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '4d0b62f3d01426887599d4f7ede23ee5/raw/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',

--- a/tutorials/nnvm/from_mxnet_to_webgl.py
+++ b/tutorials/nnvm/from_mxnet_to_webgl.py
@@ -148,7 +148,7 @@ def download_image():
     from PIL import Image
 
     url = "https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true"
-    img_name = "cat.jpg"
+    img_name = "cat.png"
 
     gluon.utils.download(url, img_name)
     image = Image.open(img_name).resize((224, 224))


### PR DESCRIPTION
Lots of examples/tutorials in the project use `cat.png` image from https://github.com/dmlc/mxnet.js/blob/master/data/cat.png

For some reason the image is saved to disk as `jpg` instead of `png`.
This PR fixes it.