### PR TITLE
Use ctx instead of tvm.gpu(0) in nnvm_quick_start tutorial

### DIFF
--- a/tutorials/nnvm_quick_start.py
+++ b/tutorials/nnvm_quick_start.py
@@ -133,7 +133,7 @@ loaded_lib = tvm.module.load(path_lib)
 loaded_params = bytearray(open(temp.relpath("deploy_param.params"), "rb").read())
 input_data = tvm.nd.array(np.random.uniform(size=data_shape).astype("float32"))
 
-module = graph_runtime.create(loaded_json, loaded_lib, tvm.gpu(0))
+module = graph_runtime.create(loaded_json, loaded_lib, ctx)
 module.load_params(loaded_params)
 module.run(data=input_data)
 out = module.get_output(0).asnumpy()


### PR DESCRIPTION
`nnvm_quick_start.py` defines `ctx = tvm.gpu()` on line 91.
We can use `ctx` variable on line 136  instead of calling `tvm.gpu(0)` again