### PR TITLE
Allow long type values in shape list

### DIFF
--- a/nnvm/python/nnvm/compiler/build_module.py
+++ b/nnvm/python/nnvm/compiler/build_module.py
@@ -251,8 +251,8 @@ def build(graph, target=None, shape=None, dtype="float32",
         if not isinstance(shape, dict):
             raise TypeError("require shape to be dict")
         for value in shape.values():
-            if not all(isinstance(x, int) for x in value):
-                raise TypeError("shape value must be int iterator")
+            if not all(isinstance(x, (int, long)) for x in value):
+                raise TypeError("shape value must be Integer types iterator")
 
         cfg = BuildConfig.current
         graph = graph if isinstance(graph, _graph.Graph) else _graph.create(graph)

--- a/nnvm/python/nnvm/compiler/build_module.py
+++ b/nnvm/python/nnvm/compiler/build_module.py
@@ -251,7 +251,7 @@ def build(graph, target=None, shape=None, dtype="float32",
         if not isinstance(shape, dict):
             raise TypeError("require shape to be dict")
         for value in shape.values():
-            if not all(isinstance(x, (int, long)) for x in value):
+            if not all(isinstance(x, tvm._ffi.base.integer_types) for x in value):
                 raise TypeError("shape value must be Integer types iterator")
 
         cfg = BuildConfig.current


### PR DESCRIPTION
I tried to compile resnet18_v1 model with opt_level=2 on ARMv7 Raspberry Pi 3 Model B+ using python2.7 and I got error - "shape value must be int iterator"
code to compile the model - https://gist.github.com/apivovarov/960a28fc1bbd5dbdb856c0ede6724f30

Error:
```
('model:', 'resnet18_v1', ', target:', 'llvm', ', opt_level:', 3, ', data_shape:', (1, 3, 224, 224))
Compiling...
Traceback (most recent call last):
  File "compile.py", line 25, in <module>
    graph, lib, params = nnvm.compiler.build(sym, target, shape={"data": data_shape}, params=params)
  File "/usr/local/lib/python2.7/dist-packages/nnvm-0.8.0-py2.7.egg/nnvm/compiler/build_module.py", line 288, in build
    graph, params = precompute_prune(graph, params)
  File "/usr/local/lib/python2.7/dist-packages/nnvm-0.8.0-py2.7.egg/nnvm/compiler/build_module.py", line 407, in precompute_prune
    out_arrs = _run_graph(pre_graph, params)
  File "/usr/local/lib/python2.7/dist-packages/nnvm-0.8.0-py2.7.egg/nnvm/compiler/build_module.py", line 356, in _run_graph
    graph, libmod, _ = build(graph, target, shape, dtype)
  File "/usr/local/lib/python2.7/dist-packages/nnvm-0.8.0-py2.7.egg/nnvm/compiler/build_module.py", line 255, in build
    raise TypeError("shape value must be int iterator")
TypeError: shape value must be int iterator
```

I checked the content of `shape.values()`  (build_module.py line 255) and saw that it contains long values instead of int values.
I was told that int/long types mess is known python2.7 issue on 32bit platforms.
```
[(256L,), (64L,), (512L,), (128L,), (64L, 64L, 3L, 3L), (128L, 64L, 1L, 1L), (256L,), (256L,), (64L,), (512L,), (128L,), (256L,), (256L, 256L, 3L, 3L), (256L,), (1000L,), (64L,), (64L,), (1000L, 512L), (256L,), (128L,), (512L,), (512L,), (512L,), (512L,), (256L,), (128L,), (256L, 128L, 1L, 1L), (256L,), (256L,), (512L,), (64L,), (64L,), (128L, 128L, 3L, 3L), (512L, 256L, 1L, 1L), (128L,), (256L,), (512L,), (128L,), (512L,), (512L,), (256L,), (256L,), (64L,), (128L, 128L, 3L, 3L), (256L,), (128L,), (512L,), (512L,), (64L,), (256L, 256L, 3L, 3L), (256L,), (64L,), (64L, 64L, 3L, 3L), (256L,), (64L,), (64L,), (128L,), (128L,), (128L,), (512L, 256L, 3L, 3L), (128L, 64L, 3L, 3L), (128L,), (512L,), (512L,), (512L,), (512L, 512L, 3L, 3L), (128L,), (512L,), (512L,), (64L,), (256L,), (128L,), (512L, 512L, 3L, 3L), (512L,), (64L, 64L, 3L, 3L), (256L,), (64L,), (256L,), (64L, 64L, 3L, 3L), (128L,), (128L,), (64L,), (64L,), (512L, 512L, 3L, 3L), (64L,), (128L,), (256L,), (64L,), (512L,), (128L,), (256L, 256L, 3L, 3L), (128L,), (64L, 3L, 7L, 7L), (256L,), (256L, 128L, 3L, 3L), (128L, 128L, 3L, 3L), (128L,), (64L,), (512L,), (64L,), (64L,), (128L,)]
```

This PR solves the issue by allowing long type values in shape list.