### PR TITLE
[RELAY][OP] expand_dims

### DIFF
--- a/docs/langref/relay_op.rst
+++ b/docs/langref/relay_op.rst
@@ -26,6 +26,7 @@ This level enables fully connected multi-layer perceptron.
    tvm.relay.sqrt
    tvm.relay.exp
    tvm.relay.add
+   tvm.relay.expand_dims
 
 **Level 2: Convolutions**
 

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -3,8 +3,8 @@
  * \file tvm/relay/attrs/nn.h
  * \brief Auxiliary attributes for nn operators.
  */
-#ifndef TVM_RELAY_ATTRS_NN_H_
-#define TVM_RELAY_ATTRS_NN_H_
+#ifndef TVM_RELAY_ATTRS_TRANSFORM_H_
+#define TVM_RELAY_ATTRS_TRANSFORM_H_
 
 #include <tvm/attrs.h>
 #include <string>
@@ -30,4 +30,4 @@ struct ExpandDimsAttrs : public tvm::AttrsNode<ExpandDimsAttrs> {
 
 }  // namespace relay
 }  // namespace tvm
-#endif  // TVM_RELAY_ATTRS_NN_H_
+#endif  // TVM_RELAY_ATTRS_TRANSFORM_H_

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -14,16 +14,18 @@ namespace relay {
 
 /*! \brief Attributes used in expand_dims operators */
 struct ExpandDimsAttrs : public tvm::AttrsNode<ExpandDimsAttrs> {
-  // TODO(Junru): docstring
   int axis;
   int num_newaxis;
 
   TVM_DECLARE_ATTRS(ExpandDimsAttrs, "relay.attrs.ExpandDimsAttrs") {
     TVM_ATTR_FIELD(axis)
-        .describe("Position in the expanded axes where the new axis is placed.")
-        .set_default(0);
+        .describe("The axis at which the input array is expanded."
+                  "Should lie in range `[-data.ndim - 1, data.ndim]`."
+                  "If `axis < 0`, it is the first axis inserted;"
+                  "If `axis >= 0`, it is the last axis inserted in Python's negative indexing.");
     TVM_ATTR_FIELD(num_newaxis)
-        .describe("Number of new axis to be inserted.")
+        .describe("Number of axises to be inserted. Should be >= 0.")
+        .set_lower_bound(0)
         .set_default(1);
   }
 };  // struct ExpandDimsAttrs

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -1,0 +1,33 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file tvm/relay/attrs/nn.h
+ * \brief Auxiliary attributes for nn operators.
+ */
+#ifndef TVM_RELAY_ATTRS_NN_H_
+#define TVM_RELAY_ATTRS_NN_H_
+
+#include <tvm/attrs.h>
+#include <string>
+
+namespace tvm {
+namespace relay {
+
+/*! \brief Attributes used in expand_dims operators */
+struct ExpandDimsAttrs : public tvm::AttrsNode<ExpandDimsAttrs> {
+  // TODO(Junru): docstring
+  int axis;
+  int num_newaxis;
+
+  TVM_DECLARE_ATTRS(ExpandDimsAttrs, "relay.attrs.ExpandDimsAttrs") {
+    TVM_ATTR_FIELD(axis)
+        .describe("Position in the expanded axes where the new axis is placed.")
+        .set_default(0);
+    TVM_ATTR_FIELD(num_newaxis)
+        .describe("Number of new axis to be inserted.")
+        .set_default(1);
+  }
+};  // struct ExpandDimsAttrs
+
+}  // namespace relay
+}  // namespace tvm
+#endif  // TVM_RELAY_ATTRS_NN_H_

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2018 by Contributors
- * \file tvm/relay/attrs/nn.h
- * \brief Auxiliary attributes for nn operators.
+ * \file tvm/relay/attrs/transform.h
+ * \brief Transform operators.
  */
 #ifndef TVM_RELAY_ATTRS_TRANSFORM_H_
 #define TVM_RELAY_ATTRS_TRANSFORM_H_

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -11,6 +11,7 @@ from . import ir_builder
 from .op import Op
 from .op.tensor import *
 from . import nn
+from .op.transform import *
 
 # Span
 Span = base.Span

--- a/python/tvm/relay/op/__init__.py
+++ b/python/tvm/relay/op/__init__.py
@@ -6,7 +6,7 @@ from .op import get, register, Op
 # Operators
 from .tensor import *
 from . import nn
-from . import transform
+from .transform import *
 
 
 # operator registry

--- a/python/tvm/relay/op/__init__.py
+++ b/python/tvm/relay/op/__init__.py
@@ -6,6 +6,7 @@ from .op import get, register, Op
 # Operators
 from .tensor import *
 from . import nn
+from . import transform
 
 
 # operator registry

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -19,5 +19,10 @@ def expand_dims(data, axis, num_newaxis=1):
 
     num_newaxis : int
         Number of axises to be inserted. Should be >= 0.
+
+    Returns
+    -------
+    result : relay.Expr
+        The reshaped result.
     """
     return _make.expand_dims(data, axis, num_newaxis)

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -4,6 +4,20 @@ from . import _make
 
 
 def expand_dims(data, axis, num_newaxis=1):
-    """TODO(Junru): docstring
+    """Insert `num_newaxis` axises at the position given by `axis`.
+
+    Parameters
+    ----------
+    data : relay.Expr
+        The input data to the operator.
+
+    axis : int
+        The axis at which the input array is expanded.
+        Should lie in range `[-data.ndim - 1, data.ndim]`.
+        If `axis < 0`, it is the first axis inserted;
+        If `axis >= 0`, it is the last axis inserted in Python's negative indexing.
+
+    num_newaxis : int
+        Number of axises to be inserted. Should be >= 0.
     """
     return _make.expand_dims(data, axis, num_newaxis)

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1,4 +1,4 @@
-"""Reshaping tensor operations."""
+"""Transform operators."""
 
 from . import _make
 

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -1,0 +1,9 @@
+"""Reshaping tensor operations."""
+
+from . import _make
+
+
+def expand_dims(data, axis, num_newaxis=1):
+    """TODO(Junru): docstring
+    """
+    return _make.expand_dims(data, axis, num_newaxis)

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2018 by Contributors
- * \file reshape.cc
- * \brief Reshape-related operators
+ * \file transform.cc
+ * \brief Transform operators.
  */
 #include <tvm/relay/op.h>
 #include <tvm/relay/attrs/transform.h>

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -23,16 +23,17 @@ bool ExpandDimsRel(const Array<Type>& types,
   if (data == nullptr) {
     return false;
   }
-  // `param` contains: axis, num_newaxis
   const ExpandDimsAttrs* param = attrs.as<ExpandDimsAttrs>();
   const int ndim = static_cast<int>(data->shape.size());
   const int axis = param->axis;
   const int num_newaxis = param->num_newaxis;
-  // TODO(Junru): check if we really support negative indexing
+  CHECK(num_newaxis >= 0)
+    << "expand_dims only accepts `num_newaxis >= 0`"
+    << ", but got num_newaxis = " << num_newaxis;
   CHECK(-ndim - 1 <= axis && axis <= ndim)
-    << "expand_dims allows only `axis` in [-ndim - 1, ndim]"
-    << " But got axis = " << axis
-    << " and ndim = " << ndim;
+    << "expand_dims only accepts `axis` in [-data.ndim - 1, data.ndim]"
+    << ", but got axis = " << axis
+    << ", and data.ndim = " << ndim;
   const int pivot = axis < 0 ? ndim + axis + 1 : axis;
   std::vector<IndexExpr> oshape;
   oshape.reserve(ndim + num_newaxis);
@@ -64,9 +65,11 @@ TVM_REGISTER_API("relay.op._make.expand_dims")
     runtime::detail::unpack_call<Expr, 3>(MakeExpandDims, args, rv);
 });
 
-// TODO(Junru)
 RELAY_REGISTER_OP("expand_dims")
-.describe(R"code(TODO(Junru)
+.describe(R"code(Insert `num_newaxis` axises at the position given by `axis`
+
+- **data**: The input data to the operator.
+
 )code" TVM_ADD_FILELINE)
 .set_num_inputs(1)
 .add_argument("data", "Tensor", "The input tensor.")

--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1,0 +1,78 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file reshape.cc
+ * \brief Reshape-related operators
+ */
+#include <tvm/relay/op.h>
+#include <tvm/relay/attrs/transform.h>
+#include <vector>
+
+
+namespace tvm {
+namespace relay {
+
+TVM_REGISTER_NODE_TYPE(ExpandDimsAttrs);
+
+bool ExpandDimsRel(const Array<Type>& types,
+                   int num_inputs,
+                   const Attrs& attrs,
+                   const TypeReporter& reporter) {
+  // `types` contains: [data, output]
+  CHECK_EQ(types.size(), 2);
+  const auto* data = types[0].as<TensorTypeNode>();
+  if (data == nullptr) {
+    return false;
+  }
+  // `param` contains: axis, num_newaxis
+  const ExpandDimsAttrs* param = attrs.as<ExpandDimsAttrs>();
+  const int ndim = static_cast<int>(data->shape.size());
+  const int axis = param->axis;
+  const int num_newaxis = param->num_newaxis;
+  // TODO(Junru): check if we really support negative indexing
+  CHECK(-ndim - 1 <= axis && axis <= ndim)
+    << "expand_dims allows only `axis` in [-ndim - 1, ndim]"
+    << " But got axis = " << axis
+    << " and ndim = " << ndim;
+  const int pivot = axis < 0 ? ndim + axis + 1 : axis;
+  std::vector<IndexExpr> oshape;
+  oshape.reserve(ndim + num_newaxis);
+  for (int i = 0; i < pivot; ++i) {
+    oshape.emplace_back(data->shape[i]);
+  }
+  for (int i = 0; i < num_newaxis; ++i) {
+    oshape.emplace_back(1);
+  }
+  for (int i = pivot; i < ndim; ++i) {
+    oshape.emplace_back(data->shape[i]);
+  }
+  reporter->Assign(types[1], TensorTypeNode::make(oshape, data->dtype));
+  return true;
+}
+
+Expr MakeExpandDims(Expr data,
+                    int axis,
+                    int num_newaxis) {
+  auto attrs = make_node<ExpandDimsAttrs>();
+  attrs->axis = axis;
+  attrs->num_newaxis = num_newaxis;
+  static const Op& op = Op::Get("expand_dims");
+  return CallNode::make(op, {data}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_API("relay.op._make.expand_dims")
+.set_body([](const TVMArgs& args, TVMRetValue* rv) {
+    runtime::detail::unpack_call<Expr, 3>(MakeExpandDims, args, rv);
+});
+
+// TODO(Junru)
+RELAY_REGISTER_OP("expand_dims")
+.describe(R"code(TODO(Junru)
+)code" TVM_ADD_FILELINE)
+.set_num_inputs(1)
+.add_argument("data", "Tensor", "The input tensor.")
+.set_support_level(1)
+.add_type_rel("ExpandDims", ExpandDimsRel);
+
+
+}  // namespace relay
+}  // namespace tvm

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -8,7 +8,7 @@ def test_expand_dims_infer_type():
     # let's mimic a batch of sequences
     x = ib.param("x", relay.ty.TensorType((n, t, d), "float32"))
     with ib.function(x) as func:
-        ib.ret(relay.transform.expand_dims(x, axis=2))
+        ib.ret(relay.expand_dims(x, axis=2))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type()

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -1,0 +1,20 @@
+import tvm
+from tvm import relay
+
+
+def test_expand_dims_infer_type():
+    ib = relay.ir_builder.IRBuilder()
+    n, t, d = tvm.var("n"), tvm.var("t"), 100
+    # let's mimic a batch of sequences
+    x = ib.param("x", relay.ty.TensorType((n, t, d), "float32"))
+    with ib.function(x) as func:
+        ib.ret(relay.transform.expand_dims(x, axis=2))
+    ib.ret(func)
+    func = relay.ir_pass.infer_type(ib.env, func.to_func())
+    ftype = func.checked_type()
+    assert ftype.ret_type == relay.ty.TensorType(
+        (n, t, 1, 100), "float32")
+
+
+if __name__ == "__main__":
+    test_expand_dims_infer_type()

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -37,10 +37,18 @@ inline Tensor expand_dims(const Tensor& x,
                           int num_newaxis = 1,
                           std::string name = "tensor",
                           std::string tag = kBroadcast) {
+  int ndim = static_cast<int>(x->shape.size());
   if (axis < 0) {
     // Calculate offset from last dimension
-    axis = static_cast<int>(x->shape.size()) + axis + 1;
+    axis = ndim + axis + 1;
   }
+  CHECK(-ndim - 1 <= axis && axis <= ndim)
+    << "expand_dims only accepts `axis` in [-data.ndim - 1, data.ndim]"
+    << ", but got axis = " << axis
+    << ", and data.ndim = " << ndim;
+  CHECK(num_newaxis >= 0)
+    << "expand_dims only accepts `num_newaxis >= 0`"
+    << ", but got num_newaxis = " << num_newaxis;
 
   Array<Expr> new_shape;
   for (size_t i = 0; i < static_cast<size_t>(axis); ++i) {


### PR DESCRIPTION
This PR contains a relay operator, `expand_dims`.

TODO:
- [x] Docstrings
- [x] I didn't see a boundary checking for `axis` in [topi](https://github.com/dmlc/tvm/blob/0247b97198b0fecf82e6ca44d2f34bc8dfc3540f/topi/include/topi/transform.h#L42). Did I miss anything?
- [x] API inconsistency with [numpy.expand_dims](https://docs.scipy.org/doc/numpy/reference/generated/numpy.expand_dims.html). Our API looks like `expand_dims(data, axis, num_newaxis=1)`, but numpy API is `expand_dims(a, axis) `. I think it is okay because ours seem to be a superset.
- [x] I implemented `axis` and `num_newaxis` as `int`. Wondering if it is possible to make them `IndexExpr`, so that `axis` could depend on some intermediate result of computation.

I am working on the docstring, and @tqchen could you help comment on the TODO 2, 3, 4?

Related issue: #1799 