### PR TITLE
Make Rust CI builds faster

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -15,6 +15,18 @@ RUN bash /install/ubuntu_install_python_package.sh
 COPY install/ubuntu_install_llvm.sh /install/ubuntu_install_llvm.sh
 RUN bash /install/ubuntu_install_llvm.sh
 
+# SGX deps (build early; changes infrequently)
+COPY install/ubuntu_install_sgx.sh /install/ubuntu_install_sgx.sh
+RUN bash /install/ubuntu_install_sgx.sh
+ENV LD_LIBRARY_PATH /opt/sgxsdk/lib64:${LD_LIBRARY_PATH}
+
+# Rust env (build early; takes a while)
+COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
+RUN bash /install/ubuntu_install_rust.sh
+ENV RUSTUP_HOME /opt/rust
+ENV CARGO_HOME /opt/rust
+ENV RUSTC_WRAPPER sccache
+
 # AutoTVM deps
 COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh
 RUN bash /install/ubuntu_install_redis.sh
@@ -22,17 +34,5 @@ RUN bash /install/ubuntu_install_redis.sh
 # Golang environment
 COPY install/ubuntu_install_golang.sh /install/ubuntu_install_golang.sh
 RUN bash /install/ubuntu_install_golang.sh
-
-# Rust env
-COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
-RUN bash /install/ubuntu_install_rust.sh
-ENV RUSTUP_HOME /opt/rust
-ENV CARGO_HOME /opt/rust
-
-# SGX deps
-COPY install/ubuntu_install_sgx.sh /install/ubuntu_install_sgx.sh
-RUN bash /install/ubuntu_install_sgx.sh
-ENV LD_LIBRARY_PATH /opt/sgxsdk/lib64:${LD_LIBRARY_PATH}
-
 
 ENV PATH $PATH:$CARGO_HOME/bin:/usr/lib/go-1.10/bin

--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -9,6 +9,7 @@ rustup toolchain add nightly
 rustup component add rust-src
 cargo +nightly install rustfmt-nightly --version 0.99.5 --force
 cargo +nightly install xargo
+cargo +nightly install sccache
 
 # make rust usable by all users
 chmod a+w /opt/rust


### PR DESCRIPTION
This PR

* moves the rust stuff to before the other dependencies in the Dockerfile to make local development easier for most people (i.e. people who want to change the AutoTVM and Go deps)
* adds `sccache` to cache rust builds. makes ci faster by like 3 minutes