### PR TITLE
Allow override gtest library search path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ target_include_directories(
 # Tests
 set(TEST_EXECS "")
 file(GLOB TEST_SRCS tests/cpp/*.cc)
-find_library(GTEST_LIB gtest)
+find_library(GTEST_LIB gtest "$ENV{GTEST_LIB}")
 
 if(GTEST_LIB)
   foreach(__srcpath ${TEST_SRCS})


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from others in the community.

With this change, we don't need to install `gtest` system wide anymore. A typical usage would look like:
````bash
# install gtest into `tvm/lib`
CACHE_PREFIX=. make -f 3rdparty/dmlc-core/scripts/packages.mk gtest
GTEST_LIB=$TVM_ROOT/lib cmake ..
make cpptest -j
````

If `GTEST_LIB` is not specified, it will look for system wide gtest library.