### PR TITLE
Supported Shape/Reshape in TensorFlow Frontend

### DIFF
--- a/nnvm/python/nnvm/compiler/build_module.py
+++ b/nnvm/python/nnvm/compiler/build_module.py
@@ -308,7 +308,9 @@ def build(graph, target=None, shape=None, dtype="float32",
         if init_var:
             if params is None:
                 params = {}
-            params.update(init_var)
+            for k, _ in init_var.items():
+                if k in graph.index.input_names:
+                    params.update(init_var)
         return graph, libmod, params
 
 def _remove_noref_params(params, graph):

--- a/nnvm/python/nnvm/graph.py
+++ b/nnvm/python/nnvm/graph.py
@@ -31,6 +31,11 @@ class GraphIndex(object):
         self.output_entries = jgraph["heads"]
 
     @property
+    def node_list(self):
+        """Get the node list."""
+        return self.nodes
+
+    @property
     def num_nodes(self):
         """Number of nodes in graph."""
         return len(self.entry_ptr) - 1

--- a/nnvm/tests/python/frontend/tensorflow/test_forward.py
+++ b/nnvm/tests/python/frontend/tensorflow/test_forward.py
@@ -260,6 +260,26 @@ def test_forward_reshape():
     _test_reshape(np.arange(6), [-1])
 
 #######################################################################
+# Shape
+# -------
+
+def _test_shape(data, data2):
+    """ One iteration of reshape operation with given data and out shape """
+
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        shape = array_ops.shape(data2)
+        array_ops.reshape(in_data, shape)
+
+        compare_tf_with_tvm(data, 'Placeholder:0', 'Reshape:0')
+
+def test_forward_shape():
+    _test_shape(np.arange(6.0), np.asarray([1,1,1,1,1,1]))
+    _test_shape(np.asarray([[10, 20]]), np.zeros((1,2)))
+    _test_shape(np.asarray([[[10, 20]]]), np.zeros([1,1,2]))
+
+#######################################################################
+#######################################################################
 # Squeeze
 # -------
 
@@ -937,7 +957,7 @@ def test_forward_leaky_relu():
     with tf.Graph().as_default():
         in1 = tf.placeholder(shape=inp_array.shape, dtype=inp_array.dtype)
         tf.nn.leaky_relu(in1, alpha=0.4)
-        compare_tf_with_tvm(inp_array, 'Placeholder:0', 'LeakyRelu:0')
+        compare_tf_with_tvm(inp_array, 'Placeholder:0', 'LeakyRelu/mul:0')
 
 def test_forward_elu():
     ishape = (1, 3, 10, 10)
@@ -1007,6 +1027,7 @@ if __name__ == '__main__':
     # Transforms
     test_forward_transpose()
     test_forward_reshape()
+    test_forward_shape()
     test_forward_squeeze()
     test_forward_pack()
     test_forward_resize_bilinear()
@@ -1055,3 +1076,5 @@ if __name__ == '__main__':
 
     # Relational ops
     test_forward_rel_ops()
+
+    print("Regression passed")


### PR DESCRIPTION
Added a constant Symbol for supporting Shape in TensorFlow frotnend.
Since a Symbol is returned from Shape, updated Reshape to handle Symbols as the second input.
Modified handling of constant Symbol to Params. This avoids adding constant Symbols to Params if the Symbol is not a graph node.
Added a test for Shape