### PR TITLE
Use new onnx API to load model from file

### DIFF
--- a/nnvm/tests/python/frontend/onnx/test_forward.py
+++ b/nnvm/tests/python/frontend/onnx/test_forward.py
@@ -66,7 +66,7 @@ def get_caffe2_output(model, x, dtype='float32'):
 def verify_onnx_forward_impl(graph_file, data_shape, out_shape):
     dtype = 'float32'
     x = np.random.uniform(size=data_shape)
-    model = onnx.load(graph_file)
+    model = onnx.load_model(graph_file)
     c2_out = get_caffe2_output(model, x, dtype)
     for target, ctx in ctx_list():
         tvm_out = get_tvm_output(model, x, target, ctx, out_shape, dtype)

--- a/nnvm/tests/python/frontend/onnx/test_graph.py
+++ b/nnvm/tests/python/frontend/onnx/test_graph.py
@@ -6,7 +6,7 @@ from model_zoo import super_resolution, super_resolution_sym
 from model_zoo import squeezenet as squeezenet
 
 def compare_graph(onnx_file, nnvm_sym, ishape):
-    onnx_model = onnx.load(onnx_file)
+    onnx_model = onnx.load_model(onnx_file)
     onnx_sym, params = nnvm.frontend.from_onnx(onnx_model)
     g1 = nnvm.graph.create(onnx_sym)
     g2 = nnvm.graph.create(nnvm_sym)

--- a/tutorials/nnvm/from_onnx.py
+++ b/tutorials/nnvm/from_onnx.py
@@ -46,7 +46,7 @@ model_url = ''.join(['https://gist.github.com/zhreshold/',
                      'super_resolution_0.2.onnx'])
 download(model_url, 'super_resolution.onnx', True)
 # now you have super_resolution.onnx on disk
-onnx_model = onnx.load('super_resolution.onnx')
+onnx_model = onnx.load_model('super_resolution.onnx')
 # we can load the graph as NNVM compatible model
 sym, params = nnvm.frontend.from_onnx(onnx_model)
 


### PR DESCRIPTION
## Description ##
ONNX module was refactored about 6 month ago.
Old method `onnx.load(file)` was replaced with `onnx.load_model(file)` in onnx version 1.2.1

https://github.com/onnx/onnx/blob/rel-1.2.1/onnx/__init__.py

