### PR TITLE
Correction for config filename

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -43,7 +43,7 @@ export PATH=${PATH}:/emsdk-related-path-here
 
 ### Build TVM with Fastcomp LLVM
 
-To build TVM with Emscripten's Fastcomp LLVM, we can modify the LLVM_CONFIG in ```config.mk```
+To build TVM with Emscripten's Fastcomp LLVM, we can modify the LLVM_CONFIG in ```config.cmake```
 to point to fastcomp's llvm-config and build TVM normally.
 
 ```bash


### PR DESCRIPTION
The LLVM_CONFIG parameter should be set in the config.cmake file for building with the emscripten llvm.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from others in the community.
