### PR TITLE
[RELAY][IR] Move type_annotation to Var, remove Param

### DIFF
--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -369,7 +369,7 @@ RELAY_DEFINE_NODE_REF(If, IfNode, Expr);
 class TupleGetItem;
 class TupleGetItemNode : public ExprNode {
  public:
-  /*! \brief The tuple expression */
+  /*! \brief The tuple Expression */
   Expr tuple;
   /*! \brief which value to get */
   int index;

--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -80,7 +80,6 @@ class ExprFunctor<R(const Expr& n, Args...)> {
                        Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const GlobalVarNode* op,
                        Args... args) EXPR_FUNCTOR_DEFAULT;
-  virtual R VisitExpr_(const ParamNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const FunctionNode* op,
                        Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const CallNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
@@ -103,7 +102,6 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAY_EXPR_FUNCTOR_DISPATCH(TupleNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(VarNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(GlobalVarNode);
-    RELAY_EXPR_FUNCTOR_DISPATCH(ParamNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(FunctionNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(CallNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(LetNode);
@@ -127,7 +125,6 @@ class ExprVisitor : public ::tvm::relay::ExprFunctor<void(const Expr& n)> {
   void VisitExpr_(const GlobalVarNode* op) override;
   void VisitExpr_(const ConstantNode* op) override;
   void VisitExpr_(const TupleNode* op) override;
-  void VisitExpr_(const ParamNode* op) override;
   void VisitExpr_(const FunctionNode* op) override;
   void VisitExpr_(const CallNode* op) override;
   void VisitExpr_(const LetNode* op) override;
@@ -151,7 +148,6 @@ class ExprMutator
   Expr VisitExpr_(const GlobalVarNode* op) override;
   Expr VisitExpr_(const OpNode* op) override;
   Expr VisitExpr_(const TupleNode* op) override;
-  Expr VisitExpr_(const ParamNode* op) override;
   Expr VisitExpr_(const FunctionNode* op) override;
   Expr VisitExpr_(const CallNode* call_node) override;
   Expr VisitExpr_(const LetNode* op) override;

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -34,7 +34,6 @@ Constant = expr.Constant
 Tuple = expr.Tuple
 Var = expr.Var
 GlobalVar = expr.GlobalVar
-Param = expr.Param
 Function = expr.Function
 Call = expr.Call
 Let = expr.Let

--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -11,7 +11,7 @@ class Expr(NodeBase):
     """The base type for all Relay expressions."""
     @property
     def checked_type(self):
-        """Get the checked type of tvm.relay.
+        """Get the checked type of tvm.relay.Expr.
 
         Returns
         -------
@@ -30,7 +30,7 @@ class Expr(NodeBase):
 
 @register_relay_node
 class Constant(Expr):
-    """A constant expression in Tvm.Relay.
+    """A constant expression in Relay.
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ class Tuple(Expr):
 
     Parameters
     ----------
-    fields : list of tvm.relay.Expr.
+    fields : List[tvm.relay.Expr]
         The fields in the tuple.
     """
     def __init__(self, fields):
@@ -98,7 +98,7 @@ class Function(Expr):
 
     Parameters
     ----------
-    params: list of tvm.relay.Var
+    params: List[tvm.relay.Var]
         List of input parameters to the function.
 
     ret_type: tvm.relay.Type
@@ -107,7 +107,7 @@ class Function(Expr):
     body: tvm.relay.Expr
         The body of the function.
 
-    type_params: list of tvm.relay.TypeParam
+    type_params: Optional[List[tvm.relay.TypeParam]]
         The additional type parameters, this is only
         used in advanced usecase of template functions.
     """
@@ -135,13 +135,13 @@ class Call(Expr):
     op: tvm.relay.Op or any tvm.relay.Expr with function type.
         The operation to be called.
 
-    args: list of tvm.relay.Expr
+    args: List[tvm.relay.Expr]
         The arguments to the call.
 
-    attrs: tvm.Attrs, optional
+    attrs: Optional[tvm.Attrs]
         Attributes to the call, can be None
 
-    type_args: list of tvm.relay.Type
+    type_args: Optional[List[tvm.relay.Type]]
         The additional type arguments, this is only
         used in advanced usecase of template functions.
     """
@@ -159,10 +159,10 @@ class Let(Expr):
     Parameters
     ----------
     var: tvm.relay.Var
-        The local variable to be binded.
+        The local variable to be bound.
 
     value: tvm.relay.Expr
-        The value to be binded.
+        The value to be bound.
 
     body: tvm.relay.Expr
         The body of the let binding.

--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -11,11 +11,11 @@ class Expr(NodeBase):
     """The base type for all Relay expressions."""
     @property
     def checked_type(self):
-        """Get the checked type of relay.
+        """Get the checked type of tvm.relay.
 
         Returns
         -------
-        checked_type : relay.Type
+        checked_type : tvm.relay.Type
             The checked type.
         """
         ret = self._checked_type_
@@ -25,70 +25,97 @@ class Expr(NodeBase):
         return ret
 
     def __call__(self, *args):
-        converted_args = []
-        for arg in args:
-            if isinstance(arg, Param):
-                converted_args.append(arg.var)
-            else:
-                converted_args.append(arg)
-
         return Call(self, args, None, None)
 
 
 @register_relay_node
 class Constant(Expr):
-    """A constant tensor in Relay, see tvm/relay/type.h for more details.
-    """
+    """A constant expression in Tvm.Relay.
 
+    Parameters
+    ----------
+    data : tvm.nd.NDArray
+        The data content of the constant expression.
+    """
     def __init__(self, data):
         self.__init_handle_by_constructor__(_make.Constant, data)
 
 
 @register_relay_node
 class Tuple(Expr):
-    """A hetereogenous sequence of values.
-       see tvm/relay/type.h for more details.
-    """
+    """Tuple expression that groups several fields together.
 
+    Parameters
+    ----------
+    fields : list of tvm.relay.Expr.
+        The fields in the tuple.
+    """
     def __init__(self, fields):
         self.__init_handle_by_constructor__(_make.Tuple, fields)
 
 
 @register_relay_node
 class Var(Expr):
-    """A local variable in Relay."""
+    """A local variable in Tvm.Relay.
 
-    def __init__(self, name_hint):
-        self.__init_handle_by_constructor__(_make.Var, name_hint)
+    Local variable can be used to declare input
+    arguments to a function, or intermediate variables.
+
+    Parameters
+    ----------
+    name_hint: str
+        The name of the variable.
+        This name only acts as a hint, and is not used
+        for equality.
+
+    type_annotation: tvm.relay.Type, optional
+        The type annotation on the variable.
+    """
+    def __init__(self, name_hint, type_annotation=None):
+        self.__init_handle_by_constructor__(
+            _make.Var, name_hint, type_annotation)
 
 
 @register_relay_node
 class GlobalVar(Expr):
-    """A global variable in Relay."""
+    """A global variable in Tvm.Relay.
 
+    GlobalVar is used to refer to the global functions
+    stored in the environment.
+
+    Parameters
+    ----------
+    name_hint: str
+        The name of the variable.
+    """
     def __init__(self, name_hint):
         self.__init_handle_by_constructor__(_make.GlobalVar, name_hint)
 
 
 @register_relay_node
-class Param(Expr):
-    """A function type in Relay, see tvm/relay/type.h for more details.
-    """
-
-    def __init__(self, var, ty):
-        self.__init_handle_by_constructor__(_make.Param, var, ty)
-
-
-@register_relay_node
 class Function(Expr):
-    """A function in Relay, see tvm/relay/expr.h for more details."""
+    """A function declaration expression.
 
+    Parameters
+    ----------
+    params: list of tvm.relay.Var
+        List of input parameters to the function.
+
+    ret_type: tvm.relay.Type
+        The return type annotation of the function.
+
+    body: tvm.relay.Expr
+        The body of the function.
+
+    type_params: list of tvm.relay.TypeParam
+        The additional type parameters, this is only
+        used in advanced usecase of template functions.
+    """
     def __init__(self,
                  params,
                  ret_type,
                  body,
-                 type_params=None
-                ):
+                 type_params=None):
         if type_params is None:
             type_params = convert([])
 
@@ -98,39 +125,87 @@ class Function(Expr):
 
 @register_relay_node
 class Call(Expr):
-    """A function call in Relay, see tvm/relay/expr.h for more details."""
+    """Function call node in Relay.
 
-    def __init__(self, op, args, attrs, ty_args=None):
-        if not ty_args:
-            ty_args = []
+    Call node corresponds the operator application node
+    in computational graph terminology.
 
+    Parameters
+    ----------
+    op: tvm.relay.Op or any tvm.relay.Expr with function type.
+        The operation to be called.
+
+    args: list of tvm.relay.Expr
+        The arguments to the call.
+
+    attrs: tvm.Attrs, optional
+        Attributes to the call, can be None
+
+    type_args: list of tvm.relay.Type
+        The additional type arguments, this is only
+        used in advanced usecase of template functions.
+    """
+    def __init__(self, op, args, attrs=None, type_args=None):
+        if not type_args:
+            type_args = []
         self.__init_handle_by_constructor__(
-            _make.Call, op, args, attrs, ty_args)
+            _make.Call, op, args, attrs, type_args)
 
 
 @register_relay_node
 class Let(Expr):
-    """A variable bindings in Relay, see tvm/relay/expr.h for more details."""
+    """Let variable binding expression.
 
-    def __init__(self, var, value, body, value_type=None):
+    Parameters
+    ----------
+    var: tvm.relay.Var
+        The local variable to be binded.
+
+    value: tvm.relay.Expr
+        The value to be binded.
+
+    body: tvm.relay.Expr
+        The body of the let binding.
+    """
+    def __init__(self, var, value, body):
         self.__init_handle_by_constructor__(
-            _make.Let, var, value, body, value_type)
+            _make.Let, var, value, body)
 
 
 @register_relay_node
 class If(Expr):
-    """A conditional expression in Relay, see tvm/relay/expr.h for more details."""
+    """A conditional expression in Relay.
 
-    def __init__(self, cond, true_value, false_value):
+    Parameters
+    ----------
+    cond: tvm.relay.Expr
+        The condition.
+
+    true_branch: tvm.relay.Expr
+        The expression evaluated when condition is true.
+
+    false_branch: tvm.relay.Expr
+        The expression evaluated when condition is false.
+    """
+    def __init__(self, cond, true_branch, false_branch):
         self.__init_handle_by_constructor__(
-            _make.If, cond, true_value, false_value)
+            _make.If, cond, true_branch, false_branch)
+
 
 @register_relay_node
 class TupleGetItem(Expr):
-    """An expression that get field from tuple in Relay, see tvm/relay/expr.h for more details."""
+    """Get index-th item from a tuple.
 
-    def __init__(self, tuple_, index):
+    Parameters
+    ----------
+    tuple_value: tvm.relay.Expr
+        The input tuple expression.
+
+    index: int
+        The index.
+    """
+    def __init__(self, tuple_value, index):
         self.__init_handle_by_constructor__(
-            _make.TupleGetItem, tuple_, index)
+            _make.TupleGetItem, tuple_value, index)
 
 debug_print = _expr._debug_print

--- a/src/relay/pass/let_list.h
+++ b/src/relay/pass/let_list.h
@@ -26,57 +26,46 @@ namespace relay {
  */
 class LetList {
  public:
-  /*! \brief insert a binding.
+  /*!
+   * \brief insert a binding.
    *
-   *  \param pv the var of the binding.
+   * \param pv the var of the binding.
    *
-   *  \param ty the type of the binding.
+   * \param expr the value of the binding.
    *
-   *  \param expr the value of the binding.
-   *
-   *  \return a Var that hold the inserted expr.
+   * \return a Var that hold the inserted expr.
    */
-  Var Push(const Var& pv, const Type& ty, const Expr& expr) {
-    std::tuple<Var, Type, Expr> tuple(pv, ty, expr);
-    lets_.push_back(tuple);
+  Var Push(Var pv, Expr expr) {
+    lets_.emplace_back(std::make_pair(pv, expr));
     return pv;
   }
 
-  /*! \brief insert a binding.
+  /*!
+   * \brief insert a binding.
    *
-   *  \param ty the type of the binding.
+   * \param ty the type of the binding.
    *
-   *  \param expr the value of the binding.
+   * \param expr the value of the binding.
    *
-   *  \return a Var that hold the inserted expr.
+   * \return a Var that hold the inserted expr.
    */
-  Var Push(const Type& ty, const Expr& expr) {
-    return Push(VarNode::make("x"), ty, expr);
+  Var Push(Type ty, Expr expr) {
+    return Push(VarNode::make("x", ty), expr);
   }
 
-  /*! \brief insert a binding.
-   *
-   *  \param pv the var of the binding.
-   *
-   *  \param expr the value of the binding.
-   *
-   *  \return a Var that hold the inserted expr.
-   */
-  Var Push(const Var& pv, const Expr& expr) {
-    return Push(pv, IncompleteTypeNode::make(TypeParamNode::kType), expr);
-  }
-
-  /*! \brief insert a binding.
+  /*!
+   * \brief insert a binding.
    *
    *  \param expr the value of the binding.
    *
    *  \return a Var that hold the inserted expr.
    */
-  Var Push(const Expr& expr) {
+  Var Push(Expr expr) {
     return Push(IncompleteTypeNode::make(TypeParamNode::kType), expr);
   }
 
-  /*! \brief wrap an expr around the LetList.
+  /*!
+   * \brief wrap an expr around the LetList.
    *
    *  \param body the Expression to be wrapped around.
    *
@@ -85,7 +74,7 @@ class LetList {
   Expr Get(const Expr& body) const {
     Expr ret = body;
     for (auto rit = lets_.rbegin(); rit != lets_.rend(); ++rit) {
-      ret = LetNode::make(std::get<0>(*rit), std::get<2>(*rit), ret, std::get<1>(*rit));
+      ret = LetNode::make(std::get<0>(*rit), std::get<1>(*rit), ret);
     }
     return ret;
   }
@@ -118,7 +107,7 @@ class LetList {
   }
 
  private:
-  std::vector<std::tuple<Var, Type, Expr> > lets_;
+  std::vector<std::pair<Var, Expr> > lets_;
 };
 
 }  // namespace relay

--- a/src/relay/pass/util.cc
+++ b/src/relay/pass/util.cc
@@ -50,14 +50,17 @@ class FreeVar : public ExprVisitor {
     if (bound_vars.count(var) == 0) {
       free_vars.insert(var);
     }
+    if (v->type_annotation.defined()) {
+      VisitType(v->type_annotation);
+    }
   }
 
   void VisitExpr_(const FunctionNode *f) final {
     for (const auto& tp : f->type_params) {
       bound_types.insert(tp);
     }
-    for (const auto& p : f->params) {
-      bound_vars.insert(p->var);
+    for (const auto& param : f->params) {
+      bound_vars.insert(param);
     }
     VisitExpr(f->body);
     VisitType(f->ret_type);
@@ -67,7 +70,6 @@ class FreeVar : public ExprVisitor {
     bound_vars.insert(l->var);
     VisitExpr(l->value);
     VisitExpr(l->body);
-    VisitType(l->value_type);
   }
 
  public:

--- a/src/relay/pass/well_formed.cc
+++ b/src/relay/pass/well_formed.cc
@@ -34,8 +34,8 @@ class WellFormedChecker : private ExprVisitor {
   }
 
   void VisitExpr_(const FunctionNode * f) final {
-    for (const Param & p : f->params) {
-      Check(p->var);
+    for (const Var & param : f->params) {
+      Check(param);
     }
     CheckWellFormed(f->body);
   }

--- a/tests/python/relay/test_ir_builder.py
+++ b/tests/python/relay/test_ir_builder.py
@@ -14,7 +14,6 @@ def test_let():
     assert var == prog.body
     assert isinstance(value, Constant)
     assert value.data.asnumpy() == np.array(1)
-    assert prog.value_type == None
 
 if __name__ == "__main__":
     test_let()

--- a/tests/python/relay/test_ir_debug_printer.py
+++ b/tests/python/relay/test_ir_debug_printer.py
@@ -49,18 +49,11 @@ def test_global_var():
     show(gv)
 
 
-def test_param():
-    lv = relay.Var('x')
-    ty = None
-    param = relay.Param(lv, ty)
-    show(lv)
-
-
 def test_function():
     param_names = ['a', 'b', 'c', 'd']
-    params = tvm.convert([relay.Param(relay.Var(n), None) for n in param_names])
+    params = tvm.convert([relay.Var(n) for n in param_names])
     ret_type = None
-    body = params[0].var
+    body = params[0]
     type_params = tvm.convert([])
     fn = relay.Function(params, ret_type, body, type_params)
     show(fn)
@@ -76,11 +69,11 @@ def test_call():
 
 
 def test_let():
-    lv = relay.Var('x')
     ty = relay.ty.TensorType((10, 20), 'float32')
+    lv = relay.Var('x', ty)
     arr = tvm.nd.array(10)
     value = relay.Constant(arr)
-    let = relay.Let(lv, value, lv, ty)
+    let = relay.Let(lv, value, lv)
     show(let)
 
 

--- a/tests/python/relay/test_ir_nodes.py
+++ b/tests/python/relay/test_ir_nodes.py
@@ -99,9 +99,15 @@ def test_tuple():
 def test_local_var():
     name_hint = 's'
     lv = relay.Var(name_hint)
-    lv.name_hint == name_hint
+    assert lv.name_hint == name_hint
+    assert lv.type_annotation is None
     # assert lv.span == None todo(@jroesch): what do we do about spans
     str(lv)
+
+    t1 = relay.ty.TensorType((), "float")
+    lv = relay.Var(name_hint, t1)
+    assert lv.name_hint == name_hint
+    assert lv.type_annotation == t1
 
 
 def test_global_var():
@@ -112,19 +118,9 @@ def test_global_var():
     str(gv)
 
 
-def test_param():
-    lv = relay.Var('x')
-    ty = None
-    param = relay.Param(lv, ty)
-    assert param.var == lv
-    assert param.type == ty
-    assert param.span == None
-    str(param)
-
-
 def test_function():
     param_names = ['a', 'b', 'c', 'd']
-    params = tvm.convert([relay.Param(relay.Var(n), None) for n in param_names])
+    params = tvm.convert([relay.Var(n) for n in param_names])
     ret_type = None
     body = None
     type_params = tvm.convert([])
@@ -154,10 +150,9 @@ def test_let():
     value = relay.Constant(arr)
     # I would prefer that the order of arguments
     # matches syntax let x: t = v in b
-    let = relay.Let(lv, value, lv, ty)
+    let = relay.Let(lv, value, lv)
     assert let.var == lv
     assert let.value == value
-    assert let.value_type == ty
     assert let.body == lv
     assert let.span == None
     str(let)
@@ -194,7 +189,6 @@ if __name__ == "__main__":
     test_tuple()
     test_local_var()
     test_global_var()
-    test_param()
     test_function()
     test_call()
     test_let()

--- a/tests/python/relay/test_ir_well_formed.py
+++ b/tests/python/relay/test_ir_well_formed.py
@@ -7,23 +7,22 @@ def test_well_formed():
     assert well_formed(x)
     v = relay.Constant(tvm.nd.array(10))
     ty = None
-    let = relay.Let(x, v, x, ty)
+    let = relay.Let(x, v, x)
     assert well_formed(let)
-    assert not well_formed(relay.Let(x, v, let, ty))
-    f = relay.Function([relay.Param(x, ty)], ty, x)
+    assert not well_formed(relay.Let(x, v, let))
+    f = relay.Function([x], ty, x)
     assert well_formed(f)
     # this test should pass in case of weak uniqueness (only test for shadowing)
     # but we want all binder to be distinct from each other.
     assert not well_formed(relay.Let(relay.Var("y"), f,
-                                     relay.Let(relay.Var("z"), f, v, ty), ty))
+                                     relay.Let(relay.Var("z"), f, v)))
 
 
 def test_tuple():
     x = relay.Var('x')
     assert well_formed(x)
     v = relay.Constant(tvm.nd.array(10))
-    ty = None
-    let = relay.Let(x, v, x, ty)
+    let = relay.Let(x, v, x)
     assert well_formed(let)
     assert well_formed(relay.Tuple([v, v]))
     assert not well_formed(relay.Tuple([let, let]))

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -27,6 +27,8 @@ def test_single_op():
                    tvm.relay.sigmoid, tvm.relay.tanh]:
         check_single_op(opfunc)
 
+
+
 def test_expand_dims_infer_type():
     ib = relay.ir_builder.IRBuilder()
     n, t, d = tvm.var("n"), tvm.var("t"), 100
@@ -75,11 +77,12 @@ def test_unary_op():
         ib = relay.ir_builder.IRBuilder()
         x = ib.param("x", relay.TensorType((10, 4), "int32"))
         with ib.function(x) as func:
-            ib.ret(op(x.var))
+            ib.ret(op(x))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
         assert ftype.ret_type == relay.TensorType((10, 4), "int32")
+
 
 def test_binary_op():
     def check_binary_op(opfunc):
@@ -94,7 +97,7 @@ def test_binary_op():
         x = b.param('x', tensor_type(5, 5, 5))
         y = b.param('y', tensor_type(5, 5, 5))
         with b.function(x, y) as func:
-            b.ret(opfunc(x.var, y.var))
+            b.ret(opfunc(x, y))
         b.ret(func)
         prog, env = b.get()
         ttype = tensor_type(5, 5, 5)
@@ -118,7 +121,7 @@ def test_binary_broadcast_op():
         x = b.param('x', tensor_type(10, 4))
         y = b.param('y', tensor_type(5, 10, 1))
         with b.function(x, y) as func:
-            b.ret(opfunc(x.var, y.var))
+            b.ret(opfunc(x, y))
         b.ret(func)
         prog, env = b.get()
 

--- a/tests/python/relay/test_op_level2.py
+++ b/tests/python/relay/test_op_level2.py
@@ -11,7 +11,7 @@ def test_conv2d_infer_type():
     w = ib.param("w", relay.ty.IncompleteType())
 
     with ib.function(x, w) as func:
-        ib.ret(relay.nn.conv2d(x.var, w.var,
+        ib.ret(relay.nn.conv2d(x, w,
                                kernel_size=(3, 3),
                                padding=(1, 1),
                                channels=2))
@@ -29,7 +29,7 @@ def test_conv2d_infer_type():
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "int8"))
     w = ib.param("w", relay.ty.TensorType((2, 10, 3, 3), "int8"))
     with ib.function(x, w) as func:
-        ib.ret(relay.nn.conv2d(x.var, w.var, out_dtype="int32"))
+        ib.ret(relay.nn.conv2d(x, w, out_dtype="int32"))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -42,7 +42,7 @@ def test_conv2d_infer_type():
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "int8"))
     w = ib.param("w", relay.ty.IncompleteType())
     with ib.function(x, w) as func:
-        ib.ret(relay.nn.conv2d(x.var, w.var,
+        ib.ret(relay.nn.conv2d(x, w,
                                kernel_size=(3, 3),
                                padding=(1, 1),
                                channels=16,
@@ -65,7 +65,7 @@ def test_conv2d_transpose_infer_type():
     w = ib.param("w", relay.ty.IncompleteType())
 
     with ib.function(x, w) as func:
-        ib.ret(relay.nn.conv2d_transpose(x.var, w.var,
+        ib.ret(relay.nn.conv2d_transpose(x, w,
                                          kernel_size=(3, 3),
                                          padding=(1, 1),
                                          channels=15))
@@ -83,7 +83,7 @@ def test_conv2d_transpose_infer_type():
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "float32"))
     w = ib.param("w", relay.ty.TensorType((12, 11, 5, 5), "float32"))
     with ib.function(x, w) as func:
-        ib.ret(relay.nn.conv2d_transpose(x.var, w.var,
+        ib.ret(relay.nn.conv2d_transpose(x, w,
                                          output_padding=(1, 1),
                                          channels=11,
                                          data_layout="NHWC"))
@@ -98,7 +98,7 @@ def test_upsampling_infer_type():
     n, c , h, w = tvm.var("n"), tvm.var("c"), tvm.var("h"), tvm.var("w")
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "float32"))
     with ib.function(x) as func:
-        ib.ret(relay.nn.upsampling(x.var, scale=2, layout="NCHW", method="BILINEAR"))
+        ib.ret(relay.nn.upsampling(x, scale=2, layout="NCHW", method="BILINEAR"))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -108,7 +108,7 @@ def test_upsampling_infer_type():
     n, c = tvm.var("n"), tvm.var("c")
     x = ib.param("x", relay.ty.TensorType((n, c, 100, 200), "float32"))
     with ib.function(x) as func:
-        ib.ret(relay.nn.upsampling(x.var, scale=2, layout="NCHW", method="BILINEAR"))
+        ib.ret(relay.nn.upsampling(x, scale=2, layout="NCHW", method="BILINEAR"))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -119,7 +119,7 @@ def _test_pool2d_infer_type(opfunc):
     n, c, h, w = tvm.var("n"), 10, 224, 224
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "float32"))
     with ib.function(x) as func:
-        ib.ret(opfunc(x.var, pool_size=(1, 1)))
+        ib.ret(opfunc(x, pool_size=(1, 1)))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -132,7 +132,7 @@ def _test_pool2d_infer_type(opfunc):
     n, c, h, w = tvm.var("n"), 10, 224, 224
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "float32"))
     with ib.function(x) as func:
-        ib.ret(opfunc(x.var, pool_size=(ph, pw), strides=(sh, sw)))
+        ib.ret(opfunc(x, pool_size=(ph, pw), strides=(sh, sw)))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -144,7 +144,7 @@ def _test_global_pool2d_infer_type(opfunc):
     n, c, h, w = tvm.var("n"), tvm.var("c"), 224, 224
     x = ib.param("x", relay.ty.TensorType((n, h, w, c), "float32"))
     with ib.function(x) as func:
-        ib.ret(opfunc(x.var, layout="NHWC"))
+        ib.ret(opfunc(x, layout="NHWC"))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -154,7 +154,7 @@ def _test_global_pool2d_infer_type(opfunc):
     n, c, h, w = tvm.var("n"), tvm.var("c"), tvm.var("h"), tvm.var("w")
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "float32"))
     with ib.function(x) as func:
-        ib.ret(opfunc(x.var))
+        ib.ret(opfunc(x))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -172,7 +172,7 @@ def test_flatten_infer_type():
     x = ib.param("x", relay.ty.TensorType((d1, d2, d3, d4), "float32"))
 
     with ib.function(x) as func:
-        ib.ret(relay.nn.batch_flatten(x.var))
+        ib.ret(relay.nn.batch_flatten(x))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -181,7 +181,7 @@ def test_flatten_infer_type():
     ib = relay.ir_builder.IRBuilder()
     x = ib.param("x", relay.ty.TensorType((3, 2, 4, 3), "float32"))
     with ib.function(x) as func:
-        ib.ret(relay.nn.batch_flatten(x.var))
+        ib.ret(relay.nn.batch_flatten(x))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -190,7 +190,7 @@ def test_flatten_infer_type():
     ib = relay.ir_builder.IRBuilder()
     x = ib.param("x", relay.ty.TensorType((d1, 2, d3, 3), "float32"))
     with ib.function(x) as func:
-        ib.ret(relay.nn.batch_flatten(x.var))
+        ib.ret(relay.nn.batch_flatten(x))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -202,7 +202,7 @@ def test_pad_infer_type():
     n, c, h, w = 1, 2, 3, 4
     t = ib.param("t", relay.TensorType((n, c, h, w), "float32"))
     with ib.function(t) as func:
-        ib.ret(relay.nn.pad(t.var, ((1, 1), (2, 2), (3, 3), (4, 4))))
+        ib.ret(relay.nn.pad(t, ((1, 1), (2, 2), (3, 3), (4, 4))))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -213,7 +213,7 @@ def test_pad_infer_type():
     n, c, h, w = tvm.var("n"), 2, 3, tvm.var("w")
     t = ib.param("t", relay.TensorType((n, c, h, w), "float32"))
     with ib.function(t) as func:
-        ib.ret(relay.nn.pad(t.var, ((1, 1), (2, 2), (3, 3), (4, 4))))
+        ib.ret(relay.nn.pad(t, ((1, 1), (2, 2), (3, 3), (4, 4))))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -227,4 +227,3 @@ if __name__ == "__main__":
     test_flatten_infer_type()
     test_pad_infer_type()
     test_conv2d_transpose_infer_type()
-

--- a/tests/python/relay/test_op_level3.py
+++ b/tests/python/relay/test_op_level3.py
@@ -17,12 +17,13 @@ def test_zeros_ones():
         ftype = func.checked_type
         assert ftype.ret_type == relay.TensorType((124, 50), "float64")
 
+
 def test_unary_identity():
     for op in [relay.zeros_like, relay.ones_like]:
         ib = relay.ir_builder.IRBuilder()
         x = ib.param("x", relay.TensorType((8, 9, 4), "int32"))
         with ib.function(x) as func:
-            ib.ret(op(x.var))
+            ib.ret(op(x))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
@@ -33,7 +34,7 @@ def test_clip_type():
     ib = relay.ir_builder.IRBuilder()
     a = ib.param("a", relay.TensorType((10, 4), "float32"))
     with ib.function(a) as func:
-        ib.ret(relay.clip(a.var, 1., 4.))
+        ib.ret(relay.clip(a, 1., 4.))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -106,7 +107,7 @@ def test_take_infer_type():
         x = ib.param("x", relay.ty.TensorType(dshape, "float32"))
         indices = ib.param("indices", relay.ty.TensorType(indices_shape, "int32"))
         with ib.function(x, indices) as func:
-            ib.ret(relay.take(x.var, indices.var, axis=axis))
+            ib.ret(relay.take(x, indices, axis=axis))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
@@ -127,7 +128,7 @@ def test_full():
     ib = relay.ir_builder.IRBuilder()
     x = ib.param("x", relay.TensorType((), "int8"))
     with ib.function(x) as func:
-        ib.ret(relay.full(x.var, ()))
+        ib.ret(relay.full(x, ()))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -137,7 +138,7 @@ def test_full():
     ib = relay.ir_builder.IRBuilder()
     x = ib.param("x", relay.TensorType((), "float32"))
     with ib.function(x) as func:
-        ib.ret(relay.full(x.var, (1, 2), "int8"))
+        ib.ret(relay.full(x, (1, 2), "int8"))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -150,7 +151,7 @@ def test_full_like():
     base = ib.param("base", relay.TensorType((1, 2, 3), "float32"))
     fill = ib.param("fill", relay.TensorType((), "float32"))
     with ib.function(base, fill) as func:
-        ib.ret(relay.full_like(base.var, fill.var))
+        ib.ret(relay.full_like(base, fill))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -162,7 +163,7 @@ def test_full_like():
     base = ib.param("base", relay.TensorType((n, c, h, w), "float32"))
     fill = ib.param("fill", relay.TensorType((), "float32"))
     with ib.function(base, fill) as func:
-        ib.ret(relay.full_like(base.var, fill.var))
+        ib.ret(relay.full_like(base, fill))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type

--- a/tests/python/relay/test_op_level4.py
+++ b/tests/python/relay/test_op_level4.py
@@ -24,7 +24,7 @@ def test_cmp_type():
         x = ib.param("x", relay.TensorType((10, 4), "float32"))
         y = ib.param("y", relay.TensorType((5, 10, 1), "float32"))
         with ib.function(x, y) as func:
-            ib.ret(op(x.var, y.var))
+            ib.ret(op(x, y))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
@@ -39,7 +39,7 @@ def test_binary_broadcast():
         x = ib.param("x", relay.TensorType((10, 4), "int32"))
         y = ib.param("y", relay.TensorType((5, 10, 1), "int32"))
         with ib.function(x, y) as func:
-            ib.ret(op(x.var, y.var))
+            ib.ret(op(x, y))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
@@ -58,7 +58,7 @@ def test_binary_op():
         x = b.param('x', tensor_type(5, 5, 5))
         y = b.param('y', tensor_type(5, 5, 5))
         with b.function(x, y) as func:
-            b.ret(opfunc(x.var, y.var))
+            b.ret(opfunc(x, y))
         b.ret(func)
         prog, env = b.get()
         ttype = tensor_type(5, 5, 5)
@@ -81,7 +81,7 @@ def test_binary_broadcast_op():
         x = b.param('x', tensor_type(10, 4))
         y = b.param('y', tensor_type(5, 10, 1))
         with b.function(x, y) as func:
-            b.ret(opfunc(x.var, y.var))
+            b.ret(opfunc(x, y))
         b.ret(func)
         prog, env = b.get()
 
@@ -103,7 +103,7 @@ def test_cmp_type():
         x = ib.param("x", relay.TensorType((10, 4), "float32"))
         y = ib.param("y", relay.TensorType((5, 10, 1), "float32"))
         with ib.function(x, y) as func:
-            ib.ret(op(x.var, y.var))
+            ib.ret(op(x, y))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
@@ -118,7 +118,7 @@ def test_binary_broadcast():
         x = ib.param("x", relay.TensorType((10, 4), "int32"))
         y = ib.param("y", relay.TensorType((5, 10, 1), "int32"))
         with ib.function(x, y) as func:
-            ib.ret(op(x.var, y.var))
+            ib.ret(op(x, y))
         ib.ret(func)
         func = relay.ir_pass.infer_type(ib.env, func.to_func())
         ftype = func.checked_type
@@ -131,7 +131,7 @@ def test_where():
     x = ib.param("x", relay.TensorType((3, 4), "float32"))
     y = ib.param("y", relay.TensorType((3, 4), "float32"))
     with ib.function(cond, x, y) as func:
-        ib.ret(relay.where(cond.var, x.var, y.var))
+        ib.ret(relay.where(cond, x, y))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type

--- a/tests/python/relay/test_op_level5.py
+++ b/tests/python/relay/test_op_level5.py
@@ -10,7 +10,7 @@ def test_resize_infer_type():
     th, tw = tvm.var("th"), tvm.var("tw")
 
     with ib.function(x) as func:
-        ib.ret(relay.image.resize(x.var, (th, tw)))
+        ib.ret(relay.image.resize(x, (th, tw)))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type
@@ -19,7 +19,7 @@ def test_resize_infer_type():
     ib = relay.ir_builder.IRBuilder()
     x = ib.param("x", relay.ty.TensorType((n, c, h, w), "int8"))
     with ib.function(x) as func:
-        ib.ret(relay.image.resize(x.var, (100, 200), "NCHW", "BILINEAR", False))
+        ib.ret(relay.image.resize(x, (100, 200), "NCHW", "BILINEAR", False))
     ib.ret(func)
     func = relay.ir_pass.infer_type(ib.env, func.to_func())
     ftype = func.checked_type

--- a/tests/python/relay/test_pass_dead_code_elimination.py
+++ b/tests/python/relay/test_pass_dead_code_elimination.py
@@ -28,17 +28,17 @@ e = env()
 
 
 def test_let():
-    orig = relay.Let(e.x, e.y, e.z, e.tt)
+    orig = relay.Let(e.x, e.y, e.z)
     assert alpha_equal(dead_code_elimination(orig), e.z)
 
 
 def test_used_let():
-    orig = relay.Let(e.a, e.b, relay.Let(e.c, e.d, e.c, e.tt), e.tt)
-    assert alpha_equal(dead_code_elimination(orig), relay.Let(e.c, e.d, e.c, e.tt))
+    orig = relay.Let(e.a, e.b, relay.Let(e.c, e.d, e.c))
+    assert alpha_equal(dead_code_elimination(orig), relay.Let(e.c, e.d, e.c))
 
 
 def test_chain_unused_let():
-    orig = relay.Let(e.a, e.b, relay.Let(e.c, e.d, e.e, e.tt), e.tt)
+    orig = relay.Let(e.a, e.b, relay.Let(e.c, e.d, e.e))
     assert alpha_equal(dead_code_elimination(orig), e.e)
 
 
@@ -56,19 +56,17 @@ def test_recursion():
        f(2, 10000);
     """
     f = relay.Var("f")
-    n = relay.Var("n")
-    np = relay.Param(n, e.int32)
-    data = relay.Var("data")
-    datap = relay.Param(data, e.float32)
+    n = relay.Var("n", e.int32)
+    data = relay.Var("data", e.float32)
     funcbody = relay.If(equal(n, convert(0)), data, f(subtract(n, convert(1.0)), log(data)))
-    value = relay.Function([np, datap], e.float32, funcbody, [])
-    orig = relay.Let(f, funcbody, f(convert(2.0), convert(10000.0)), e.float32)
+    value = relay.Function([n, data], e.float32, funcbody, [])
+    orig = relay.Let(f, funcbody, f(convert(2.0), convert(10000.0)))
     assert alpha_equal(dead_code_elimination(orig), orig)
-    assert alpha_equal(dead_code_elimination(relay.Let(f, funcbody, e.three, e.float32)), e.three)
+    assert alpha_equal(dead_code_elimination(relay.Let(f, funcbody, e.three)), e.three)
 
 
 def test_op_let():
-    assert alpha_equal(dead_code_elimination(add(relay.Let(e.a, e.one, e.three, e.float32), e.two)), add(e.three, e.two))
+    assert alpha_equal(dead_code_elimination(add(relay.Let(e.a, e.one, e.three), e.two)), add(e.three, e.two))
 
 
 def test_if():
@@ -80,7 +78,7 @@ def test_tuple_get_item():
     t = relay.Var('t')
     g = relay.TupleGetItem(t, 0)
     assert alpha_equal(dead_code_elimination(g), g)
-    assert alpha_equal(dead_code_elimination(relay.TupleGetItem(relay.Let(e.a, e.one, t, e.float32), 0)), g)
+    assert alpha_equal(dead_code_elimination(relay.TupleGetItem(relay.Let(e.a, e.one, t), 0)), g)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_free_vars.py
+++ b/tests/python/relay/test_pass_free_vars.py
@@ -3,16 +3,17 @@ from tvm import relay
 from tvm.relay.ir_pass import free_vars, free_type_vars
 
 def test_free_vars():
-    x = relay.Var("x")
+    ty = relay.TensorType([], "int32")
+    x = relay.Var("x", ty)
     fvx = free_vars(x)
     assert len(fvx) == 1
     assert fvx[0] == x
     v = relay.Constant(tvm.nd.array(10))
-    ty = relay.TensorType([], "int32")
-    let = relay.Let(x, v, x, ty)
+
+    let = relay.Let(x, v, x)
     fvx = free_vars(let)
     assert len(free_vars(let)) == 0
-    f = relay.Function([relay.Param(x, ty)], ty, x)
+    f = relay.Function([x], ty, x)
     assert len(free_vars(f)) == 0
 
 
@@ -29,9 +30,9 @@ def test_tuple():
 def test_free_type_vars():
     tp = relay.TypeParam("")
     ty = relay.TupleType([tp, relay.TensorType([], "int32")])
-    x = relay.Var("x")
+    x = relay.Var("x", ty)
     y = relay.Var("y")
-    let = relay.Let(x, y, x, ty)
+    let = relay.Let(x, y, x)
     fvl = free_vars(let)
     assert len(fvl) == 1
     assert fvl[0] == y


### PR DESCRIPTION
- [x] Move type_annotation as a field of Var
   - Remove value_type in Let
   - Remove Param and use Var instead
- [x] Add/correct docstring of all python Expr class, make them self-contained.

The reasoning behind the change:
- The current Param was a bit confusing and is only used in the place of the function parameter declaration. Folding the type annotation into Var allows removing one concept.
- This will make the future graph style programming easier, which I will follow up with subsequent PR.

