### PR TITLE
Add dtype option to verify_mxnet_frontend_impl

### DIFF
--- a/nnvm/tests/python/frontend/mxnet/test_forward.py
+++ b/nnvm/tests/python/frontend/mxnet/test_forward.py
@@ -14,7 +14,7 @@ import model_zoo
 
 
 def verify_mxnet_frontend_impl(mx_symbol, data_shape=(1, 3, 224, 224), out_shape=(1, 1000),
-                               gluon_impl=False, name=None):
+                               gluon_impl=False, name=None, dtype='float32'):
     """Use name different from test to avoid let nose pick it up"""
     if gluon_impl:
         def get_gluon_output(name, x):
@@ -57,7 +57,6 @@ def verify_mxnet_frontend_impl(mx_symbol, data_shape=(1, 3, 224, 224), out_shape
         return out.asnumpy()
 
     # random input
-    dtype = 'float32'
     x = np.random.uniform(size=data_shape)
     if gluon_impl:
         gluon_out, gluon_sym = get_gluon_output(name, x)


### PR DESCRIPTION
This PR makes it possible to pass the `dtype` to the mxnet frontend operaot test.

related to #1814 