### PR TITLE
[DOC]Add javadoc build into Jenkins workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ lint: cpplint pylint jnilint
 doc:
 	doxygen docs/Doxyfile
 
+javadoc:
+	# build artifact is in jvm/core/target/site/apidocs
+	cd jvm && mvn javadoc:javadoc
+
 # Cython build
 cython:
 	cd python; python setup.py build_ext --inplace

--- a/docs/api_links.rst
+++ b/docs/api_links.rst
@@ -1,7 +1,8 @@
-Links to C++ and JS API References
+Links to API References
 ==================================
 
 This page contains links to API references that are build with different doc build system.
 
 * `C++ doyxgen API <doxygen/index.html>`_
 * `Javascript jsdoc API <jsdoc/index.html>`_
+* `Java Javadoc API <javadoc/index.html>`_

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -12,6 +12,10 @@ make doc
 jsdoc web/tvm_runtime.js web/README.md || exit -1
 mv out docs/_build/html/jsdoc || exit -1
 
+# Java doc
+make javadoc || exit -1
+mv jvm/core/target/site/apidocs docs/_build/html/javadoc || exit -1
+
 rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
 
 cd docs


### PR DESCRIPTION
resolves https://github.com/dmlc/tvm/issues/1854.

test I have done, the pages are rendered correctly:
````bash
make javadoc
python -m SimpleHTTPServer
open localhost:8000 in browser
````