### PR TITLE
[Relay][WIP] JSON round trip tests for Relay nodes

### DIFF
--- a/tests/python/relay/test_ir_nodes.py
+++ b/tests/python/relay/test_ir_nodes.py
@@ -2,6 +2,13 @@
 import tvm
 from tvm import relay
 from tvm.expr import *
+from tvm.relay.ir_pass import alpha_equal
+
+
+def json_roundtrip(node):
+    json_str = tvm.save_json(node)
+    return tvm.load_json(json_str)
+
 
 def test_bad_constructor():
     try:
@@ -21,6 +28,11 @@ def test_span():
     assert isinstance(span, relay.base.Span)
     str(span)
 
+    back = json_roundtrip(span)
+    assert back.source == span.source
+    assert back.lineno == span.lineno
+    assert back.col_offset == span.col_offset
+
 # Types
 
 def test_tensor_type():
@@ -32,6 +44,10 @@ def test_tensor_type():
     assert tt.span == None
     str(tt)
 
+    # roundtrip preserves alpha-equality
+    back = json_roundtrip(tt)
+    assert back == tt
+
 
 def test_type_param():
     tp = relay.TypeParam('name', relay.Kind.Type)
@@ -39,37 +55,47 @@ def test_type_param():
     # assert tp.span  # TODO allow us to set span
     str(tp)
 
+    back = json_roundtrip(tp)
+    # pointer equality will not be preserved so alpha-equality will fail
+    assert back.kind == tp.kind
+
 
 def test_func_type():
     type_params = tvm.convert([])
     type_constraints = tvm.convert([])  # TODO: fill me in
     arg_types = tvm.convert([])
-    ret_type = None
+    ret_type = relay.TensorType((1, 2, 3), 'float32')
     tf = relay.FuncType(arg_types, ret_type, type_params, type_constraints)
     assert tf.type_params == type_params
     assert tf.type_constraints == type_constraints
     assert tf.arg_types == arg_types
     assert tf.ret_type == ret_type
     assert tf.span == None
-    # TODO make sure we can set
+    # TODO make sure we can set span
     str(tf)
+
+    back = json_roundtrip(tf)
+    assert back == tf
 
 
 def test_tuple_type():
-    tp = relay.TypeParam('tp', relay.Kind.Type)
-    tf = relay.FuncType(tvm.convert([]), None, tvm.convert([]), tvm.convert([]))
+    # tp = relay.TypeParam('tp', relay.Kind.Type)
     tt = relay.TensorType(tvm.convert([1, 2, 3]), 'float32')
-    fields = tvm.convert([tp, tf, tt])
+    tf = relay.FuncType(tvm.convert([]), tt, tvm.convert([]), tvm.convert([]))
+    fields = tvm.convert([tf, tt])
 
     tup_ty = relay.TupleType(fields)
     assert tup_ty.fields == fields
 
+    back = json_roundtrip(tup_ty)
+    assert back == tup_ty
+
 
 def test_type_relation():
-    tp = relay.TypeParam('tp', relay.Kind.Type)
-    tf = relay.FuncType(tvm.convert([]), None, tvm.convert([]), tvm.convert([]))
+    # tp = relay.TypeParam('tp', relay.Kind.Type)
     tt = relay.TensorType(tvm.convert([1, 2, 3]), 'float32')
-    args = tvm.convert([tf, tt, tp])
+    tf = relay.FuncType(tvm.convert([]), tt, tvm.convert([]), tvm.convert([]))
+    args = tvm.convert([tf, tt])
 
     num_inputs = 2
     func = tvm.get_env_func("tvm.relay.type_relation.Broadcast")
@@ -79,6 +105,14 @@ def test_type_relation():
     assert tr.args == args
     assert tr.num_inputs == num_inputs
 
+    back = json_roundtrip(tr)
+    # assert back == tr
+    assert tr.num_inputs == back.num_inputs
+    assert len(back.args) == len(tr.args)
+    for i in range(len(back.args)):
+        assert back.args[i] == tr.args[i]
+    assert back.attrs.name == tr.attrs.name
+
 
 def test_constant():
     arr = tvm.nd.array(10)
@@ -87,6 +121,9 @@ def test_constant():
     assert const.span == None
     str(const)
 
+    back = json_roundtrip(const)
+    assert alpha_equal(const, back)
+
 
 def test_tuple():
     fields = tvm.convert([])
@@ -94,6 +131,9 @@ def test_tuple():
     assert tup.fields == fields
     assert tup.span == None
     str(tup)
+
+    back = json_roundtrip(tup)
+    assert alpha_equal(tup, back)
 
 
 def test_local_var():
@@ -109,6 +149,11 @@ def test_local_var():
     assert lv.name_hint == name_hint
     assert lv.type_annotation == t1
 
+    back = json_roundtrip(lv)
+    # assert alpha_equal(lv, back)
+    assert back.name_hint == lv.name_hint
+    assert back.type_annotation == lv.type_annotation
+
 
 def test_global_var():
     name_hint = 'g'
@@ -117,19 +162,26 @@ def test_global_var():
     # assert lv.span == None todo(@jroesch): what do we do about spans
     str(gv)
 
+    back = json_roundtrip(gv)
+    # assert alpha_equal(gv, back)
+    assert back.name_hint == gv.name_hint
+
 
 def test_function():
     param_names = ['a', 'b', 'c', 'd']
     params = tvm.convert([relay.Var(n) for n in param_names])
-    ret_type = None
-    body = None
+    ret_type = relay.TupleType(tvm.convert([]))
+    body = relay.Tuple(tvm.convert([]))
     type_params = tvm.convert([])
-    fn = relay.Function(params, ret_type, body, type_params)
+    fn = relay.Function(params, body, ret_type, type_params)
     assert fn.params == params
     assert fn.body == body
     assert fn.type_params == type_params
     assert fn.span == None
     str(fn)
+
+    back = json_roundtrip(fn)
+    assert alpha_equal(fn, back)
 
 
 def test_call():
@@ -141,6 +193,13 @@ def test_call():
     assert call.args == args
     assert call.span == None
     str(call)
+
+    back = json_roundtrip(call)
+    # assert alpha_equal(call, back)
+    assert back.op.name_hint == call.op.name_hint
+    assert len(back.args) == len(call.args)
+    for i in range(len(call.args)):
+        assert back.args[i].name_hint == call.args[i].name_hint
 
 
 def test_let():
@@ -157,6 +216,12 @@ def test_let():
     assert let.span == None
     str(let)
 
+    back = json_roundtrip(let)
+    # assert alpha_equal(let, back)
+    assert back.var.name_hint == let.var.name_hint
+    assert alpha_equal(back.value, let.value)
+    assert back.body.name_hint == let.body.name_hint
+
 
 def test_if():
     cond = relay.Var('cond')
@@ -169,6 +234,12 @@ def test_if():
     assert ife.span == None
     str(ife)
 
+    back = json_roundtrip(ife)
+    #assert alpha_equal(ife, back)
+    assert back.cond.name_hint == ife.cond.name_hint
+    assert back.true_branch.name_hint == ife.true_branch.name_hint
+    assert back.false_branch.name_hint == ife.false_branch.name_hint
+
 
 def test_tuple_get_item():
     tup = relay.Var("tuple")
@@ -176,6 +247,12 @@ def test_tuple_get_item():
     assert get.tuple == tup
     assert get.index == 1
     str(get)
+
+    back = json_roundtrip(get)
+    #assert alpha_equal(get, back)
+    assert back.tuple.name_hint == get.tuple.name_hint
+    assert back.index == get.index
+
 
 if __name__ == "__main__":
     test_bad_constructor()


### PR DESCRIPTION
Serializing Relay nodes no longer segfaults, but numerous issues came up when trying to write even these simple tests. I am curious for input about the best ways to address some of them, as some are not obvious.

In particular, it would be nice if round-trip serialization preserved alpha-equality, as one would expect it to. However, that is not the case, as there are numerous places where we check structural equality by pointer equality, as with vars and attrs. How should that be addressed?

Perhaps serialization tests should be separate from the IR node tests, so we could try many different cases instead.