### PR TITLE
Update SGX example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ tvm_t.*
 *.cer
 *.crt
 *.der
+
+# patch sentinel
+patched.txt

--- a/apps/sgx/enclave/enclave_config.xml.in
+++ b/apps/sgx/enclave/enclave_config.xml.in
@@ -1,8 +1,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x20000</StackMaxSize>
-  <HeapMaxSize>0x5000000</HeapMaxSize>
+  <StackMaxSize>0xf0000</StackMaxSize>
+  <HeapMaxSize>0xf000000</HeapMaxSize>
   <TCSNum>NUM_THREADS</TCSNum>
   <TCSPolicy>0</TCSPolicy> <!-- must be "bound" to use thread_local -->
   <DisableDebug>0</DisableDebug>

--- a/apps/sgx/run_model.py
+++ b/apps/sgx/run_model.py
@@ -8,8 +8,10 @@ CWD = osp.abspath(osp.dirname(__file__))
 def main():
     ctx = tvm.context('cpu', 0)
     model = tvm.module.load(osp.join(CWD, 'build', 'enclave.signed.so'))
-    out = model()
-    if out == 42:
+    inp = tvm.nd.array(np.ones((1, 3, 224, 224), dtype='float32'), ctx)
+    out = tvm.nd.array(np.empty((1, 1000), dtype='float32'), ctx)
+    model(inp, out)
+    if abs(out.asnumpy().sum() - 1) < 0.001:
         print('It works!')
     else:
         print('It doesn\'t work!')

--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -3,7 +3,7 @@ apt-get update && apt-get install -y --no-install-recommends --force-yes curl
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 # this rustc is one supported by the installed version of rust-sgx-sdk
-curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2018-09-25
+curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2018-10-01
 . $CARGO_HOME/env
 rustup toolchain add nightly
 rustup component add rust-src

--- a/rust/src/runtime/mod.rs
+++ b/rust/src/runtime/mod.rs
@@ -14,6 +14,9 @@ use std::os::raw::c_char;
 
 pub use self::{array::*, graph::*, module::*, packed_func::*, threading::*, workspace::*};
 
+#[cfg(target_env = "sgx")]
+use self::sgx::ocall_packed_func;
+
 #[no_mangle]
 pub extern "C" fn TVMAPISetLastError(cmsg: *const c_char) {
   #[cfg(not(target_env = "sgx"))]

--- a/rust/src/runtime/sgx.rs
+++ b/rust/src/runtime/sgx.rs
@@ -60,11 +60,11 @@ pub fn ocall_packed_func<S: AsRef<str>>(fn_name: S, args: &[TVMArgValue]) -> Res
 #[macro_export]
 macro_rules! ocall_packed {
   ($fn_name:expr, $($args:expr),+) => {
-    ::runtime::sgx::ocall_packed_func($fn_name, &[$($args.into(),)+])
+    ocall_packed_func($fn_name, &[$($args.into(),)+])
       .expect(concat!("Error calling `", $fn_name, "`"))
   };
   ($fn_name:expr) => {
-    ::runtime::sgx::ocall_packed_func($fn_name, &Vec::new())
+    ocall_packed_func($fn_name, &Vec::new())
       .expect(concat!("Error calling `", $fn_name, "`"))
   }
 }

--- a/rust/src/runtime/threading.rs
+++ b/rust/src/runtime/threading.rs
@@ -23,7 +23,7 @@ use super::super::errors::*;
 use ffi::runtime::TVMParallelGroupEnv;
 
 #[cfg(target_env = "sgx")]
-use super::{TVMArgValue, TVMRetValue};
+use super::{sgx::ocall_packed_func, TVMArgValue, TVMRetValue};
 
 type FTVMParallelLambda =
   extern "C" fn(task_id: usize, penv: *const TVMParallelGroupEnv, cdata: *const c_void) -> i32;

--- a/src/runtime/sgx/tvm.edl
+++ b/src/runtime/sgx/tvm.edl
@@ -21,7 +21,6 @@ enclave {
                                    [out] TVMValue* ret_val,
                                    [out] int* ret_type_code);
         void tvm_ocall_register_export([in, string] const char* name, int func_id);
-        void* tvm_ocall_reserve_space(size_t num_bytes, size_t alignment);
     };
 };
 


### PR DESCRIPTION
This PR
* updates the SGX example to include copying outputs out of SGX
* removes the unnecessary `tvm_ocall_reserve_space`
* updates rustc to a newer nightly (does not affect tests)