### PR TITLE
[VTA] pynq v2.1 -> v2.3

### DIFF
--- a/apps/pynq_rpc/start_rpc_server.sh
+++ b/apps/pynq_rpc/start_rpc_server.sh
@@ -2,4 +2,5 @@
 PROJROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
 
 export PYTHONPATH=${PYTHONPATH}:${PROJROOT}/python:${PROJROOT}/vta/python
-python -m vta.exec.rpc_server
+export PYTHONPATH=${PYTHONPATH}:/home/xilinx/pynq
+python3 -m vta.exec.rpc_server

--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -38,13 +38,10 @@ elseif(PYTHON)
     set_target_properties(vta PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
   endif(APPLE)
 
-  # PYNQ rules
+  # PYNQ rules for Pynq v2.3
   if(${VTA_TARGET} STREQUAL "pynq")
-    find_library(__sds_lib NAMES sds_lib PATHS /usr/lib)
-    find_library(__dma_lib NAMES dma PATHS
-      "/opt/python3.6/lib/python3.6/site-packages/pynq/drivers/"
-      "/opt/python3.6/lib/python3.6/site-packages/pynq/lib/")
-    target_link_libraries(vta ${__sds_lib} ${__dma_lib})
+    find_library(__cma_lib NAMES cma PATH /usr/lib)
+    target_link_libraries(vta ${__cma_lib})
   endif()
 else()
   message(STATUS "Cannot found python in env, VTA build is skipped..")

--- a/docs/vta/install.md
+++ b/docs/vta/install.md
@@ -67,7 +67,7 @@ This guide covers the following themes:
 
 Setup your Pynq board based on the [Pynq board getting started tutorial](http://pynq.readthedocs.io/en/latest/getting_started.html).
 You should follow the instructions up to and including the *Turning On the PYNQ-Z1* step (no need to pursue the tutorial beyond this point).
-* Make sure that you've downloaded the latest Pynq image, [PYNQ-Z1 v2.1](http://pynq-testing.readthedocs.io/en/image_v2.2/getting_started/pynq_image.html) (released 21 Feb 2018), and have imaged your SD card with it (we recommend the free [Etcher](https://etcher.io/) program).
+* Make sure that you've downloaded the latest Pynq image, [PYNQ-Z1 v2.3](http://www.pynq.io/board.html) (released October 3rd 2018), and have imaged your SD card with it (we recommend the free [Etcher](https://etcher.io/) program).
 * For this test setup, follow the ["Connect to a Computer"](http://pynq.readthedocs.io/en/latest/getting_started.html#connect-to-a-computer) Ethernet setup instructions. To be able to talk to the board, make sure to [assign your computer a static IP address](http://pynq.readthedocs.io/en/latest/appendix.html#assign-your-computer-a-static-ip)
 
 Once the board is powered on and connected to your development machine, try connecting to it to make sure you've properly set up your Pynq board:

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -95,12 +95,6 @@ void VTAFlushCache(vta_phy_addr_t buf, int size);
  */
 void VTAInvalidateCache(vta_phy_addr_t buf, int size);
 
-/*!
- * \brief Programming the bit stream on the FPGA.
- * \param bitstream The path to the bit stream file.
- */
-void VTAProgram(const char* bitstream);
-
 #ifdef __cplusplus
 }
 #endif

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -52,7 +52,6 @@ def server_start():
     @tvm.register_func("tvm.contrib.vta.init", override=True)
     def program_fpga(file_name):
         path = tvm.get_global_func("tvm.rpc.server.workpath")(file_name)
-        # load_vta_dll().VTAProgram(c_str(path))
         bs = Bitstream(path)
         bs.download()
         logging.info("Program FPGA with %s", file_name)

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -10,7 +10,6 @@ import os
 import ctypes
 import json
 import tvm
-from tvm._ffi.base import c_str
 from tvm import rpc
 from tvm.contrib import cc
 from pynq import Bitstream
@@ -52,8 +51,8 @@ def server_start():
     @tvm.register_func("tvm.contrib.vta.init", override=True)
     def program_fpga(file_name):
         path = tvm.get_global_func("tvm.rpc.server.workpath")(file_name)
-        bs = Bitstream(path)
-        bs.download()
+        bitstream = Bitstream(path)
+        bitstream.download()
         logging.info("Program FPGA with %s", file_name)
 
     @tvm.register_func("tvm.rpc.server.shutdown", override=True)

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -13,6 +13,7 @@ import tvm
 from tvm._ffi.base import c_str
 from tvm import rpc
 from tvm.contrib import cc
+from pynq import Bitstream
 
 from ..environment import get_env
 from ..pkg_config import PkgConfig
@@ -51,7 +52,9 @@ def server_start():
     @tvm.register_func("tvm.contrib.vta.init", override=True)
     def program_fpga(file_name):
         path = tvm.get_global_func("tvm.rpc.server.workpath")(file_name)
-        load_vta_dll().VTAProgram(c_str(path))
+        # load_vta_dll().VTAProgram(c_str(path))
+        bs = Bitstream(path)
+        bs.download()
         logging.info("Program FPGA with %s", file_name)
 
     @tvm.register_func("tvm.rpc.server.shutdown", override=True)

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -136,34 +136,3 @@ int VTADeviceRun(VTADeviceHandle handle,
   return static_cast<VTADevice*>(handle)->Run(
       insn_phy_addr, insn_count, wait_cycles);
 }
-
-void VTAProgram(const char* bitstream) {
-  int elem;
-  FILE *src, *dst, *partial;
-  partial = fopen(VTA_PYNQ_BS_IS_PARTIAL, "w");
-  if (partial == NULL) {
-    printf("Cannot open partial config file %s\n", VTA_PYNQ_BS_IS_PARTIAL);
-        fclose(partial);
-        exit(1);
-  }
-  fputc('0', partial);
-  fclose(partial);
-  src = fopen(bitstream, "rb");
-  if (src == NULL) {
-    printf("Cannot open bitstream %s\n", bitstream);
-    exit(1);
-  }
-  dst = fopen(VTA_PYNQ_BS_XDEVCFG, "wb");
-  if (dst == NULL) {
-    printf("Cannot open device file %s\n", VTA_PYNQ_BS_XDEVCFG);
-    fclose(dst);
-    exit(1);
-  }
-  elem = fgetc(src);
-  while (elem != EOF) {
-    fputc(elem, dst);
-    elem = fgetc(src);
-  }
-  fclose(src);
-  fclose(dst);
-}

--- a/vta/src/pynq/pynq_driver.h
+++ b/vta/src/pynq/pynq_driver.h
@@ -37,11 +37,6 @@ void VTAUnmapRegister(void *vta, size_t length);
 void VTAWriteMappedReg(void* base_addr, uint32_t offset, uint32_t val);
 uint32_t VTAReadMappedReg(void* base_addr, uint32_t offset);
 
-/*! \brief (Pynq only) Partial bitstream status file path */
-#define VTA_PYNQ_BS_IS_PARTIAL "/sys/devices/soc0/amba/f8007000.devcfg/is_partial_bitstream"
-/*! \brief (Pynq only) Bitstream destination file path */
-#define VTA_PYNQ_BS_XDEVCFG "/dev/xdevcfg"
-
 /*! \brief (Pynq only) Path to /dev/mem */
 #define VTA_PYNQ_DEV_MEM_PATH "/dev/mem"
 /*! \brief (Pynq only) MMIO driver constant */


### PR DESCRIPTION
We are trying to remain up to date with the latest pynq version releases (v2.3 was released earlier this month).

Notes about this update for v2.3 support:
* These changes are not backwards compatible, so you will need to upgrade your pynq setup to v2.3 (http://www.pynq.io/board.html)
* Also we're moving away from our custom programming driver since they can break from version to version - instead we're using the pynq python libraries for bitstream programming to remain in sync with whatever current version VTA is relying upon