### PR TITLE
[AUTOTVM] Fix measurement initilization for CPU

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -460,7 +460,11 @@ def run_through_rpc(measure_input, build_result,
         if ref_input:
             args = [nd.array(x, ctx=ctx) for x in ref_input]
         else:
+            # create empty arrays on the remote device and copy them once.
+            # This can avoid some memory issues that make the measurment results unreliable.
             args = [nd.empty(x[0], dtype=x[1], ctx=ctx) for x in build_result.arg_info]
+            args = [nd.array(x, ctx=ctx) for x in args]
+            ctx.sync()
 
         costs = time_f(*args).results
         if len(costs) > 2:  # remove largest and smallest value to reduce variance


### PR DESCRIPTION
Fix the initialization issue in measurement for ARM CPU / X86 CPU.
Currently, autotvm will report better performance for some operators due to the wrong initialization.

If you find the performance of an operator is much slower in e2e test than the tuner reports, it is likely that you encountered this problem.

cc @FrozenGene @kevinthesun @eqy 