### PR TITLE
[RFC][BACKEND] support CCE target name 

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -63,6 +63,8 @@ typedef enum {
   kDLAOCL = 5,
   kDLSDAccel = 6,
   kOpenGL = 11,
+  /*! \brief CCE C is for Huawei DaVinci core */
+  kDLCce = 13,
   // AddExtraTVMType which is not in DLPack here
 } TVMDeviceExtType;
 

--- a/python/tvm/_ffi/runtime_ctypes.py
+++ b/python/tvm/_ffi/runtime_ctypes.py
@@ -113,6 +113,7 @@ class TVMContext(ctypes.Structure):
         10: 'rocm',
         11: 'opengl',
         12: 'ext_dev',
+        13: 'cce',
     }
     STR2MASK = {
         'llvm': 1,
@@ -132,6 +133,7 @@ class TVMContext(ctypes.Structure):
         'rocm': 10,
         'opengl': 11,
         'ext_dev': 12,
+        'cce': 13,
     }
     def __init__(self, device_type, device_id):
         super(TVMContext, self).__init__()

--- a/python/tvm/ndarray.py
+++ b/python/tvm/ndarray.py
@@ -173,6 +173,20 @@ def ext_dev(dev_id=0):
     """
     return TVMContext(12, dev_id)
 
+def cce_dev(dev_id=0):
+    """Construct a CCE device
+
+    Parameters
+    ----------
+    dev_id : int, optional
+        The integer device id
+
+    Returns
+    -------
+    ctx : TVMContext
+        The created context
+    """
+    return TVMContext(13, dev_id)
 
 cl = opencl
 mtl = metal

--- a/python/tvm/ndarray.py
+++ b/python/tvm/ndarray.py
@@ -173,7 +173,7 @@ def ext_dev(dev_id=0):
     """
     return TVMContext(12, dev_id)
 
-def cce_dev(dev_id=0):
+def cce(dev_id=0):
     """Construct a CCE device
 
     Parameters

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -103,6 +103,8 @@ Target CreateTarget(const std::string& target_name,
     t->device_type = kDLCPU;
   } else if (target_name == "ext_dev") {
     t->device_type = kDLExtDev;
+  } else if (target_name == "cce") {
+    t->device_type = kDLCce;
   } else {
     LOG(ERROR) << "Unknown target name " << target_name;
     return target::stackvm();

--- a/src/runtime/c_runtime_api.cc
+++ b/src/runtime/c_runtime_api.cc
@@ -39,6 +39,7 @@ inline std::string DeviceName(int type) {
     case kDLROCM: return "rocm";
     case kOpenGL: return "opengl";
     case kDLExtDev: return "ext_dev";
+    case kDLCce: return "cce";
     default: LOG(FATAL) << "unknown type =" << type; return "Unknown";
   }
 }

--- a/tests/python/unittest/test_codegen_device.py
+++ b/tests/python/unittest/test_codegen_device.py
@@ -86,6 +86,11 @@ def test_add_pipeline():
     check_target("rocm", host="llvm")
     check_module_save("vulkan", host="stackvm")
 
+def test_cce_target():
+    target = tvm.target.create("cce")
+    ctx = tvm.context(target.target_name, 0)
+    assert ctx.device_type == 13
 
 if __name__ == "__main__":
     test_add_pipeline()
+    test_cce_target()


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).

As we discuss here, https://discuss.tvm.ai/t/rfc-support-cce-target-name-in-tvm/922

just similar to Cuda C, CCE C is a programming language for Huawei’s AI chip, DaVinci IP core.
We have supported cce backend based on TVM with the help of community, thanks goes to community members.

Ascend AI IP and chip series(with unified Davinci core inside) has been released today at HC 2018, you can check it out here. https://www.huawei.com/en/press-events/news/2018/10/huawei-hc-2018-eric-xu-ai 

We would like to support cce target name in tvm first, send PRs of improvements or fixes from our inhouse repo, and the whole backend opening strategy is still in discussion. 

@tqchen @merrymercy @ZihengJiang @tmoreau89 @yzhliu @kun-zh please review, thanks!