### PR TITLE
[Relay] Serialization round-trip tests

### DIFF
--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -141,3 +141,25 @@ def alpha_equal(lhs, rhs):
       True iff lhs is alpha equal to rhs.
     """
     return bool(_make._alpha_equal(lhs, rhs))
+
+
+def graph_equal(lhs, rhs):
+    """Compare two Relay expr for data-flow equivalence.
+    The difference between this and alpha-equality is that
+    variables are not expected to match between lhs and rhs;
+    they are treated as sources and are mapped between each other.
+
+    Parameters
+    ----------
+    lhs: tvm.relay.Expr
+      One of the input Expression.
+
+    rhs: tvm.relay.Expr
+      One of the input Expression.
+
+    Returns
+    -------
+    result: bool
+      True iff lhs is data-flow equivalent to rhs.
+    """
+    return bool(_make._graph_equal(lhs, rhs))

--- a/src/relay/ir/alpha_equal.cc
+++ b/src/relay/ir/alpha_equal.cc
@@ -183,7 +183,7 @@ class AlphaEqualHandler:
 
   bool VisitType_(const TypeRelationNode* lhs, const Type& other) final {
     if (const TypeRelationNode* rhs = other.as<TypeRelationNode>()) {
-      if (!lhs->func.same_as(rhs->func)) return false;
+      if (lhs->func->name != rhs->func->name) return false;
       if (lhs->num_inputs != rhs->num_inputs) return false;
       if (!this->AttrEqual(lhs->attrs, rhs->attrs)) return false;
       if (lhs->args.size() != rhs->args.size()) return false;

--- a/tests/python/relay/test_ir_nodes.py
+++ b/tests/python/relay/test_ir_nodes.py
@@ -2,6 +2,13 @@
 import tvm
 from tvm import relay
 from tvm.expr import *
+from tvm.relay.ir_pass import alpha_equal
+
+
+def json_roundtrip(node):
+    json_str = tvm.save_json(node)
+    return tvm.load_json(json_str)
+
 
 def test_bad_constructor():
     try:
@@ -21,6 +28,11 @@ def test_span():
     assert isinstance(span, relay.base.Span)
     str(span)
 
+    back = json_roundtrip(span)
+    assert back.source == span.source
+    assert back.lineno == span.lineno
+    assert back.col_offset == span.col_offset
+
 # Types
 
 def test_tensor_type():
@@ -32,6 +44,10 @@ def test_tensor_type():
     assert tt.span == None
     str(tt)
 
+    # roundtrip preserves alpha-equality
+    back = json_roundtrip(tt)
+    assert back == tt
+
 
 def test_type_param():
     tp = relay.TypeVar('name', relay.Kind.Type)
@@ -39,20 +55,27 @@ def test_type_param():
     # assert tp.span  # TODO allow us to set span
     str(tp)
 
+    back = json_roundtrip(tp)
+    # pointer equality will not be preserved so alpha-equality will fail
+    assert back.kind == tp.kind
+
 
 def test_func_type():
     type_params = tvm.convert([])
     type_constraints = tvm.convert([])  # TODO: fill me in
     arg_types = tvm.convert([])
-    ret_type = None
+    ret_type = relay.TensorType((1, 2, 3), 'float32')
     tf = relay.FuncType(arg_types, ret_type, type_params, type_constraints)
     assert tf.type_params == type_params
     assert tf.type_constraints == type_constraints
     assert tf.arg_types == arg_types
     assert tf.ret_type == ret_type
     assert tf.span == None
-    # TODO make sure we can set
+    # TODO make sure we can set span
     str(tf)
+
+    back = json_roundtrip(tf)
+    assert back == tf
 
 
 def test_tuple_type():
@@ -64,12 +87,15 @@ def test_tuple_type():
     tup_ty = relay.TupleType(fields)
     assert tup_ty.fields == fields
 
+    back = json_roundtrip(tup_ty)
+    assert back == tup_ty
+
 
 def test_type_relation():
     tp = relay.TypeVar('tp', relay.Kind.Type)
     tf = relay.FuncType(tvm.convert([]), None, tvm.convert([]), tvm.convert([]))
     tt = relay.TensorType(tvm.convert([1, 2, 3]), 'float32')
-    args = tvm.convert([tf, tt, tp])
+    args = tvm.convert([tp, tf, tt])
 
     num_inputs = 2
     func = tvm.get_env_func("tvm.relay.type_relation.Broadcast")
@@ -79,6 +105,14 @@ def test_type_relation():
     assert tr.args == args
     assert tr.num_inputs == num_inputs
 
+    back = json_roundtrip(tr)
+    # assert back == tr
+    assert tr.num_inputs == back.num_inputs
+    assert len(back.args) == len(tr.args)
+    for i in range(len(back.args)):
+        assert back.args[i] == tr.args[i]
+    assert back.attrs.name == tr.attrs.name
+
 
 def test_constant():
     arr = tvm.nd.array(10)
@@ -87,6 +121,9 @@ def test_constant():
     assert const.span == None
     str(const)
 
+    back = json_roundtrip(const)
+    assert alpha_equal(const, back)
+
 
 def test_tuple():
     fields = tvm.convert([])
@@ -94,6 +131,9 @@ def test_tuple():
     assert tup.fields == fields
     assert tup.span == None
     str(tup)
+
+    back = json_roundtrip(tup)
+    assert alpha_equal(tup, back)
 
 
 def test_local_var():
@@ -109,6 +149,11 @@ def test_local_var():
     assert lv.name_hint == name_hint
     assert lv.type_annotation == t1
 
+    back = json_roundtrip(lv)
+    # assert alpha_equal(lv, back)
+    assert back.name_hint == lv.name_hint
+    assert back.type_annotation == lv.type_annotation
+
 
 def test_global_var():
     name_hint = 'g'
@@ -117,19 +162,26 @@ def test_global_var():
     # assert lv.span == None todo(@jroesch): what do we do about spans
     str(gv)
 
+    back = json_roundtrip(gv)
+    # assert alpha_equal(gv, back)
+    assert back.name_hint == gv.name_hint
+
 
 def test_function():
     param_names = ['a', 'b', 'c', 'd']
     params = tvm.convert([relay.Var(n) for n in param_names])
-    ret_type = None
-    body = None
+    ret_type = relay.TupleType(tvm.convert([]))
+    body = relay.Tuple(tvm.convert([]))
     type_params = tvm.convert([])
-    fn = relay.Function(params, ret_type, body, type_params)
+    fn = relay.Function(params, body, ret_type, type_params)
     assert fn.params == params
     assert fn.body == body
     assert fn.type_params == type_params
     assert fn.span == None
     str(fn)
+
+    back = json_roundtrip(fn)
+    assert alpha_equal(fn, back)
 
 
 def test_call():
@@ -141,6 +193,13 @@ def test_call():
     assert call.args == args
     assert call.span == None
     str(call)
+
+    back = json_roundtrip(call)
+    # assert alpha_equal(call, back)
+    assert back.op.name_hint == call.op.name_hint
+    assert len(back.args) == len(call.args)
+    for i in range(len(call.args)):
+        assert back.args[i].name_hint == call.args[i].name_hint
 
 
 def test_let():
@@ -157,6 +216,12 @@ def test_let():
     assert let.span == None
     str(let)
 
+    back = json_roundtrip(let)
+    # assert alpha_equal(let, back)
+    assert back.var.name_hint == let.var.name_hint
+    assert alpha_equal(back.value, let.value)
+    assert back.body.name_hint == let.body.name_hint
+
 
 def test_if():
     cond = relay.Var('cond')
@@ -169,6 +234,12 @@ def test_if():
     assert ife.span == None
     str(ife)
 
+    back = json_roundtrip(ife)
+    #assert alpha_equal(ife, back)
+    assert back.cond.name_hint == ife.cond.name_hint
+    assert back.true_branch.name_hint == ife.true_branch.name_hint
+    assert back.false_branch.name_hint == ife.false_branch.name_hint
+
 
 def test_tuple_get_item():
     tup = relay.Var("tuple")
@@ -176,6 +247,12 @@ def test_tuple_get_item():
     assert get.tuple_value == tup
     assert get.index == 1
     str(get)
+
+    back = json_roundtrip(get)
+    #assert alpha_equal(get, back)
+    assert back.tuple.name_hint == get.tuple.name_hint
+    assert back.index == get.index
+
 
 if __name__ == "__main__":
     test_bad_constructor()


### PR DESCRIPTION
Uses `graph_equal` to add a simple JSON serialization round-trip test to `test_ir_nodes.py`. Also corrects a small issue in alpha-equality for checking type relations: previously, it only checked pointer equality for the functions, whereas it should really be checking the relation's names (they are registered in tvm/relay/op.h).

Perhaps more serialization tests should be separately produced, to try more interesting cases. (I'd love to see some kind of fuzz testing with the serialization, since `graph_equal` gives us an easy property to check for those.)