### PR TITLE
[RUNTIME][TRACE] Support trace primitive.

### DIFF
--- a/include/tvm/ir.h
+++ b/include/tvm/ir.h
@@ -395,6 +395,17 @@ constexpr const char* tvm_stack_make_array = "tvm_stack_make_array";
 constexpr const char* tvm_call_packed = "tvm_call_packed";
 /*!
  * \brief See pesudo code
+ *
+ *  int tvm_call_trace_packed(name, TVMValue* args) {
+ *     ModuleNode* env = GetCurrentEnv();
+ *     const PackedFunc* f = env->GetFuncFromEnv(name);
+ *     (*f)(args, type_code_of(args), len(args));
+ *     return 0;
+ *  }
+ */
+constexpr const char *tvm_call_trace_packed = "tvm_call_trace_packed";
+/*!
+ * \brief See pesudo code
  *  Mark the content as thread local context, can get optimized
  *  by only call the call once at thread start.
  *
@@ -422,6 +433,25 @@ constexpr const char* tvm_thread_context = "tvm_thread_context";
  *  }
  */
 constexpr const char* tvm_call_packed_lowered = "tvm_call_packed_lowered";
+/*!
+ * \brief Lowered version of trace intrinsic, the space of value and
+ *  type codes are explicitly allocated. The return value is the
+ *  (end - 1) value on the stack.
+ *
+ *  int tvm_call_trace_packed_lowered(name,
+ *                                    TVMValue* value_stack,
+ *                                    int* tcode_stack,
+ *                                    int begin,
+ *                                    int end) {
+ *     ModuleNode* env = GetCurrentEnv();
+ *     const PackedFunc* f = env->GetFuncFromEnv(name);
+ *     f->CallPacked(TVMArgs(value_stack[begin:end],
+ *                           tcode_stack[begin:end]),
+ *                   TVMRetValue(value_stack + end, tcode_stack + end));
+ *  }
+ */
+constexpr const char *tvm_call_trace_packed_lowered =
+    "tvm_call_trace_packed_lowered";
 /*!
  * \brief See pseudo code
  *

--- a/python/tvm/intrin.py
+++ b/python/tvm/intrin.py
@@ -488,6 +488,42 @@ def _rule_float_direct(op):
         return call_pure_extern(op.dtype, op.name, *op.args)
     return None
 
+@_register_func("tvm.default_trace_action")
+def _tvm_default_trace_action(*args):
+    print(list(args))
+
+def trace(args, trace_action="tvm.default_trace_action"):
+    """Trace tensor data at the runtime.
+
+    The trace function allows to trace specific tensor at the
+    runtime. The tracing value should come as last argument.
+    The trace action should be specified, by default
+    tvm.default_trace_action is used.
+
+    Parameters
+    ----------
+    args : list of Expr or Buffers.
+        Positional arguments.
+
+    trace_action : str.
+        The name of the trace action.
+
+    Returns
+    -------
+    call : Expr
+        The call expression.
+
+    See Also
+    --------
+    tvm.call_packed : Creates packed function.
+    """
+    if not isinstance(args, list):
+        raise Exception("tvm.trace consumes the args as list type")
+    call_args = [_pack_buffer(x) if isinstance(x, _Buffer) else x for x in args]
+    call_args.insert(0, trace_action)
+    return _make.Call(
+        args[-1].dtype, "tvm_call_trace_packed", call_args, _Call.Intrinsic, None, 0)
+
 # opencl pattern for exp
 register_intrin_rule("opencl", "exp", _rule_float_direct, override=True)
 # default pattern for exp

--- a/src/codegen/llvm/codegen_cpu.h
+++ b/src/codegen/llvm/codegen_cpu.h
@@ -79,8 +79,15 @@ class CodeGenCPU : public CodeGenLLVM {
   void UnpackClosureData(llvm::Value*cdata,
                          const Array<Var>& fields,
                          std::unordered_map<const Variable*, llvm::Value*>* vmap);
+  // Make packed call.
+  llvm::BasicBlock *MakeCallPacked(const Array<Expr> &args,
+                                   llvm::Value **rvalue,
+                                   llvm::Value **ret_tcode, const Type &r_type,
+                                   const int64_t begin, const int64_t end);
   // create call into tvm packed function.
   llvm::Value* CreateCallPacked(const Call* op);
+  // Create trace call into tvm packed function.
+  llvm::Value* CreateCallTracePacked(const Call *op);
   // Create static initialization
   void CreateStaticInit(const std::string& init_fname, const Stmt& body);
   // Create parallel launch

--- a/tests/python/unittest/test_runtime_packed_func.py
+++ b/tests/python/unittest/test_runtime_packed_func.py
@@ -80,6 +80,177 @@ def test_ctx():
     x = tvm._api_internal._context_test(x, x.device_type, x.device_id)
     assert x == tvm.opencl(10)
 
+def test_trace_default_action():
+    n = 2
+    x = tvm.placeholder((n,n,n), name="X", dtype="float32")
+    y = tvm.compute(x.shape, lambda i, j, k: tvm.trace([i, j, k, x[i][j][k]]))
+    s = tvm.create_schedule(y.op)
+    f = tvm.build(s, [x, y], target="llvm")
+    xnd = tvm.nd.array(np.ones((n,n,n), dtype=x.dtype))
+    ynd = tvm.nd.array(np.zeros((n,n,n), dtype=y.dtype))
+    f(xnd, ynd)
+
+def test_trace_expr_assign():
+    @tvm.register_func("tvm.trace_callback2")
+    def trace_buffer(x):
+        return
+
+    def check_assign(dtype):
+        n = 4
+        x = tvm.placeholder((n,n,n), name="X", dtype=dtype)
+        y = tvm.compute(x.shape, lambda i, j, k: tvm.trace([x[i][j][k]], "tvm.trace_callback2"))
+        z = tvm.compute(x.shape, lambda i, j, k: tvm.trace([y[i][j][k]], "tvm.trace_callback2"))
+        s = tvm.create_schedule(z.op)
+        f = tvm.build(s, [x, y, z], "llvm")
+
+        xnd = tvm.nd.array(np.ones((n,n,n), dtype=x.dtype))
+        ynd = tvm.nd.array(np.zeros((n,n,n), dtype=y.dtype))
+        znd = tvm.nd.array(np.zeros((n,n,n), dtype=z.dtype))
+        f(xnd, ynd, znd)
+
+        assert(np.array_equal(xnd.asnumpy(), np.ones((n,n,n))))
+        assert(np.array_equal(ynd.asnumpy(), np.ones((n,n,n))))
+        assert(np.array_equal(znd.asnumpy(), np.ones((n,n,n))))
+
+    for t in ["float64", "float32", "int64", "int32"]:
+        check_assign(t)
+
+def test_trace_expr_sum_generated():
+    @tvm.register_func("tvm.trace_callback3")
+    def trace_buffer(x):
+        return
+
+    def check_expr_sum(dtype):
+        n = 4
+        a = tvm.placeholder((n,n,n), name="a", dtype=dtype)
+        b = tvm.placeholder((n,n,n), name="b", dtype=dtype)
+        c = tvm.compute(a.shape, lambda i, j, k: tvm.trace([a[i][j][k]],"tvm.trace_callback3")
+                                         + tvm.trace([b[i][j][k]],"tvm.trace_callback3"))
+        s = tvm.create_schedule(c.op)
+        f = tvm.build(s, [a, b, c])
+        xnd = tvm.nd.array(np.array(np.ones((n,n,n), dtype=a.dtype)))
+        ynd = tvm.nd.array(np.array(np.ones((n,n,n), dtype=b.dtype)))
+        znd = tvm.nd.array(np.zeros((n,n,n), dtype=c.dtype))
+        f(xnd, ynd, znd)
+        assert(np.array_equal(znd.asnumpy(), xnd.asnumpy() + ynd.asnumpy()))
+
+    for t in ["float64", "float32", "int64", "int32"]:
+        check_expr_sum(t)
+
+def test_trace_expr_sum_args():
+    @tvm.register_func("tvm.trace_silent")
+    def silent(*args):
+      return
+
+    def check_expr_sum(dtype):
+        n = 4
+        a = tvm.placeholder((n,n,n), name="a", dtype=dtype)
+        b = tvm.placeholder((n,n,n), name="b", dtype=dtype)
+        e = tvm.placeholder((n,n,n), name="e", dtype=dtype)
+        d = tvm.placeholder((n,n,n), name="d", dtype=dtype)
+
+        c = tvm.compute(a.shape, lambda i, j, k: tvm.trace([i, j, k, a[i][j][k]], "tvm.trace_silent")
+                                               + tvm.trace([i, j, k, b[i][j][k]], "tvm.trace_silent")
+                                               + tvm.trace([i, j, k, d[i][j][k]], "tvm.trace_silent")
+                                               + tvm.trace([i, j, k, e[i][j][k]], "tvm.trace_silent"))
+        s = tvm.create_schedule(c.op)
+        f = tvm.build(s, [a, b, d, e, c])
+        a_nd = tvm.nd.array(np.array(np.ones((n,n,n), dtype=a.dtype)))
+        b_nd = tvm.nd.array(np.array(np.ones((n,n,n), dtype=b.dtype)))
+        d_nd = tvm.nd.array(np.array(np.ones((n,n,n), dtype=d.dtype)))
+        e_nd = tvm.nd.array(np.array(np.ones((n,n,n), dtype=e.dtype)))
+        c_nd = tvm.nd.array(np.zeros((n,n,n), dtype=c.dtype))
+        f(a_nd, b_nd, d_nd, e_nd, c_nd)
+        assert(np.array_equal(c_nd.asnumpy(), a_nd.asnumpy()
+                                            + b_nd.asnumpy()
+                                            + d_nd.asnumpy()
+                                            + e_nd.asnumpy()))
+
+    for t in ["float64", "float32", "int64", "int32"]:
+        check_expr_sum(t)
+
+def test_trace_expr_sum_custom():
+    @tvm.register_func("tvm.trace_callback4")
+    def trace_buffer(x):
+        return
+
+    def check_expr_sum_custom(dtype):
+        n = 4
+        a = tvm.placeholder((n,n), name="a", dtype=dtype)
+        b = tvm.placeholder((n,n), name="b", dtype=dtype)
+        c = tvm.compute(a.shape, lambda i,j: tvm.trace([a[i][j]], "tvm.trace_callback4")
+                                         + tvm.trace([b[i][j]], "tvm.trace_callback4"))
+        s = tvm.create_schedule(c.op)
+        f = tvm.build(s, [a, b, c])
+        npa = np.array([[1,0,0,0], [0,1,0,0],[0,0,1,0],[0,0,0,1]], dtype=a.dtype)
+        npb = np.array([[1,0,0,0], [0,1,0,0],[0,0,1,0],[0,0,0,1]], dtype=a.dtype)
+        xnd = tvm.nd.array(npa)
+        ynd = tvm.nd.array(npb)
+        znd = tvm.nd.array(np.zeros((n,n), dtype=c.dtype))
+        f(xnd, ynd, znd)
+        assert(np.array_equal(znd.asnumpy(), npa + npb))
+
+    for t in ["float64", "float32", "int64", "int32"]:
+        check_expr_sum_custom(t)
+
+def test_trace_can_change_traced_value_int():
+    @tvm.register_func("tvm.trace_change_int_first")
+    def trace_buffer(x):
+        return 13
+
+    @tvm.register_func("tvm.trace_change_int_second")
+    def trace_buffer(x):
+        return 14
+
+    def check_assign(dtype):
+        n = 4
+        x = tvm.placeholder((n,), name="X", dtype=dtype)
+        y = tvm.compute(x.shape, lambda i: tvm.trace([x[i]], "tvm.trace_change_int_first"))
+        z = tvm.compute(x.shape, lambda i: tvm.trace([y[i]], "tvm.trace_change_int_second"))
+        s = tvm.create_schedule(z.op)
+        f = tvm.build(s, [x, y, z], "llvm")
+
+        xnd = tvm.nd.array(np.ones((n,), dtype=x.dtype))
+        ynd = tvm.nd.array(np.zeros((n,), dtype=y.dtype))
+        znd = tvm.nd.array(np.zeros((n,), dtype=z.dtype))
+        f(xnd, ynd, znd)
+        check_array_first = np.array([13, 13, 13, 13])
+        check_array_second = np.array([14, 14, 14, 14])
+        assert(np.array_equal(ynd.asnumpy(), check_array_first))
+        assert(np.array_equal(znd.asnumpy(), check_array_second))
+
+    for t in ["int64", "int32"]:
+        check_assign(t)
+
+def test_trace_can_change_traced_value_float():
+    @tvm.register_func("tvm.trace_change_float_first")
+    def trace_buffer(x):
+        return 13.0
+
+    @tvm.register_func("tvm.trace_change_float_second")
+    def trace_buffer(x):
+        return 14.0
+
+    def check_assign(dtype):
+        n = 4
+        x = tvm.placeholder((n,), name="X", dtype=dtype)
+        y = tvm.compute(x.shape, lambda i: tvm.trace([x[i]], "tvm.trace_change_float_first"))
+        z = tvm.compute(x.shape, lambda i: tvm.trace([y[i]], "tvm.trace_change_float_second"))
+        s = tvm.create_schedule(z.op)
+        f = tvm.build(s, [x, y, z], "llvm")
+
+        xnd = tvm.nd.array(np.ones((n,), dtype=x.dtype))
+        ynd = tvm.nd.array(np.zeros((n,), dtype=y.dtype))
+        znd = tvm.nd.array(np.zeros((n,), dtype=z.dtype))
+        f(xnd, ynd, znd)
+        check_array_first = np.array([13.0, 13.0, 13.0, 13.0])
+        check_array_second = np.array([14.0, 14.0, 14.0, 14.0])
+        assert(np.array_equal(ynd.asnumpy(), check_array_first))
+        assert(np.array_equal(znd.asnumpy(), check_array_second))
+
+    for t in ["float64", "float32"]:
+        check_assign(t)
+
 if __name__ == "__main__":
     test_empty_array()
     test_get_global()
@@ -88,3 +259,11 @@ if __name__ == "__main__":
     test_return_func()
     test_byte_array()
     test_ctx()
+    test_trace_expr_assign()
+    test_trace_expr_sum_generated()
+    test_trace_expr_sum_custom()
+    test_trace_expr_sum_args()
+    test_trace_default_action()
+    test_trace_can_change_traced_value_int()
+    test_trace_can_change_traced_value_float()
+


### PR DESCRIPTION
The patch is related to issue:
https://discuss.tvm.ai/t/idea-trace-expression/945

This patch allows to trace Tensor data at the runtime. 

Use case example:
**1. Write model.**
...
tvm::Array<tvm::Expr> shape = {n, n, n};
tvm::Tensor  C = tvm::compute (shape, [&] (tvm::Var i, tvm::Var j, tvm::Var k) {
 return tvm::trace ("A", {i,j, k}, A[i][j][k]) + B[i][j][k];
}
...

**2. Run model with specif data.**
output is
...
A [1][4][5] =  $actual_tensor_value
...

How it works:
tvm::trace adds ir::Call expr with type External and then lowers by llvm codegen part
to external call,  so, the runtime support is added. The runtime just processes added function expanding arguments by "var_arg" and writes to file specific data, by default it is a stdout, but log file could be specified by env variable TVM_TRACE, also tracing process could be disable/enable.
Example:
export TVM_TRACE=trace_log_file=path/to/file:process_tracing=1


