### PR TITLE
[RELAY] Add structural hashing for Relay

### DIFF
--- a/include/tvm/relay/pass.h
+++ b/include/tvm/relay/pass.h
@@ -136,6 +136,17 @@ tvm::Array<TypeVar> FreeTypeVars(const Expr& expr);
  */
 Expr DeadCodeElimination(const Expr& e);
 
+/*! \brief Hash a Relay type.
+ *
+ */
+size_t HashType(const Expr &);
+
+/*! \brief Hash a Relay expression.
+ *
+ */
+size_t HashExpr(const Expr &);
+
+
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_PASS_H_

--- a/include/tvm/relay/pass.h
+++ b/include/tvm/relay/pass.h
@@ -144,7 +144,7 @@ Expr DeadCodeElimination(const Expr& e);
  *
  *  \return the hash value.
  */
-size_t HashType(const Type& type);
+size_t StructuralHash(const Type& type);
 
 /*! \brief Hash a Relay expression.
  *
@@ -154,7 +154,7 @@ size_t HashType(const Type& type);
  *
  * \return the hash value.
  */
-size_t HashExpr(const Expr& expr);
+size_t StructuralHash(const Expr& expr);
 
 
 }  // namespace relay

--- a/include/tvm/relay/pass.h
+++ b/include/tvm/relay/pass.h
@@ -138,13 +138,23 @@ Expr DeadCodeElimination(const Expr& e);
 
 /*! \brief Hash a Relay type.
  *
+ * Implements structural hashing of a Relay type.
+ *
+ *  \param type the type to hash.
+ *
+ *  \return the hash value.
  */
-size_t HashType(const Expr &);
+size_t HashType(const Type& type);
 
 /*! \brief Hash a Relay expression.
  *
+ * Implements structural hashing of a Relay expression.
+ *
+ * \param expr the expression to hash.
+ *
+ * \return the hash value.
  */
-size_t HashExpr(const Expr &);
+size_t HashExpr(const Expr& expr);
 
 
 }  // namespace relay

--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -171,4 +171,16 @@ def graph_equal(lhs, rhs):
     return bool(_make._graph_equal(lhs, rhs))
 
 def expr_hash(expr):
-  return bool(_ir_pass._expr_hash(expr))
+    """Hash a Relay expression structurally.
+
+    Parameters
+    ----------
+    expr: tvm.relay.Expr
+      The expression to hash.
+
+    Returns
+    -------
+    result: int
+      The hash value
+    """
+    return int(_ir_pass._expr_hash(expr))

--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -149,10 +149,6 @@ def alpha_equal(lhs, rhs):
     """
     return bool(_make._alpha_equal(lhs, rhs))
 
-lower_ops = _ir_pass.LowerOps
-fuse_ops = _ir_pass.FuseOps
-monomorph = _ir_pass.Monomorph
-
 def graph_equal(lhs, rhs):
     """Compare two Relay expr for data-flow equivalence.
     The difference between this and alpha-equality is that

--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-else-return,
+# pylint: disable=no-else-return
 # pylint: disable=unidiomatic-typecheck
 """The set of passes for Relay.
 
@@ -7,6 +7,7 @@ scripting them in Python.
 """
 from . import _ir_pass
 from . import _make
+from .. import Expr, Type
 # pylint: disable=invalid-name
 
 def infer_type(expr, env=None):
@@ -148,6 +149,9 @@ def alpha_equal(lhs, rhs):
     """
     return bool(_make._alpha_equal(lhs, rhs))
 
+lower_ops = _ir_pass.LowerOps
+fuse_ops = _ir_pass.FuseOps
+monomorph = _ir_pass.Monomorph
 
 def graph_equal(lhs, rhs):
     """Compare two Relay expr for data-flow equivalence.
@@ -170,12 +174,12 @@ def graph_equal(lhs, rhs):
     """
     return bool(_make._graph_equal(lhs, rhs))
 
-def expr_hash(expr):
+def structural_hash(value):
     """Hash a Relay expression structurally.
 
     Parameters
     ----------
-    expr: tvm.relay.Expr
+    expr: tvm.relay.Expr or tvm.relay.Type
       The expression to hash.
 
     Returns
@@ -183,4 +187,9 @@ def expr_hash(expr):
     result: int
       The hash value
     """
-    return int(_ir_pass._expr_hash(expr))
+    if isinstance(value, Expr):
+      return int(_ir_pass._expr_hash(value))
+    elif isinstance(value, Type):
+      return int(_ir_pass._type_hash(value))
+    else:
+      raise TypeError("found value of type {0} expected relay.Expr or relay.Type".format(type(value)))

--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -7,8 +7,8 @@ scripting them in Python.
 """
 from . import _ir_pass
 from . import _make
-from .. import Expr, Type
-# pylint: disable=invalid-name
+from .expr import Expr
+from .ty import Type
 
 def infer_type(expr, env=None):
     """Infer the type of expr under the context of env.

--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -188,8 +188,10 @@ def structural_hash(value):
       The hash value
     """
     if isinstance(value, Expr):
-      return int(_ir_pass._expr_hash(value))
+        return int(_ir_pass._expr_hash(value))
     elif isinstance(value, Type):
-      return int(_ir_pass._type_hash(value))
+        return int(_ir_pass._type_hash(value))
     else:
-      raise TypeError("found value of type {0} expected relay.Expr or relay.Type".format(type(value)))
+        msg = ("found value of type {0} expected" +
+               "relay.Expr or relay.Type").format(type(value))
+        raise TypeError(msg)

--- a/python/tvm/relay/ir_pass.py
+++ b/python/tvm/relay/ir_pass.py
@@ -169,3 +169,6 @@ def graph_equal(lhs, rhs):
       True iff lhs is data-flow equivalent to rhs.
     """
     return bool(_make._graph_equal(lhs, rhs))
+
+def expr_hash(expr):
+  return bool(_ir_pass._expr_hash(expr))

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -30,6 +30,7 @@ class RelayHashHandler:
    */
   size_t Hash(const NodeRef& ref) {
     if (!ref.defined()) return ref.hash();
+
     if (ref->derived_from<TypeNode>()) {
       return TypeHash(Downcast<Type>(ref));
     }
@@ -45,6 +46,7 @@ class RelayHashHandler:
    * \return the hash value
    */
   size_t AttrHash(const NodeRef& ref) {
+    if (!ref.defined()) { return ref.hash(); }
     return AttrsHashHandler::Hash(ref);
   }
   /*!
@@ -54,6 +56,7 @@ class RelayHashHandler:
    * \return the hash value.
    */
   size_t TypeHash(const Type& type) {
+    if (!type.defined()) { return type.hash(); }
     auto found = hash_map_.find(type);
     if (found != hash_map_.end()) {
       return found->second;
@@ -312,16 +315,16 @@ size_t HashExpr(const Expr& expr) {
   return RelayHashHandler(false).ExprHash(expr);
 }
 
-// // TODO(@jroesch): move to correct namespace?
-// TVM_REGISTER_API("relay._make._alpha_equal")
-// .set_body([](TVMArgs args, TVMRetValue* ret) {
-//     *ret = RelayHashHandler(false).Hash(args[0]);
-//   });
+// TODO(@jroesch): move to correct namespace?
+TVM_REGISTER_API("relay._ir_pass._expr_hash")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
+    *ret = static_cast<int64_t>(RelayHashHandler(false).Hash(args[0]));
+  });
 
-// TVM_REGISTER_API("relay._make._type_alpha_equal")
-// .set_body([](TVMArgs args, TVMRetValue* ret) {
-//     *ret = RelayHashHandler(false).TypeHash(args[0]);
-//   });
+TVM_REGISTER_API("relay._ir_pass._type_hash")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
+    *ret = static_cast<int64_t>(RelayHashHandler(false).TypeHash(args[0]));
+  });
 
 // TVM_REGISTER_API("relay._make._graph_equal")
 // .set_body([](TVMArgs args, TVMRetValue* ret) {

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -105,7 +105,9 @@ class RelayHashHandler:
       return it->second;
     }
 
-    return std::hash<std::string>()(var->name_hint);
+
+    size_t hash = std::hash<std::string>()(var->_type_key);
+    return Combine(hash, std::hash<std::string>()(var->name_hint));
   }
 
   // Type hashing

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -166,19 +166,15 @@ class RelayHashHandler:
   }
 
   size_t VisitType_(const TypeRelationNode* type_rel) final {
-    return GetRef<TypeRelation>(type_rel).hash();
-    // if (const TypeRelationNode* rhs = other.as<TypeRelationNode>()) {
-    //   if (lhs->func->name != rhs->func->name) return false;
-    //   if (lhs->num_inputs != rhs->num_inputs) return false;
-    //   if (!this->AttrEqual(lhs->attrs, rhs->attrs)) return false;
-    //   if (lhs->args.size() != rhs->args.size()) return false;
-    //   for (size_t i = 0; i < lhs->args.size(); ++i) {
-    //     if (!TypeEqual(lhs->args[i], rhs->args[i])) return false;
-    //   }
-    //   return true;
-    // } else {
-    //   return false;
-    // }
+    size_t hash = std::hash<std::string>()(type_rel->_type_key);
+    hash = Combine(hash, std::hash<std::string>()(type_rel->func->name));
+    hash = Combine(hash, AttrHash(type_rel->attrs));
+
+    for (auto arg : type_rel->args) {
+      hash = Combine(hash, TypeHash(arg));
+    }
+
+    return hash;
   }
 
   size_t VisitType_(const TupleTypeNode* tuple_type) final {

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -117,7 +117,8 @@ class RelayHashHandler:
   }
 
   size_t VisitType_(const IncompleteTypeNode* incomplete) final {
-    return GetRef<IncompleteType>(incomplete);
+    size_t hash = std::hash<std::string>()(incomplete->_type_key);
+    return Combine(hash, std::hash<int>()(incomplete->kind));
   }
 
   size_t VisitType_(const TypeVarNode* tyvar) final {
@@ -190,7 +191,7 @@ class RelayHashHandler:
 
   size_t BindVar(const NodeRef& var) {
     size_t hash = std::hash<int>()(var_counter++);
-    CHECK(hash_map_.count(var) == 0);
+    CHECK_EQ(hash_map_.count(var), 0);
     hash_map_[var] = hash;
 
     const auto* ty_param = var.as<TypeVarNode>();

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -1,0 +1,332 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file src/tvm/relay/ir/hash.cc
+ * \brief Hash functions for Relay types and expressions.
+ */
+#include <tvm/ir_pass.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/relay/pass.h>
+#include "type_functor.h"
+#include "../../lang/attr_functor.h"
+
+namespace tvm {
+namespace relay {
+
+// Alpha equal handler for relay.
+class RelayHashHandler:
+      public AttrsHashHandler,
+      public TypeFunctor<size_t(const Type&)>,
+      public ExprFunctor<size_t(const Expr&)> {
+ public:
+  explicit RelayHashHandler(bool map_free_var)
+      : map_free_var_(map_free_var) {}
+
+  /*!
+   * Check equality of two nodes.
+   * \param lhs The left hand operand.
+   * \param rhs The right hand operand.
+   * \return the compare result.
+   */
+  size_t Hash(const NodeRef& ref) {
+    if (!ref.defined()) return ref.hash();
+    if (ref->derived_from<TypeNode>()) {
+      return TypeHash(Downcast<Type>(ref));
+    }
+    if (ref->derived_from<ExprNode>()) {
+      return ExprHash(Downcast<Expr>(ref));
+    }
+    return AttrHash(ref);
+  }
+
+  /*!
+   * Compute hash of the attributes.
+   * \param ref The attributes.
+   * \return the hash value
+   */
+  size_t AttrHash(const NodeRef& ref) {
+    return AttrsHashHandler::Hash(ref);
+  }
+  /*!
+   * Compute hash of a Relay type.
+   * \param ref The type to hash.
+   * \param rhs The right hand operand.
+   * \return the hash value.
+   */
+  size_t TypeHash(const Type& type) {
+    auto found = hash_map_.find(type);
+    if (found != hash_map_.end()) {
+      return found->second;
+    } else {
+      auto hash = this->VisitType(type);
+      hash_map_.insert({type, hash});
+      return hash;
+    }
+  }
+  /*!
+   * Compute the hash of an expression.
+   *
+   * \note We run graph structural equality checking when comparing two Exprs.
+   *   This means that AlphaEqualHandler can only be used once for each pair.
+   *   The equality checker checks data-flow equvalence of the Expr DAG.
+   *   This function also runs faster as it memomizes equal_map.
+   *
+   * \param expr The expression to hash.
+   * \return the hash value.
+   */
+  size_t ExprHash(const Expr& expr) {
+    if (!expr.defined()) return expr.hash();
+    auto found = hash_map_.find(expr);
+    if (found != hash_map_.end()) {
+      return found->second;
+    } else {
+      auto hash = this->VisitExpr(expr);
+      hash_map_.insert({expr, hash});
+      return hash;
+    }
+  }
+
+ protected:
+  /*!
+   * \brief Check if data type equals each other.
+   * \param lhs The left hand operand.
+   * \param rhs The right hand operand.
+   * \return the compare result.
+   */
+  size_t DataTypeHash(const DataType& dtype) {
+     return std::hash<int>()(
+         static_cast<int>(dtype.code()) |
+         (static_cast<int>(dtype.bits()) << 8) |
+         (static_cast<int>(dtype.lanes()) << 16));
+  }
+
+  /*!
+   * \brief Check Equality of leaf node of the graph.
+   *  if map_free_var_ is set to true, try to map via equal node.
+   * \param lhs The left hand operand.
+   * \param rhs The right hand operand.
+   * \return the compare result.
+   */
+  size_t LeafNodeEqual(const NodeRef& lhs, const NodeRef& rhs) {
+    return 0;
+    // if (lhs.same_as(rhs)) return true;
+    // auto it = equal_map_.find(lhs);
+    // if (it != equal_map_.end()) {
+    //   return it->second.same_as(rhs);
+    // } else {
+    //   if (map_free_var_) {
+    //     if (lhs->type_index() != rhs->type_index()) return false;
+    //     equal_map_[lhs] = rhs;
+    //     return true;
+    //   } else {
+    //     return false;
+    //   }
+    // }
+  }
+
+  using AttrsHashHandler::VisitAttr_;
+  size_t VisitAttr_(const Variable* lhs) final {
+    return 0; // return LeafNodeEqual(GetRef<NodeRef>(lhs), other);
+  }
+
+  // Type equality
+  size_t VisitType_(const TensorTypeNode* tensor_type) final {
+    size_t hash = std::hash<std::string>()(tensor_type->_type_key);
+    hash = Combine(hash, DataTypeHash(tensor_type->dtype));
+    hash = Combine(hash, Hash(tensor_type->shape));
+    return hash;
+  }
+
+  size_t VisitType_(const IncompleteTypeNode* incomplete) final {
+    return GetRef<IncompleteType>(incomplete);
+  }
+
+  size_t VisitType_(const TypeVarNode* lhs) final {
+    return 0;
+    // if (const TypeVarNode* rhs = other.as<TypeVarNode>()) {
+    //   if (lhs->kind != rhs->kind) return false;
+    //   return LeafNodeEqual(GetRef<NodeRef>(lhs), other);
+    // } else {
+    //   return false;
+    // }
+  }
+
+  size_t VisitType_(const FuncTypeNode* func_type) final {
+    size_t hash = std::hash<std::string>()(func_type->_type_key);
+    for (auto type_param : func_type->type_params) {
+      hash = Combine(hash, TypeHash(type_param));
+    }
+
+    for (auto arg : func_type->arg_types) {
+      hash = Combine(hash, TypeHash(arg));
+    }
+
+    hash = Combine(hash, TypeHash(func_type->ret_type));
+    for (auto cs : func_type->type_constraints) {
+      hash = Combine(hash, TypeHash(cs));
+    }
+
+    return hash;
+  }
+
+  size_t VisitType_(const TypeRelationNode* type_rel) final {
+    return GetRef<TypeRelation>(type_rel).hash();
+    // if (const TypeRelationNode* rhs = other.as<TypeRelationNode>()) {
+    //   if (lhs->func->name != rhs->func->name) return false;
+    //   if (lhs->num_inputs != rhs->num_inputs) return false;
+    //   if (!this->AttrEqual(lhs->attrs, rhs->attrs)) return false;
+    //   if (lhs->args.size() != rhs->args.size()) return false;
+    //   for (size_t i = 0; i < lhs->args.size(); ++i) {
+    //     if (!TypeEqual(lhs->args[i], rhs->args[i])) return false;
+    //   }
+    //   return true;
+    // } else {
+    //   return false;
+    // }
+  }
+
+  size_t VisitType_(const TupleTypeNode* tuple_type) final {
+    size_t hash = std::hash<std::string>()(tuple_type->_type_key);
+    for (size_t i = 0; i < tuple_type->fields.size(); i++) {
+      hash = Combine(hash, TypeHash(tuple_type->fields[i]));
+    }
+    return hash;
+  }
+
+  // Expr equal checking.
+  size_t NDArrayHash(const runtime::NDArray& array) {
+    return 0;
+    // if (lhs.defined() != rhs.defined()) {
+    //   return false;
+    // } else if (lhs.same_as(rhs)) {
+    //   return true;
+    // } else {
+    //   auto ldt = lhs->dtype;
+    //   auto rdt = rhs->dtype;
+    //   CHECK_EQ(lhs->ctx.device_type, kDLCPU) << "can only compare CPU tensor";
+    //   CHECK_EQ(rhs->ctx.device_type, kDLCPU) << "can only compare CPU tensor";
+    //   if (ldt.code == rdt.code && ldt.lanes == rdt.lanes && ldt.bits == rdt.bits) {
+    //     size_t data_size = runtime::GetDataSize(*lhs.operator->());
+    //     return std::memcmp(lhs->data, rhs->data, data_size) == 0;
+    //   } else {
+    //     return false;
+    //   }
+    // }
+  }
+
+  int BindVar(const NodeRef& var) {
+    var_map_[var] = var_counter;
+    return var_counter++;
+  }
+
+  size_t VisitExpr_(const VarNode* var) final {
+    return std::hash<int>()(var_map_[GetRef<Var>(var)]);
+  }
+
+  size_t VisitExpr_(const GlobalVarNode* global) final {
+    return GetRef<GlobalVar>(global).hash();
+  }
+
+  size_t VisitExpr_(const TupleNode* tuple) final {
+    size_t hash = std::hash<std::string>()(tuple->_type_key);
+    for (size_t i = 0; i < tuple->fields.size(); i++) {
+      hash = Combine(hash, ExprHash(tuple->fields[i]));
+    }
+    return hash;
+  }
+
+  size_t VisitExpr_(const FunctionNode* func) final {
+    size_t hash = std::hash<std::string>()(func->_type_key);
+    for (auto type_param : func->type_params) {
+      hash = Combine(hash, TypeHash(type_param));
+    }
+
+    for (auto param : func->params) {
+      hash = Combine(hash, std::hash<int>()(BindVar(param)));
+    }
+
+    hash = Combine(hash, TypeHash(func->ret_type));
+    hash =  Combine(hash, ExprHash(func->body));
+
+    return hash;
+  }
+
+  size_t VisitExpr_(const CallNode* call) final {
+    size_t hash = std::hash<std::string>()(call->_type_key);
+    hash = Combine(hash, ExprHash(call->op));
+
+    for (auto arg : call->args) {
+      hash = Combine(hash, ExprHash(arg));
+    }
+
+    hash = Combine(hash, AttrHash(call->attrs));
+
+    return hash;
+  }
+
+  size_t VisitExpr_(const LetNode* let) final {
+    size_t hash = std::hash<std::string>()(let->_type_key);
+    hash = Combine(hash, std::hash<int>()(BindVar(let->var)));
+    hash = Combine(hash, ExprHash(let->value));
+    hash = Combine(hash, ExprHash(let->body));
+    return hash;
+  }
+
+  size_t VisitExpr_(const IfNode* ite) final {
+    size_t hash = std::hash<std::string>()(ite->_type_key);
+    hash = Combine(hash, ExprHash(ite->cond));
+    hash = Combine(hash, ExprHash(ite->true_branch));
+    hash = Combine(hash, ExprHash(ite->false_branch));
+    return hash;
+  }
+
+  size_t VisitExpr_(const OpNode* op) final {
+    return GetRef<Op>(op).hash();
+  }
+
+  size_t VisitExpr_(const ConstantNode* rconst) final {
+    return NDArrayHash(rconst->data);
+  }
+
+  size_t VisitExpr_(const TupleGetItemNode* get_item) final {
+    size_t hash = std::hash<std::string>()(get_item->_type_key);
+    hash = Combine(hash, ExprHash(get_item->tuple));
+    hash = Combine(hash, std::hash<int>()(get_item->index));
+    return hash;
+  }
+
+ private:
+  // whether to map open terms.
+  bool map_free_var_{false};
+  // renaming of NodeRef to indicate two nodes equals to each other
+  std::unordered_map<NodeRef, size_t, NodeHash, NodeEqual> hash_map_;
+  std::unordered_map<NodeRef, int, NodeHash, NodeEqual> var_map_;
+  int var_counter = 0;
+};
+
+size_t HashType(const Type& type) {
+  return RelayHashHandler(false).TypeHash(type);
+}
+
+size_t HashExpr(const Expr& expr) {
+  return RelayHashHandler(false).ExprHash(expr);
+}
+
+// // TODO(@jroesch): move to correct namespace?
+// TVM_REGISTER_API("relay._make._alpha_equal")
+// .set_body([](TVMArgs args, TVMRetValue* ret) {
+//     *ret = RelayHashHandler(false).Hash(args[0]);
+//   });
+
+// TVM_REGISTER_API("relay._make._type_alpha_equal")
+// .set_body([](TVMArgs args, TVMRetValue* ret) {
+//     *ret = RelayHashHandler(false).TypeHash(args[0]);
+//   });
+
+// TVM_REGISTER_API("relay._make._graph_equal")
+// .set_body([](TVMArgs args, TVMRetValue* ret) {
+//     *ret = AlphaEqualHandler(true).Equal(args[0], args[1]);
+//   });
+
+}  // namespace relay
+}  // namespace tvm

--- a/tests/python/relay/test_pass_alpha_equal.py
+++ b/tests/python/relay/test_pass_alpha_equal.py
@@ -1,7 +1,10 @@
 import tvm
 import numpy as np
 from tvm import relay
-from tvm.relay.ir_pass import alpha_equal
+from tvm.relay import ir_pass
+
+def alpha_equal(x, y):
+    return ir_pass.alpha_equal(x, y) and ir_pass.expr_hash(x) == ir_pass.expr_hash(y)
 
 def test_tensor_type_alpha_equal():
     t1 = relay.TensorType((3, 4), "float32")

--- a/tests/python/relay/test_pass_alpha_equal.py
+++ b/tests/python/relay/test_pass_alpha_equal.py
@@ -8,10 +8,7 @@ def alpha_equal(x, y):
     Wrapper around alpha equality which ensures that
     the hash function respects equality.
     """
-    if ir_pass.alpha_equal(x, y):
-        return ir_pass.expr_hash(x) == ir_pass.expr_hash(y)
-    else:
-        return ir_pass.expr_hash(x) != ir_pass.expr_hash(y)
+    return ir_pass.alpha_equal(x, y) and ir_pass.expr_hash(x) == ir_pass.expr_hash(y)
 
 def test_tensor_type_alpha_equal():
     t1 = relay.TensorType((3, 4), "float32")

--- a/tests/python/relay/test_pass_alpha_equal.py
+++ b/tests/python/relay/test_pass_alpha_equal.py
@@ -8,7 +8,7 @@ def alpha_equal(x, y):
     Wrapper around alpha equality which ensures that
     the hash function respects equality.
     """
-    return ir_pass.alpha_equal(x, y) and ir_pass.expr_hash(x) == ir_pass.expr_hash(y)
+    return ir_pass.alpha_equal(x, y) and ir_pass.structural_hash(x) == ir_pass.structural_hash(y)
 
 def test_tensor_type_alpha_equal():
     t1 = relay.TensorType((3, 4), "float32")

--- a/tests/python/relay/test_pass_alpha_equal.py
+++ b/tests/python/relay/test_pass_alpha_equal.py
@@ -4,7 +4,14 @@ from tvm import relay
 from tvm.relay import ir_pass
 
 def alpha_equal(x, y):
-    return ir_pass.alpha_equal(x, y) and ir_pass.expr_hash(x) == ir_pass.expr_hash(y)
+    """
+    Wrapper around alpha equality which ensures that
+    the hash function respects equality.
+    """
+    if ir_pass.alpha_equal(x, y):
+        return ir_pass.expr_hash(x) == ir_pass.expr_hash(y)
+    else:
+        return ir_pass.expr_hash(x) != ir_pass.expr_hash(y)
 
 def test_tensor_type_alpha_equal():
     t1 = relay.TensorType((3, 4), "float32")


### PR DESCRIPTION
Add an implementation of structural hashing for Relay. 

This PR also extends the alpha equality tests to ensure the hash matches when equal, and does not match when not equal.

cc @MarisaKirisame @tqchen @slyubomirsky 

Should be good to go.