### PR TITLE
[Relay] fix small typekey issue

### DIFF
--- a/include/tvm/relay/type.h
+++ b/include/tvm/relay/type.h
@@ -251,7 +251,7 @@ class TupleTypeNode : public TypeNode {
 
   TVM_DLL static TupleType make(tvm::Array<Type> fields);
 
-  static constexpr const char* _type_key = "relay.TypeTuple";
+  static constexpr const char* _type_key = "relay.TupleType";
   TVM_DECLARE_NODE_TYPE_INFO(TupleTypeNode, TypeNode);
 };
 


### PR DESCRIPTION
It might cause TupleTypeNode to be printed incorrectly.
it doesnt show in http://ci.tvm.ai:8080/blue/organizations/jenkins/tvm/detail/PR-1989/1/pipeline/141, but if you run it on local machine you will see what get compared being NodeBase and TupleType.

Also as a side thought can we write a giant macro that make sure everything get did right (all field get visited, typekey match, declare_node_type_info match, etc?) I can do some macro metaprogramming, so I can take up the work.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
