### PR TITLE
Refine porting x86 NCHWc conv to AutoTVM

### DIFF
--- a/nnvm/python/nnvm/top/nn.py
+++ b/nnvm/python/nnvm/top/nn.py
@@ -167,16 +167,16 @@ def compute_contrib_conv2d_NCHWc(attrs, inputs, _):
     padding = attrs.get_int_tuple("padding")
     strides = attrs.get_int_tuple("strides")
     dilation = attrs.get_int_tuple("dilation")
-    kh, kw = attrs.get_int_tuple('kernel_size')
     groups = attrs.get_int("groups")
-    channels = attrs.get_int("channels")
     layout = attrs.get_string("layout")
     out_layout = attrs.get_string("out_layout")
+    out_dtype = attrs.get_string("out_dtype")
+    out_dtype = inputs[0].dtype if out_dtype == "same" else out_dtype
     assert dilation == (1, 1), "not support dilate now"
     if groups == 1:
         # pylint: disable=assignment-from-no-return
-        out = topi.nn.conv2d_NCHWc(inputs[0], inputs[1], channels, (kh, kw),
-                                   strides, padding, layout, out_layout)
+        out = topi.nn.conv2d_NCHWc(inputs[0], inputs[1], strides, padding,
+                                   layout, out_layout, out_dtype)
         # pylint: enable=assignment-from-no-return
     else:
         raise ValueError("not support arbitrary group number > 1 for now")
@@ -192,7 +192,7 @@ def schedule_contrib_conv2d_NCHWc(attrs, outs, target):
     groups = attrs.get_int("groups")
     with tvm.target.create(target):
         if groups == 1:
-            return topi.generic.schedule_conv2d_NCHWc(outs, attrs.get_int_tuple('kernel_size'))
+            return topi.generic.schedule_conv2d_NCHWc(outs)
         else:
             raise ValueError("not support group number > 1 for now")
 

--- a/nnvm/python/nnvm/top/nn.py
+++ b/nnvm/python/nnvm/top/nn.py
@@ -190,17 +190,9 @@ def compute_contrib_conv2d_NCHWc(attrs, inputs, _):
 def schedule_contrib_conv2d_NCHWc(attrs, outs, target):
     """Schedule definition of conv2d NCHWc"""
     groups = attrs.get_int("groups")
-    kh, kw = attrs.get_int_tuple('kernel_size')
-    oc = attrs.get_int("channels")
-    padding = attrs.get_int_tuple("padding")
-    strides = attrs.get_int_tuple("strides")
-    layout = attrs.get_string("layout")
-    out_layout = attrs.get_string("out_layout")
     with tvm.target.create(target):
         if groups == 1:
-            return topi.generic.schedule_conv2d_NCHWc(outs, oc, (kh, kw),
-                                                      strides, padding,
-                                                      layout, out_layout)
+            return topi.generic.schedule_conv2d_NCHWc(outs, attrs.get_int_tuple('kernel_size'))
         else:
             raise ValueError("not support group number > 1 for now")
 

--- a/nnvm/python/nnvm/top/nn.py
+++ b/nnvm/python/nnvm/top/nn.py
@@ -198,8 +198,9 @@ def schedule_contrib_conv2d_NCHWc(attrs, outs, target):
     out_layout = attrs.get_string("out_layout")
     with tvm.target.create(target):
         if groups == 1:
-            return topi.generic.schedule_conv2d_NCHWc(oc, (kh, kw), strides, padding,
-                                                      layout, out_layout, outs)
+            return topi.generic.schedule_conv2d_NCHWc(outs, oc, (kh, kw),
+                                                      strides, padding,
+                                                      layout, out_layout)
         else:
             raise ValueError("not support group number > 1 for now")
 

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -432,9 +432,10 @@ class ApplyGraphBest(DispatchContext):
             The specific configuration.
         """
         key = (str(target), workload)
-        if self._counter < len(self._records) and (key not in self._global_cfg_dict):
+        if self._counter < len(self._records):
             cfg = self._records[self._counter][0].config
             self._counter += 1
+            self.update(key, cfg)
             return cfg
         return self._global_cfg_dict[key]
 

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -431,12 +431,12 @@ class ApplyGraphBest(DispatchContext):
         cfg : ConfigSpace
             The specific configuration.
         """
-        key = (str(target), workload)
         if self._counter < len(self._records):
             cfg = self._records[self._counter][0].config
             self._counter += 1
-            self.update(key, cfg)
+            self.update(target, workload, cfg)
             return cfg
+        key = (str(target), workload)
         return self._global_cfg_dict[key]
 
     def update(self, target, workload, cfg):

--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-few-public-methods,invalid-name,unused-argument,arguments-differ
-# pylint: disable=consider-using-enumerate
+# pylint: disable=consider-using-enumerate,too-many-lines
 """
 Template configuration space.
 
@@ -995,6 +995,18 @@ class FallbackConfigEntity(ConfigSpace):
         for knob_name in self.space_map.keys():
             if not isinstance(self.space_map[knob_name], SplitSpace):
                 self._entity_map[knob_name] = best_match_cfg[knob_name]
+
+    def __setitem__(self, name, entity):
+        """set the entity(knob) of by name
+
+        Parameters
+        ----------
+        name: str
+            name of the entity
+        entity: SplitEntity, ReorderEntity, AnnotateEntity, OtherOptionEntity
+            value of the entity
+        """
+        self._entity_map[name] = entity
 
     def __repr__(self):
         return "%s,%s,%s" % (str(self._entity_map)[12:-1], self.template_key, self.code_hash)

--- a/python/tvm/autotvm/task/topi_integration.py
+++ b/python/tvm/autotvm/task/topi_integration.py
@@ -1,4 +1,4 @@
-# pylint: disable=unused-variable,invalid-name
+# pylint: disable=unused-variable,invalid-name,unused-argument
 """
 Decorators for registering tunable templates to TOPI.
 
@@ -153,7 +153,7 @@ def register_topi_schedule(topi_schedule, target_keys, template_keys, func=None)
             if topi_schedule not in _REGISTED_DISPATHCER[target_key]:
                 @topi_schedule.register(target_key)
                 @dispatcher
-                def config_dispatcher(outs):
+                def config_dispatcher(outs, *args, **kwargs):
                     """override topi call as a workload dispatcher"""
                     def traverse(tensors):
                         """traverse all ops to find attached workload"""
@@ -179,11 +179,11 @@ def register_topi_schedule(topi_schedule, target_keys, template_keys, func=None)
             config_dispatcher = _REGISTED_DISPATHCER[target_key][topi_schedule]
 
             @config_dispatcher.register(template_keys)
-            def template_call(cfg, outs):
+            def template_call(cfg, outs, *args, **kwargs):
                 """call the schedule func"""
                 if f == topi_schedule.fdefault:
-                    return f(outs)
-                return f(cfg, outs)
+                    return f(outs, *args, **kwargs)
+                return f(cfg, outs, *args, **kwargs)
 
         return f
 

--- a/python/tvm/autotvm/task/topi_integration.py
+++ b/python/tvm/autotvm/task/topi_integration.py
@@ -13,7 +13,6 @@ See tvm/topi/python/topi/arm_cpu/depthwise_conv2d.py for example usage.
 
 from ... import _api_internal, tensor
 
-from ..util import get_func_name
 from .task import args_to_workload, dispatcher
 
 
@@ -55,8 +54,6 @@ def register_topi_compute(topi_compute, target_keys, template_keys, func=None):
     --------
     See tvm/topi/python/topi/arm_cpu/depthwise_conv2d.py for example usage.
     """
-    fname = get_func_name(topi_compute)
-
     def _decorator(f):
         targets = [target_keys] if isinstance(target_keys, str) else target_keys
         for target_key in targets:
@@ -68,7 +65,7 @@ def register_topi_compute(topi_compute, target_keys, template_keys, func=None):
                 def config_dispatcher(*args, **kwargs):
                     """override topi call as a config dispatcher"""
                     assert not kwargs, "Do not support kwargs in template function call"
-                    return (fname, ) + args_to_workload(args)
+                    return args_to_workload(args, topi_compute)
                 _REGISTED_DISPATHCER[target_key][topi_compute] = config_dispatcher
 
             config_dispatcher = _REGISTED_DISPATHCER[target_key][topi_compute]
@@ -88,7 +85,7 @@ def register_topi_compute(topi_compute, target_keys, template_keys, func=None):
                 attrs = {}
                 for k, v in node.op.attrs.items():
                     attrs[k] = v
-                attrs['workload'] = (fname, ) + args_to_workload(args)
+                attrs['workload'] = args_to_workload(args, topi_compute)
                 if isinstance(op, tensor.ComputeOp):
                     op = _api_internal._ComputeOp(
                         op.name, op.tag, attrs, op.axis, op.body)

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -55,7 +55,7 @@ def schedule_conv2d_nhwc(outs):
 
 
 @tvm.target.generic_func
-def schedule_conv2d_NCHWc(outs, kernel_size):
+def schedule_conv2d_NCHWc(outs):
     """Schedule for conv2d_NCHW[x]c
 
     Parameters
@@ -64,9 +64,6 @@ def schedule_conv2d_NCHWc(outs, kernel_size):
         The computation graph description of conv2d_NCHWc
         in the format of an array of tensors.
         The number of filter, i.e., the output channel.
-
-    kernel_size : tuple of int
-        (kernel_height, kernel_width)
 
     Returns
     -------

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -55,8 +55,7 @@ def schedule_conv2d_nhwc(outs):
 
 
 @tvm.target.generic_func
-def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, strides,
-                          padding, layout, out_layout):
+def schedule_conv2d_NCHWc(outs, kernel_size):
     """Schedule for conv2d_NCHW[x]c
 
     Parameters
@@ -64,24 +63,10 @@ def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, strides,
     outs : Array of Tensor
         The computation graph description of conv2d_NCHWc
         in the format of an array of tensors.
-
-    num_filter : int
         The number of filter, i.e., the output channel.
 
     kernel_size : tuple of int
         (kernel_height, kernel_width)
-
-    strides : tuple of int
-        (stride_of_height, stride_of_width)
-
-    padding : tuple of int
-        (pad_of_height, pad_of_width)
-
-    layout : str
-        Input data layout
-
-    out_layout : str
-        Output data layout
 
     Returns
     -------

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -55,12 +55,16 @@ def schedule_conv2d_nhwc(outs):
 
 
 @tvm.target.generic_func
-def schedule_conv2d_NCHWc(num_filter, kernel_size, strides,
-                          padding, layout, out_layout, outs):
+def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, strides,
+                          padding, layout, out_layout):
     """Schedule for conv2d_NCHW[x]c
 
     Parameters
     ----------
+    outs : Array of Tensor
+        The computation graph description of conv2d_NCHWc
+        in the format of an array of tensors.
+
     num_filter : int
         The number of filter, i.e., the output channel.
 
@@ -78,10 +82,6 @@ def schedule_conv2d_NCHWc(num_filter, kernel_size, strides,
 
     out_layout : str
         Output data layout
-
-    outs : Array of Tensor
-        The computation graph description of conv2d_NCHWc
-        in the format of an array of tensors.
 
     Returns
     -------

--- a/topi/python/topi/hls/nn.py
+++ b/topi/python/topi/hls/nn.py
@@ -73,7 +73,7 @@ def schedule_conv2d_nhwc(outs):
 
 
 @generic.schedule_conv2d_NCHWc.register(["hls"])
-def schedule_conv2d_NCHWc(outs, kernel_size):
+def schedule_conv2d_NCHWc(outs):
     """Schedule for conv2d_NCHW[x]c
 
     Parameters
@@ -81,9 +81,6 @@ def schedule_conv2d_NCHWc(outs, kernel_size):
     outs : Array of Tensor
         The computation graph description of conv2d_NCHWc
         in the format of an array of tensors.
-
-    kernel_size : tuple of int
-        (kernel_height, kernel_width)
 
     Returns
     -------

--- a/topi/python/topi/hls/nn.py
+++ b/topi/python/topi/hls/nn.py
@@ -73,8 +73,7 @@ def schedule_conv2d_nhwc(outs):
 
 
 @generic.schedule_conv2d_NCHWc.register(["hls"])
-def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, strides,
-                          padding, layout, out_layout):
+def schedule_conv2d_NCHWc(outs, kernel_size):
     """Schedule for conv2d_NCHW[x]c
 
     Parameters
@@ -83,23 +82,8 @@ def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, strides,
         The computation graph description of conv2d_NCHWc
         in the format of an array of tensors.
 
-    num_filter : int
-        The number of filter, i.e., the output channel.
-
     kernel_size : tuple of int
         (kernel_height, kernel_width)
-
-    strides : tuple of int
-        (stride_of_height, stride_of_width)
-
-    padding : tuple of int
-        (pad_of_height, pad_of_width)
-
-    layout : str
-        Input data layout
-
-    out_layout : str
-        Output data layout
 
     Returns
     -------

--- a/topi/python/topi/hls/nn.py
+++ b/topi/python/topi/hls/nn.py
@@ -73,12 +73,16 @@ def schedule_conv2d_nhwc(outs):
 
 
 @generic.schedule_conv2d_NCHWc.register(["hls"])
-def schedule_conv2d_NCHWc(num_filter, kernel_size, strides,
-                          padding, layout, out_layout, outs):
+def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, strides,
+                          padding, layout, out_layout):
     """Schedule for conv2d_NCHW[x]c
 
     Parameters
     ----------
+    outs : Array of Tensor
+        The computation graph description of conv2d_NCHWc
+        in the format of an array of tensors.
+
     num_filter : int
         The number of filter, i.e., the output channel.
 
@@ -96,10 +100,6 @@ def schedule_conv2d_NCHWc(num_filter, kernel_size, strides,
 
     out_layout : str
         Output data layout
-
-    outs : Array of Tensor
-        The computation graph description of conv2d_NCHWc
-        in the format of an array of tensors.
 
     Returns
     -------

--- a/topi/python/topi/intel_graphics/conv2d.py
+++ b/topi/python/topi/intel_graphics/conv2d.py
@@ -61,8 +61,7 @@ def _alter_conv2d_layout(attrs, inputs, tinfos):
     return sym.contrib.conv2d_NCHWc(*copy_inputs, **new_attrs)
 
 @conv2d_NCHWc.register(["intel_graphics"])
-def _decl_conv2d(data, kernel, num_filter, kernel_size, stride, padding, layout,\
-                 out_layout, out_dtype='float32'):
+def _decl_conv2d(data, kernel, stride, padding, layout, out_layout, out_dtype='float32'):
     """Conv2D operator for Intel Graphics backend.
 
     Parameters
@@ -101,7 +100,7 @@ def _decl_conv2d(data, kernel, num_filter, kernel_size, stride, padding, layout,
     return _decl_cl_spatialpack_NCHWc(data, kernel, stride, padding, out_dtype)
 
 @generic.schedule_conv2d_NCHWc.register(["intel_graphics"])
-def schedule_conv2d_NCHWc(outs, kernel_size):
+def schedule_conv2d_NCHWc(outs):
     """Schedule for conv2d_nchw for Intel Graphics
 
     Parameters

--- a/topi/python/topi/intel_graphics/conv2d.py
+++ b/topi/python/topi/intel_graphics/conv2d.py
@@ -101,7 +101,7 @@ def _decl_conv2d(data, kernel, num_filter, kernel_size, stride, padding, layout,
     return _decl_cl_spatialpack_NCHWc(data, kernel, stride, padding, out_dtype)
 
 @generic.schedule_conv2d_NCHWc.register(["intel_graphics"])
-def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, stride, padding, layout, out_layout):
+def schedule_conv2d_NCHWc(outs, kernel_size):
     """Schedule for conv2d_nchw for Intel Graphics
 
     Parameters

--- a/topi/python/topi/intel_graphics/conv2d.py
+++ b/topi/python/topi/intel_graphics/conv2d.py
@@ -101,7 +101,7 @@ def _decl_conv2d(data, kernel, num_filter, kernel_size, stride, padding, layout,
     return _decl_cl_spatialpack_NCHWc(data, kernel, stride, padding, out_dtype)
 
 @generic.schedule_conv2d_NCHWc.register(["intel_graphics"])
-def schedule_conv2d_NCHWc(num_filter, kernel_size, stride, padding, layout, out_layout, outs):
+def schedule_conv2d_NCHWc(outs, num_filter, kernel_size, stride, padding, layout, out_layout):
     """Schedule for conv2d_nchw for Intel Graphics
 
     Parameters

--- a/topi/python/topi/nn/conv2d.py
+++ b/topi/python/topi/nn/conv2d.py
@@ -254,8 +254,7 @@ def conv2d_nhwc(Input, Filter, stride, padding, out_dtype='float32'):
 
 
 @tvm.target.generic_func
-def conv2d_NCHWc(data, kernel, num_filter, kernel_size, stride,
-                 padding, layout, out_layout, out_dtype='float32'):
+def conv2d_NCHWc(data, kernel, stride, padding, layout, out_layout, out_dtype='float32'):
     """Conv2D operator for nChw[x]c layout.
 
     Parameters
@@ -267,12 +266,6 @@ def conv2d_NCHWc(data, kernel, num_filter, kernel_size, stride,
         6-D with shape
         [num_filter_chunk, in_channel_chunk, filter_height, filter_width,
         in_channel_block, num_filter_block]
-
-    num_filter : int
-        number of filters, i.e., output channel size
-
-    kernel_size : tuple of two ints
-       [kernel_height, kernel_width]
 
     stride : int or a list/tuple of two ints
         stride size, or [stride_height, stride_width]

--- a/topi/python/topi/nn/conv2d.py
+++ b/topi/python/topi/nn/conv2d.py
@@ -84,57 +84,9 @@ def _get_workload(data, kernel, stride, padding, out_dtype):
         '{} vs. {}".format(data.dtype, kernel.dtype)
     return Workload(data.dtype, out_dtype, IH, IW, CI, CO, KH, KW, HPAD, WPAD, HSTR, WSTR)
 
-def _get_workload_int8(data, kernel, stride, padding, out_dtype):
-    """ Get the workload structure. """
-    _, CI, IH, IW = [x.value for x in data.shape]
-    CO, _, KH, KW = [x.value for x in kernel.shape]
-    HPAD, WPAD, _, _ = get_pad_tuple(padding, kernel)
-    if isinstance(stride, (tuple, list)):
-        HSTR, WSTR = stride
-    else:
-        HSTR, WSTR = stride, stride
-    assert (data.dtype == kernel.dtype) or (data.dtype == 'uint8' and kernel.dtype == 'int8'), \
-        "Do not support inputs with different data types now. ' \
-        '{} vs. {}".format(data.dtype, kernel.dtype)
-    return Workload(data.dtype, out_dtype, IH, IW, CI, CO, KH, KW, HPAD, WPAD, HSTR, WSTR)
-
-
-
-@tvm.target.generic_func
-def _get_alter_layout_schedule(wkl):
-    # pylint: disable=unreachable
-    """ Get the platform specific schedule for conv2d_alter_layout. """
-    target = tvm.target.current_target()
-    raise RuntimeError(
-        "No schedule for current target:{}".format(target))
-    # This return has no use, merely to supress pylint warning
-    return wkl
-
 
 @tvm.target.generic_func
 def _get_schedule(wkl):
-    # pylint: disable=unreachable
-    """ Get the platform specific schedule. """
-    target = tvm.target.current_target()
-    raise RuntimeError(
-        "No schedule for current target:{}".format(target))
-    # This return has no use, merely to supress pylint warning
-    return wkl
-
-
-@tvm.target.generic_func
-def _get_schedule_NCHWc(wkl, layout, out_layout):
-    # pylint: disable=unreachable
-    """ Get the platform specific schedule. """
-    target = tvm.target.current_target()
-    raise RuntimeError(
-        "No schedule for current target:{}".format(target))
-    # This return has no use, merely to supress pylint warning
-    return wkl
-
-
-@tvm.target.generic_func
-def _get_schedule_NCHWc_int8(wkl, layout, out_layout):
     # pylint: disable=unreachable
     """ Get the platform specific schedule. """
     target = tvm.target.current_target()

--- a/topi/python/topi/x86/conv2d_avx_1x1.py
+++ b/topi/python/topi/x86/conv2d_avx_1x1.py
@@ -73,7 +73,7 @@ def _fallback_schedule(wkl, simd_width):
                                       ["tile_oh", "ot", oh_factor],
                                       ["tile_ow", "sp", [out_width // ow_factor,
                                                          ow_factor]],],
-                                "t": ""}
+                                "t": "direct"}
                     return ConfigEntity.from_json_dict(cfg_dict)
 
     raise ValueError("cannot decide default schedule for workload: {}".format(wkl))

--- a/topi/python/topi/x86/conv2d_avx_1x1.py
+++ b/topi/python/topi/x86/conv2d_avx_1x1.py
@@ -5,6 +5,7 @@ import tvm
 from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
 from ..nn.util import infer_pad
+from ..util import get_const_tuple
 from .tensor_intrin import dot_16x1x16_int8_int8_int32
 from .check_targets import check_skylake
 
@@ -107,8 +108,8 @@ def _schedule_conv(s, cfg, data, data_pad, data_vec, kernel_vec, conv_out, outpu
 
 def _schedule_conv_NCHWc(s, cfg, data, conv_out, last):
     # fetch schedule
-    ic_bn, oh_factor, ow_factor = (cfg["tile_ic"].size[-1], cfg["tile_oh"].val,
-                                   cfg["tile_ow"].size[-1])
+    oh_factor, ow_factor = cfg["tile_oh"].val, cfg["tile_ow"].size[-1]
+    _, _, _, _, ic_bn = get_const_tuple(data.shape)
 
     # schedule data
     A = data
@@ -174,8 +175,10 @@ def _schedule_conv_NCHWc_int8(s, cfg, data, conv_out, last):
     else:
         return s
     assert int32_lanes != -1
-    ic_bn, oc_bn, oh_factor, ow_factor = (cfg["tile_ic"].size[-1], cfg["tile_oc"].size[-1],
-                                          cfg["tile_oh"].val, cfg["tile_ow"].size[-1])
+
+    oh_factor, ow_factor = cfg["tile_oh"].val, cfg["tile_ow"].size[-1]
+    _, _, _, _, ic_bn = get_const_tuple(data.shape)
+    _, _, _, _, oc_bn = get_const_tuple(conv_out.shape)
 
     # schedule data
     A = data

--- a/topi/python/topi/x86/conv2d_avx_common.py
+++ b/topi/python/topi/x86/conv2d_avx_common.py
@@ -70,7 +70,7 @@ def _fallback_schedule(wkl, simd_width):
                       ["tile_oc", "sp", [out_channel // oc_bn, oc_bn]],
                       ["tile_ow", "sp", [out_width // reg_n, reg_n]],
                       ["unroll_kw", "ot", False]],
-                "t": ""}
+                "t": "direct"}
     return ConfigEntity.from_json_dict(cfg_dict)
 
 

--- a/topi/recipe/conv/test_conv_int8_intel.py
+++ b/topi/recipe/conv/test_conv_int8_intel.py
@@ -114,13 +114,13 @@ def run_inference(data_dtype, kernel_dtype, out_dtype, im_height, im_width, in_f
         LOGGER.debug(tvm.lower(sch, [data, kernel], simple_mode=True))
 
         # Generate and run the optimized schedule
-        sconv = topi.generic.nn.schedule_conv2d_NCHWc(num_filter=out_filter,
+        sconv = topi.generic.nn.schedule_conv2d_NCHWc(outs=[out],
+                                                      num_filter=out_filter,
                                                       kernel_size=(k_h, k_w),
                                                       strides=hstride,
                                                       padding=hpad,
                                                       layout='NCHWc',
-                                                      out_layout='NCHWc',
-                                                      outs=[out])
+                                                      out_layout='NCHWc')
         func = tvm.build(sconv, [data, kernel, out], target=TARGET_NAME, name='conv')
         func(data_array, kernel_array, c_sch)
 

--- a/topi/recipe/conv/test_conv_int8_intel.py
+++ b/topi/recipe/conv/test_conv_int8_intel.py
@@ -61,12 +61,8 @@ def get_shape(im_height, im_width, in_filter, out_filter, k_h, k_w, hpad, wpad,
             kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, NUM_VEC_LANES//4,
                             NUM_VEC_LANES, 4, k_h, k_w)
     elif out_dtype == 'float32':
-        if k_h != 1:
-            kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, k_h, k_w,
-                            NUM_VEC_LANES, NUM_VEC_LANES)
-        else:
-            kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, NUM_VEC_LANES,
-                            NUM_VEC_LANES, k_h, k_w)
+        kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, k_h, k_w,
+                        NUM_VEC_LANES, NUM_VEC_LANES)
     out_height = (im_height + 2 * hpad - k_h) // hstride + 1
     out_width = (im_width + 2 * wpad - k_w) // wstride + 1
     o_shape = (1, out_filter//NUM_VEC_LANES, out_height, out_width, NUM_VEC_LANES)
@@ -114,13 +110,7 @@ def run_inference(data_dtype, kernel_dtype, out_dtype, im_height, im_width, in_f
         LOGGER.debug(tvm.lower(sch, [data, kernel], simple_mode=True))
 
         # Generate and run the optimized schedule
-        sconv = topi.generic.nn.schedule_conv2d_NCHWc(outs=[out],
-                                                      num_filter=out_filter,
-                                                      kernel_size=(k_h, k_w),
-                                                      strides=hstride,
-                                                      padding=hpad,
-                                                      layout='NCHWc',
-                                                      out_layout='NCHWc')
+        sconv = topi.generic.nn.schedule_conv2d_NCHWc(outs=[out], kernel_size=(k_h, k_w))
         func = tvm.build(sconv, [data, kernel, out], target=TARGET_NAME, name='conv')
         func(data_array, kernel_array, c_sch)
 

--- a/topi/recipe/conv/test_conv_int8_intel.py
+++ b/topi/recipe/conv/test_conv_int8_intel.py
@@ -54,12 +54,8 @@ def get_shape(im_height, im_width, in_filter, out_filter, k_h, k_w, hpad, wpad,
     data_shape = (1, in_filter//NUM_VEC_LANES, im_height, im_width, NUM_VEC_LANES)
 
     if out_dtype == 'int32':
-        if k_h != 1:
-            kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, k_h, k_w,
-                            NUM_VEC_LANES//4, NUM_VEC_LANES, 4)
-        else:
-            kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, NUM_VEC_LANES//4,
-                            NUM_VEC_LANES, 4, k_h, k_w)
+        kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, k_h, k_w,
+                        NUM_VEC_LANES//4, NUM_VEC_LANES, 4)
     elif out_dtype == 'float32':
         kernel_shape = (out_filter//NUM_VEC_LANES, in_filter//NUM_VEC_LANES, k_h, k_w,
                         NUM_VEC_LANES, NUM_VEC_LANES)
@@ -99,8 +95,7 @@ def run_inference(data_dtype, kernel_dtype, out_dtype, im_height, im_width, in_f
 
 
     with tvm.target.create(TARGET_NAME):
-        conv = topi.nn.conv2d_NCHWc(data, kernel, num_filter=out_filter,
-                                    kernel_size=(k_h, k_w), stride=hstride,
+        conv = topi.nn.conv2d_NCHWc(data, kernel, stride=hstride,
                                     padding=hpad, layout='NCHWc',
                                     out_layout='NCHWc', out_dtype=out_dtype)
         out = topi.nn.relu(conv)
@@ -110,7 +105,7 @@ def run_inference(data_dtype, kernel_dtype, out_dtype, im_height, im_width, in_f
         LOGGER.debug(tvm.lower(sch, [data, kernel], simple_mode=True))
 
         # Generate and run the optimized schedule
-        sconv = topi.generic.nn.schedule_conv2d_NCHWc(outs=[out], kernel_size=(k_h, k_w))
+        sconv = topi.generic.nn.schedule_conv2d_NCHWc(outs=[out])
         func = tvm.build(sconv, [data, kernel, out], target=TARGET_NAME, name='conv')
         func(data_array, kernel_array, c_sch)
 

--- a/topi/tests/python/test_topi_conv2d_NCHWc.py
+++ b/topi/tests/python/test_topi_conv2d_NCHWc.py
@@ -1,0 +1,206 @@
+"""Test for NCHW[x]c convolution"""
+
+import numpy as np
+import tvm
+from tvm import autotvm
+import topi
+import topi.testing
+from tvm.contrib.pickle_memoize import memoize
+from topi.util import get_const_tuple
+
+from common import get_all_backend
+
+def _transform_data(data, bn):
+    # NCHW -> NCHW[x]c
+    batch_size, channel, height, width = data.shape
+    data = np.transpose(data, (0, 2, 3, 1))
+    data = np.reshape(data, (batch_size, height, width, channel//bn, bn))
+    data = np.transpose(data, (0, 3, 1, 2, 4))
+    return data
+
+def _transform_kernel(kernel, ic_bn, oc_bn):
+    # OIHW -> OIHW[x]i[x]o
+    out_channel, in_channel, kh, kw = kernel.shape
+    kernel = np.transpose(kernel, (1, 2, 3, 0))
+    kernel = np.reshape(kernel, (in_channel, kh, kw, out_channel//oc_bn, oc_bn))
+    kernel = np.transpose(kernel, (1, 2, 3, 4, 0))
+    kernel = np.reshape(kernel, (kh, kw, out_channel//oc_bn, oc_bn, in_channel//ic_bn, ic_bn))
+    kernel = np.transpose(kernel, (2, 4, 0, 1, 5, 3))
+    return kernel
+
+def _transform_bias(bias, bn):
+    # [num_filter, 1, 1] -> [num_filter//bn, 1, 1, bn]
+    num_filter, h, w = bias.shape
+    bias = np.transpose(bias, (1, 2, 0))
+    bias = np.reshape(bias, (h, w, num_filter//bn, bn))
+    bias = np.transpose(bias, (2, 0, 1, 3))
+    return bias
+
+def verify_conv2d_NCHWc(batch, in_channel, in_size, num_filter, kernel, stride,
+                        padding, dilation=1, add_bias=False, add_relu=False, dtype="float32"):
+    assert dilation == 1, "conv2d_NCHWc does not support dilation for now."
+    print("Workload: (%d, %d, %d, %d, %d, %d, %d)" %
+          (batch, in_channel, in_size, num_filter, kernel, stride, padding))
+
+    in_height = in_width = in_size
+
+    # for testing functionality,
+    # we choose arbitrary block size that can divide the channel,
+    # regardless of the performance.
+    oc_block = 1
+    for bn in range(16, 0, -1):
+        if num_filter % bn == 0:
+            oc_block = bn
+            break
+
+    ic_block = 1
+    for bn in range(oc_block, 0, -1):
+        if in_channel % bn == 0:
+            ic_block = bn
+            break
+
+    A = tvm.placeholder((batch, in_channel//ic_block, in_height, in_width, ic_block), name='A')
+    W = tvm.placeholder((num_filter//oc_block, in_channel//ic_block, kernel, kernel, ic_block, oc_block), name='W')
+    bias = tvm.placeholder((num_filter//oc_block, 1, 1, oc_block), name='bias')
+
+    @memoize("topi.tests.test_topi_conv2d_NCHWc.verify_conv2d_NCHWc")
+    def get_ref_data():
+        a_np = np.random.uniform(size=(batch, in_channel, in_height, in_width)).astype(dtype)
+        w_np = np.random.uniform(size=(num_filter, in_channel, kernel, kernel)).astype(dtype)
+        b_np = np.random.uniform(size=(num_filter, 1, 1)).astype(dtype)
+        c_np = topi.testing.conv2d_nchw_python(a_np, w_np, stride, padding)
+        if add_bias:
+            c_np += b_np
+        if add_relu:
+            c_np = np.maximum(c_np, 0)
+        return _transform_data(a_np, ic_block), _transform_kernel(w_np, ic_block, oc_block), \
+               _transform_bias(b_np, oc_block), _transform_data(c_np, oc_block)
+
+    a_np, w_np, b_np, c_np = get_ref_data()
+
+    def check_device(device):
+        ctx = tvm.context(device, 0)
+        if not ctx.exist:
+            print("Skip because %s is not enabled" % device)
+            return
+        print("Running on target: %s" % device)
+        with tvm.target.create(device):
+            C = topi.nn.conv2d_NCHWc(A, W, (stride, stride), (padding, padding),
+                                     layout='NCHW%dc'%ic_block,
+                                     out_layout="NCHW%dc"%oc_block,
+                                     out_dtype=dtype)
+            if add_bias:
+                C = topi.add(C, bias)
+            if add_relu:
+                C = topi.nn.relu(C)
+            s = topi.generic.schedule_conv2d_NCHWc([C])
+
+        a = tvm.nd.array(a_np, ctx)
+        w = tvm.nd.array(w_np, ctx)
+        b = tvm.nd.array(b_np, ctx)
+        c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), ctx)
+        if add_bias:
+            func = tvm.build(s, [A, W, bias, C], device,
+                             name="relu_%d_%d_%d_%d_%d_%d_%d_%d" %
+                                  (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func(a, w, b, c)
+        else:
+            func = tvm.build(s, [A, W, C], device,
+                             name="relu_%d_%d_%d_%d_%d_%d_%d_%d" %
+                                  (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func(a, w, c)
+        tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=1e-5)
+
+    # test llvm only for now since conv2d_NCHWc implement is missing in other backend.
+    for device in ["llvm"]:
+        with autotvm.tophub.context(device):  # load tophub pre-tuned parameters
+            check_device(device)
+
+
+if __name__ == "__main__":
+    # ResNet18 workloads
+    verify_conv2d_NCHWc(1,   3, 224,  64, 7, 2, 3)
+    verify_conv2d_NCHWc(1,  64,  56,  64, 3, 1, 1)
+    verify_conv2d_NCHWc(1,  64,  56,  64, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  64,  56, 128, 3, 2, 1)
+    verify_conv2d_NCHWc(1,  64,  56, 128, 1, 2, 0)
+    verify_conv2d_NCHWc(1, 128,  28, 128, 3, 1, 1)
+    verify_conv2d_NCHWc(1, 128,  28, 256, 3, 2, 1)
+    verify_conv2d_NCHWc(1, 128,  28, 256, 1, 2, 0)
+    verify_conv2d_NCHWc(1, 256,  14, 256, 3, 1, 1)
+    verify_conv2d_NCHWc(1, 256,  14, 512, 3, 2, 1)
+    verify_conv2d_NCHWc(1, 256,  14, 512, 1, 2, 0)
+    verify_conv2d_NCHWc(1, 512,   7, 512, 3, 1, 1)
+
+    # bias, relu
+    verify_conv2d_NCHWc(1, 64, 56, 64, 3, 1, 1, add_relu=True)
+    verify_conv2d_NCHWc(1, 64, 56, 64, 3, 1, 1, add_bias=True)
+    verify_conv2d_NCHWc(1, 64, 56, 64, 3, 1, 1, add_bias=True, add_relu=True)
+
+    # disable dilation test since it is not supported by NCHW[x]c conv for now.
+    # verify_conv2d_NCHWc(1, 64, 56, 64, 3, 1, 1, dilation=2)
+
+    # batch size
+    verify_conv2d_NCHWc(4, 64, 56, 64, 3, 1, 1)
+    verify_conv2d_NCHWc(9, 64, 56, 64, 3, 1, 1)
+
+    # weird workloads
+    verify_conv2d_NCHWc(2, 2, 2, 2, 2, 2, 2)
+    verify_conv2d_NCHWc(3, 3, 3, 3, 3, 3, 3)
+    verify_conv2d_NCHWc(4, 4, 4, 4, 4, 4, 4)
+    verify_conv2d_NCHWc(5, 5, 5, 5, 5, 5, 5)
+    verify_conv2d_NCHWc(6, 6, 6, 6, 6, 6, 6)
+
+    # disable these tests due to some bugs of llvm with nvptx
+    # verify_conv2d_NCHWc(1, 1, 1, 1, 1, 1, 1, dilation=1)
+    # verify_conv2d_NCHWc(1, 1, 1, 1, 1, 1, 1, dilation=2)
+    # verify_conv2d_NCHWc(2, 13, 71, 59, 3, 1, 1)
+
+    # inception v3 workloads
+    verify_conv2d_NCHWc(1,    3, 299,  32, 3, 2, 0)
+    verify_conv2d_NCHWc(1,   32, 149,  32, 3, 1, 0)
+    verify_conv2d_NCHWc(1,   32, 147,  64, 3, 1, 1)
+    verify_conv2d_NCHWc(1,   64,  73,  80, 1, 1, 0)
+    verify_conv2d_NCHWc(1,   80,  73, 192, 3, 1, 0)
+    verify_conv2d_NCHWc(1,  192,  35,  64, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  192,  35,  48, 1, 1, 0)
+    verify_conv2d_NCHWc(1,   48,  35,  64, 5, 1, 2)
+    verify_conv2d_NCHWc(1,   64,  35,  96, 3, 1, 1)
+    verify_conv2d_NCHWc(1,   96,  35,  96, 3, 1, 1)
+    verify_conv2d_NCHWc(1,  192,  35,  32, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  256,  35,  64, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  256,  35,  48, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  288,  35,  64, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  288,  35,  48, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  288,  35, 384, 3, 2, 0)
+    verify_conv2d_NCHWc(1,   96,  35,  96, 3, 2, 0)
+    verify_conv2d_NCHWc(1,  768,  17, 192, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  768,  17, 128, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  128,  17, 128, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  128,  17, 192, 7, 1, 3)
+    verify_conv2d_NCHWc(1,  128,  17, 128, 7, 1, 3)
+    verify_conv2d_NCHWc(1,  128,  17, 192, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  768,  17, 160, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  160,  17, 160, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  160,  17, 192, 7, 1, 3)
+    verify_conv2d_NCHWc(1,  160,  17, 160, 7, 1, 3)
+    verify_conv2d_NCHWc(1,  160,  17, 192, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  192,  17, 192, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  192,  17, 192, 7, 1, 3)
+    verify_conv2d_NCHWc(1,  192,  17, 320, 3, 2, 0)
+    verify_conv2d_NCHWc(1,  192,  17, 192, 3, 2, 0)
+    verify_conv2d_NCHWc(1, 1280,   8, 320, 1, 1, 0)
+    verify_conv2d_NCHWc(1, 1280,   8, 384, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  384,   8, 384, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  384,   8, 384, 3, 1, 1)
+    verify_conv2d_NCHWc(1, 1280,   8, 448, 1, 1, 0)
+    verify_conv2d_NCHWc(1,  448,   8, 384, 3, 1, 1)
+    verify_conv2d_NCHWc(1, 1280,   8, 192, 1, 1, 0)
+    verify_conv2d_NCHWc(1, 2048,   8, 320, 1, 1, 0)
+    verify_conv2d_NCHWc(1, 2048,   8, 384, 1, 1, 0)
+    verify_conv2d_NCHWc(1, 2048,   8, 448, 1, 1, 0)
+    verify_conv2d_NCHWc(1, 2048,   8, 192, 1, 1, 0)
+    verify_conv2d_NCHWc(1, 1024,  19,  84, 3, 1, 1)
+    verify_conv2d_NCHWc(1, 2048,  10, 126, 3, 1, 1)
+    verify_conv2d_NCHWc(1,  512,   5, 126, 3, 1, 1)
+    verify_conv2d_NCHWc(1,  256,   3, 126, 3, 1, 1)

--- a/tutorials/autotvm/tune_nnvm_x86.py
+++ b/tutorials/autotvm/tune_nnvm_x86.py
@@ -126,7 +126,8 @@ def tune_kernels(tasks,
         args_conv_NCHWc = [data_plc, kernel_plc, num_filter,
                            kernel_size, strides, padding, layout, dtype]
         args_conv_NCHWc = autotvm.task.nnvm_integration.serialize_args(args_conv_NCHWc)
-        task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=args_conv_NCHWc, target=target)
+        task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=args_conv_NCHWc,
+                                   target=target, template_key='direct')
         task.workload = tsk.workload
 
         # create tuner

--- a/tutorials/autotvm/tune_nnvm_x86.py
+++ b/tutorials/autotvm/tune_nnvm_x86.py
@@ -14,7 +14,6 @@ import nnvm.compiler
 import tvm
 from tvm import autotvm
 from tvm.autotvm.tuner import XGBTuner, GATuner, RandomTuner, GridSearchTuner
-from topi.x86.conv2d import conv_NCHWc_arg_to_workload
 import tvm.contrib.graph_runtime as runtime
 
 #################################################################
@@ -123,12 +122,12 @@ def tune_kernels(tasks,
         kernel_size = (kernel[1][2], kernel[1][3])
         data_plc = tvm.placeholder(data[1], name="data")
         kernel_plc = tvm.placeholder(kernel[1], name="kernel")
-        args = [data_plc, kernel_plc, kernel[1][0], kernel_size, strides,
-                padding, layout, layout, dtype]
-        args = autotvm.task.nnvm_integration.serialize_args(args)
-        task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=args, target=target)
-        task.workload = conv_NCHWc_arg_to_workload(data_plc, kernel_plc, kernel_size,
-                                                   strides, padding, layout, layout, dtype)
+        num_filter = kernel[1][0]
+        args_conv_NCHWc = [data_plc, kernel_plc, num_filter,
+                           kernel_size, strides, padding, layout, dtype]
+        args_conv_NCHWc = autotvm.task.nnvm_integration.serialize_args(args_conv_NCHWc)
+        task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=args_conv_NCHWc, target=target)
+        task.workload = tsk.workload
 
         # create tuner
         if tuner == 'xgb' or tuner == 'xgb-rank':

--- a/tutorials/autotvm/tune_nnvm_x86.py
+++ b/tutorials/autotvm/tune_nnvm_x86.py
@@ -117,16 +117,7 @@ def tune_kernels(tasks,
         prefix = "[Task %2d/%2d] " % (i+1, len(tasks))
 
         # converting conv2d tasks to conv2d_NCHWc tasks
-        # data, kernel are tuples of ("TENSOR", shape, dtype)
-        data, kernel, strides, padding, layout, dtype = tsk.args
-        kernel_size = (kernel[1][2], kernel[1][3])
-        data_plc = tvm.placeholder(data[1], name="data")
-        kernel_plc = tvm.placeholder(kernel[1], name="kernel")
-        num_filter = kernel[1][0]
-        args_conv_NCHWc = [data_plc, kernel_plc, num_filter,
-                           kernel_size, strides, padding, layout, dtype]
-        args_conv_NCHWc = autotvm.task.nnvm_integration.serialize_args(args_conv_NCHWc)
-        task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=args_conv_NCHWc,
+        task = autotvm.task.create("topi_x86_conv2d_NCHWc", args=tsk.args,
                                    target=target, template_key='direct')
         task.workload = tsk.workload
 


### PR DESCRIPTION
* Add `update` to dispatchers so that `alter_op_layout` can provide config for updated operators.
* Register NCHWc's `compute`, `schedule` and `args_to_workload` to autotvm

The whole process becomes,
- Tuning: tune with origin workload, but users can choose to use NCHWc compute & schedule.
- AlterLayout: extract config using origin workload, replace conv op with NCHWc implement, update dispatcher with NCHWc workload and config
- Compute & schedule: normal way as in autotvm. NCHWc workloads will exist since `AlterLayout` updated that.

Reviews please review @kevinthesun @merrymercy 