### PR TITLE
[PASS] add a pass for the specific hardware accelarator when it is not binded

### DIFF
--- a/include/tvm/ir.h
+++ b/include/tvm/ir.h
@@ -238,6 +238,11 @@ constexpr const char* pipeline_exec_scope = "pipeline_exec_scope";
 constexpr const char* opengl_stage_scope = "opengl_stage_scope";
 
 /*!
+ * \brief Mark that it is in the device scope.
+ */
+constexpr const char* device_scope = "device_scope";
+
+/*!
  * \brief Check if attr_key is a pragma key extension
  * \param attr_key The attr key to be compared
  * \return true if it is a pragma key

--- a/include/tvm/ir_pass.h
+++ b/include/tvm/ir_pass.h
@@ -327,13 +327,13 @@ Stmt RewriteUnsafeSelect(Stmt stmt);
 Stmt LowerStorageAccessInfo(Stmt stmt);
 
 /*!
- * \brief insert the mark of device for the hardware accelarator when 
- * it is not binded with thread or block.
+ * \brief Decorate the stmt with a device scope, this is helpful for 
+ * hardware accelerator without thread blocks.
  *
  * \param stmt The stmt to be trasnformed
  * \return Transformed stmt.
  */
-Stmt MarkDevice(Stmt stmt);
+Stmt DecorateDeviceScope(Stmt stmt);
 
 /*!
  * \brief Make an user callable API LoweredFunc.

--- a/include/tvm/ir_pass.h
+++ b/include/tvm/ir_pass.h
@@ -327,6 +327,15 @@ Stmt RewriteUnsafeSelect(Stmt stmt);
 Stmt LowerStorageAccessInfo(Stmt stmt);
 
 /*!
+ * \brief insert the mark of device for the hardware accelarator when 
+ * it is not binded with thread or block.
+ *
+ * \param stmt The stmt to be trasnformed
+ * \return Transformed stmt.
+ */
+Stmt DeviceMark(Stmt stmt);
+
+/*!
  * \brief Make an user callable API LoweredFunc.
  *
  *  The main task of this function is to create code to :

--- a/include/tvm/ir_pass.h
+++ b/include/tvm/ir_pass.h
@@ -333,7 +333,7 @@ Stmt LowerStorageAccessInfo(Stmt stmt);
  * \param stmt The stmt to be trasnformed
  * \return Transformed stmt.
  */
-Stmt DeviceMark(Stmt stmt);
+Stmt MarkDevice(Stmt stmt);
 
 /*!
  * \brief Make an user callable API LoweredFunc.

--- a/src/api/api_pass.cc
+++ b/src/api/api_pass.cc
@@ -154,6 +154,6 @@ REGISTER_PASS1(LowerTVMBuiltin);
 REGISTER_PASS1(CombineContextCall);
 REGISTER_PASS2(VerifyMemory);
 REGISTER_PASS2(VerifyGPUCode);
-REGISTER_PASS1(MarkDevice);
+REGISTER_PASS1(DecorateDeviceScope);
 }  // namespace ir
 }  // namespace tvm

--- a/src/api/api_pass.cc
+++ b/src/api/api_pass.cc
@@ -154,5 +154,6 @@ REGISTER_PASS1(LowerTVMBuiltin);
 REGISTER_PASS1(CombineContextCall);
 REGISTER_PASS2(VerifyMemory);
 REGISTER_PASS2(VerifyGPUCode);
+REGISTER_PASS1(DeviceMark);
 }  // namespace ir
 }  // namespace tvm

--- a/src/api/api_pass.cc
+++ b/src/api/api_pass.cc
@@ -154,6 +154,6 @@ REGISTER_PASS1(LowerTVMBuiltin);
 REGISTER_PASS1(CombineContextCall);
 REGISTER_PASS2(VerifyMemory);
 REGISTER_PASS2(VerifyGPUCode);
-REGISTER_PASS1(DeviceMark);
+REGISTER_PASS1(MarkDevice);
 }  // namespace ir
 }  // namespace tvm

--- a/src/pass/detect_device.cc
+++ b/src/pass/detect_device.cc
@@ -1,0 +1,30 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file detect_device.cc
+ */
+
+#include <tvm/ir_pass.h>
+#include <tvm/ir_mutator.h>
+#include "../pass/ir_util.h"
+
+namespace tvm {
+namespace ir {
+
+class DetectDevice : public IRMutator {
+ public:
+  DetectDevice() {}
+  Stmt Detect(Stmt stmt) {
+    Stmt body = AttrStmt::make(make_zero(Int(32)),
+                               ir::attr::pragma_scope_prefix,
+                               StringImm::make("device"),
+                               stmt);
+    return body;
+  }
+};
+
+Stmt DeviceMark(Stmt stmt) {
+  return DetectDevice().Detect(stmt);
+}
+
+}  // namespace ir
+}  // namespace tvm

--- a/src/pass/detect_device.cc
+++ b/src/pass/detect_device.cc
@@ -9,21 +9,12 @@
 
 namespace tvm {
 namespace ir {
-
-class DetectDevice : public IRMutator {
- public:
-  DetectDevice() {}
-  Stmt Detect(Stmt stmt) {
-    Stmt body = AttrStmt::make(make_zero(Int(32)),
-                               ir::attr::device_scope,
-                               0,
-                               stmt);
-    return body;
-  }
-};
-
-Stmt MarkDevice(Stmt stmt) {
-  return DetectDevice().Detect(stmt);
+Stmt DecorateDeviceScope(Stmt stmt) {
+  Stmt body = AttrStmt::make(make_zero(Int(32)),
+                             ir::attr::device_scope,
+                             0,
+                             stmt);
+  return body;
 }
 
 }  // namespace ir

--- a/src/pass/detect_device.cc
+++ b/src/pass/detect_device.cc
@@ -15,14 +15,14 @@ class DetectDevice : public IRMutator {
   DetectDevice() {}
   Stmt Detect(Stmt stmt) {
     Stmt body = AttrStmt::make(make_zero(Int(32)),
-                               ir::attr::pragma_scope_prefix,
-                               StringImm::make("device"),
+                               ir::attr::device_scope,
+                               0,
                                stmt);
     return body;
   }
 };
 
-Stmt DeviceMark(Stmt stmt) {
+Stmt MarkDevice(Stmt stmt) {
   return DetectDevice().Detect(stmt);
 }
 

--- a/src/pass/split_host_device.cc
+++ b/src/pass/split_host_device.cc
@@ -153,7 +153,9 @@ class HostDeviceSplitter : public IRMutator {
 
   Stmt Mutate_(const AttrStmt *op, const Stmt& s) final {
     if (op->attr_key == attr::thread_extent ||
-        op->attr_key == attr::pipeline_exec_scope) {
+        op->attr_key == attr::pipeline_exec_scope ||
+        (op->attr_key == attr::pragma_scope_prefix &&
+        op->value.as<StringImm>()->value == "device")) {
       return SplitDeviceFunc(s);
     }
     return IRMutator::Mutate_(op, s);

--- a/src/pass/split_host_device.cc
+++ b/src/pass/split_host_device.cc
@@ -154,8 +154,7 @@ class HostDeviceSplitter : public IRMutator {
   Stmt Mutate_(const AttrStmt *op, const Stmt& s) final {
     if (op->attr_key == attr::thread_extent ||
         op->attr_key == attr::pipeline_exec_scope ||
-        (op->attr_key == attr::pragma_scope_prefix &&
-        op->value.as<StringImm>()->value == "device")) {
+        op->attr_key == attr::device_scope) {
       return SplitDeviceFunc(s);
     }
     return IRMutator::Mutate_(op, s);

--- a/tests/python/unittest/test_pass_decorate_device_scope.py
+++ b/tests/python/unittest/test_pass_decorate_device_scope.py
@@ -1,6 +1,6 @@
 import tvm
 
-def test_detect_device():
+def test_decorate_device():
     m = tvm.var('m')
     l = tvm.var('l')
     A = tvm.placeholder((m, l), name='A')
@@ -16,11 +16,11 @@ def test_detect_device():
     bounds = tvm.schedule.InferBound(s)
     stmt = tvm.schedule.ScheduleOps(s, bounds)
     stmt1 = tvm.ir_pass.Simplify(stmt)
-    stmt2 = tvm.ir_pass.MarkDevice(stmt1)
+    stmt2 = tvm.ir_pass.DecorateDeviceScope(stmt1)
     assert isinstance(stmt2, tvm.stmt.AttrStmt)
     assert stmt2.attr_key == "device_scope"
     assert stmt1 == stmt2.body
-
+    
 if __name__ == "__main__":
-    test_detect_device()
+    test_decorate_device()
 

--- a/tests/python/unittest/test_pass_detect_device.py
+++ b/tests/python/unittest/test_pass_detect_device.py
@@ -15,8 +15,11 @@ def test_detect_device():
 
     bounds = tvm.schedule.InferBound(s)
     stmt = tvm.schedule.ScheduleOps(s, bounds)
-    stmt = tvm.ir_pass.DeviceMark(stmt)
-    print stmt
+    stmt1 = tvm.ir_pass.Simplify(stmt)
+    stmt2 = tvm.ir_pass.DeviceMark(stmt1)
+    assert isinstance(stmt2, tvm.stmt.AttrStmt)
+    assert stmt2.attr_key == "pragma_"
+    assert stmt1 == stmt2.body
 
 if __name__ == "__main__":
     test_detect_device()

--- a/tests/python/unittest/test_pass_detect_device.py
+++ b/tests/python/unittest/test_pass_detect_device.py
@@ -16,9 +16,9 @@ def test_detect_device():
     bounds = tvm.schedule.InferBound(s)
     stmt = tvm.schedule.ScheduleOps(s, bounds)
     stmt1 = tvm.ir_pass.Simplify(stmt)
-    stmt2 = tvm.ir_pass.DeviceMark(stmt1)
+    stmt2 = tvm.ir_pass.MarkDevice(stmt1)
     assert isinstance(stmt2, tvm.stmt.AttrStmt)
-    assert stmt2.attr_key == "pragma_"
+    assert stmt2.attr_key == "device_scope"
     assert stmt1 == stmt2.body
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_pass_detect_device.py
+++ b/tests/python/unittest/test_pass_detect_device.py
@@ -1,0 +1,23 @@
+import tvm
+
+def test_detect_device():
+    m = tvm.var('m')
+    l = tvm.var('l')
+    A = tvm.placeholder((m, l), name='A')
+
+    A1 = tvm.compute((m, l), lambda i, j: A[i, j], name='A1')
+    A2 = tvm.compute((m, l), lambda i, j: A1[i, j] + 3, name='A2')
+
+    s = tvm.create_schedule(A2.op)
+    xo, xi = s[A2].split(A2.op.axis[0], factor=8)
+    s[A1].compute_at(s[A2], xo)
+    s[A1].set_scope("shared")
+
+    bounds = tvm.schedule.InferBound(s)
+    stmt = tvm.schedule.ScheduleOps(s, bounds)
+    stmt = tvm.ir_pass.DeviceMark(stmt)
+    print stmt
+
+if __name__ == "__main__":
+    test_detect_device()
+


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).

For accelerators, host device splitting is different from gpu, as discussed here, 
https://discuss.tvm.ai/t/split-we-want-to-split-the-host-and-device-code-flexibly/932

this is a solution we are using for DaVinci core, and can use for other accelerators.

@tqchen @yzhliu @tmoreau89 @ZihengJiang please review, thanks!