### PR TITLE
[Frontend][MXNet] Change mxnet graph traversal from recursion to iteration

### DIFF
--- a/nnvm/python/nnvm/frontend/mxnet.py
+++ b/nnvm/python/nnvm/frontend/mxnet.py
@@ -454,6 +454,7 @@ def _from_mxnet_impl(symbol, graph):
         output_index = json.loads(symbol.tojson())['heads'][0][1]
         return graph[name][output_index]
 
+    assert symbol is not None
     # Traverse all symbols in topological order
     for sym in _topo_sort(symbol):
         name = sym.attr('name')
@@ -469,7 +470,14 @@ def _from_mxnet_impl(symbol, graph):
         else:
             node = _sym.Variable(name=name, **attr)
         graph[name] = node
-    return [get_node(sym) for sym in symbol]
+    nodes = []
+    for sym in symbol:
+        node = get_node(sym)
+        assert node is not None
+        nodes.append(node)
+    if len(nodes) > 1:
+        return _sym.Group(nodes)
+    return nodes[0]
 
 def from_mxnet(symbol, arg_params=None, aux_params=None):
     """Convert from MXNet's model into compatible NNVM format.

--- a/nnvm/python/nnvm/frontend/mxnet.py
+++ b/nnvm/python/nnvm/frontend/mxnet.py
@@ -407,7 +407,7 @@ def _topo_sort(symbol):
         if childs is None:
             dep_cnts[name] = 0
         else:
-            dep_cnts[name] = len(childs)
+            dep_cnts[name] = len(set([c.attr('name') for c in childs]))
             for child in childs:
                 child_name = child.attr('name')
                 if child_name not in deps:
@@ -451,7 +451,7 @@ def _from_mxnet_impl(symbol, graph):
         name = sym.attr('name')
         if name not in graph:
             return None
-        output_index = json.loads(symbol.tojson())['heads'][0][1]
+        output_index = json.loads(sym.tojson())['heads'][0][1]
         return graph[name][output_index]
 
     assert symbol is not None


### PR DESCRIPTION
Previous _from_mxnet_impl uses recursion to traverse graph. It causes call stack overflow when there're too many symbols in the graph. Now create symbols using topological order.