### PR TITLE
[DOCKER] temporary revert cuda version to cuda8

### DIFF
--- a/docker/Dockerfile.ci_gpu
+++ b/docker/Dockerfile.ci_gpu
@@ -1,5 +1,5 @@
 # CI docker GPU env
-FROM nvidia/cuda:9.0-cudnn7-devel
+FROM nvidia/cuda:8.0-cudnn7-devel
 
 # Base scripts
 RUN apt-get update --fix-missing
@@ -61,9 +61,6 @@ RUN pip3 install Pillow
 
 COPY install/ubuntu_install_vulkan.sh /install/ubuntu_install_vulkan.sh
 RUN bash /install/ubuntu_install_vulkan.sh
-
-COPY install/ubuntu_install_tensorflow.sh /install/ubuntu_install_tensorflow.sh
-RUN bash /install/ubuntu_install_tensorflow.sh
 
 # AutoTVM deps
 COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh


### PR DESCRIPTION
cc @srkreddy1238 mainly due to the reason that we are still using legacy g2 machine which don't have cuda9 support yet