### PR TITLE
[PASS]unroll loops with extent=1

### DIFF
--- a/src/pass/unroll_loop.cc
+++ b/src/pass/unroll_loop.cc
@@ -76,7 +76,9 @@ class LoopUnroller : public IRMutator {
       normal_loop_depth_ += 1;
     }
 
-    if (auto_unroll && explicit_unroll_) {
+    if ((auto_unroll && explicit_unroll_) ||
+        // unroll loops with extent = 1, no matter how many steps in body
+        (value <= auto_max_extent_ && auto_max_extent_ == 1)) {
       return Unroll(op);
     } else {
       if (auto_unroll) {


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).

I tried to set unroll flags to unroll loops with extent = 1, failed, we should always unroll loops with extent=1 if flag is set. This PR fix it.

@tqchen @kevinthesun @yzhliu please review, thanks.