### PR TITLE
[RUNTIME][OPENCL] Create command queue for each module

### DIFF
--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -129,7 +129,7 @@ void OpenCLWorkspace::CopyDataFromTo(const void* from,
     // wait on the last kernel event to complete.
     OpenCLBuffer *buf = static_cast<OpenCLBuffer*>((void*)from);  // NOLINT(*)
     if (buf->last_kernel_event) {
-      nr_events++;
+      nr_events = 1;
       pevent = &buf->last_kernel_event;
     }
   }


### PR DESCRIPTION
This PR creates a command queue for each module and uses it for kernel execution.  The change improves performance when we run multiple modules concurrently.

The below is an experimental result (platform: OpenCL 1.2 CUDA 8.0.0, GPU: GeForce GTX TITAN X).
- before
  ```
  $ python apps/benchmark/gpu_imagenet_bench.py --target opencl --network resnet-18 --thread 4
  --------------------------------------------------
  Network Name         Mean Inference Time (std dev)
  --------------------------------------------------
  resnet-18            15.75 ms            (9.50 ms)
  resnet-18            15.71 ms            (9.59 ms)
  resnet-18            15.90 ms            (9.37 ms)
  resnet-18            15.78 ms            (9.40 ms)
  ```
- after
  ```
  $ python apps/benchmark/gpu_imagenet_bench.py --target opencl --network resnet-18 --thread 4
  --------------------------------------------------
  Network Name         Mean Inference Time (std dev)
  --------------------------------------------------
  resnet-18            9.76 ms             (10.56 ms)
  resnet-18            9.85 ms             (11.22 ms)
  resnet-18            9.88 ms             (11.86 ms)
  resnet-18            9.74 ms             (11.92 ms)
  ```

@tqchen @nishi-t  Can you please review?