### PR TITLE
[VTA] Improved RPC for VTA

### DIFF
--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -100,9 +100,9 @@ def main():
     parser.add_argument('--host', type=str, default="0.0.0.0",
                         help='the hostname of the server')
     parser.add_argument('--port', type=int, default=9091,
-                        help='The port of the PRC')
+                        help='The port of the RPC')
     parser.add_argument('--port-end', type=int, default=9199,
-                        help='The end search port of the PRC')
+                        help='The end search port of the RPC')
     parser.add_argument('--key', type=str, default="",
                         help="RPC key used to identify the connection type.")
     parser.add_argument('--tracker', type=str, default="",

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -87,8 +87,8 @@ def server_start():
         ldflags = pkg.ldflags
         lib_name = dll_path
         source = pkg.lib_source
-        logging.info("Rebuild runtime: output=%s, cflags=%s, source=%s, ldflags=%s",
-                     dll_path, str(cflags), str(source), str(ldflags))
+        logging.info("Rebuild runtime:\n output=%s,\n cflags=%s,\n source=%s,\n ldflags=%s",
+                     dll_path, '\n\t'.join(cflags), '\n\t'.join(source), '\n\t'.join(ldflags))
         cc.create_shared(lib_name, source, cflags + ldflags)
         with open(cfg_path, "w") as outputfile:
             outputfile.write(pkg.cfg_json)

--- a/vta/python/vta/exec/rpc_server.py
+++ b/vta/python/vta/exec/rpc_server.py
@@ -99,7 +99,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', type=str, default="0.0.0.0",
                         help='the hostname of the server')
-    parser.add_argument('--port', type=int, default=9090,
+    parser.add_argument('--port', type=int, default=9091,
                         help='The port of the PRC')
     parser.add_argument('--port-end', type=int, default=9199,
                         help='The end search port of the PRC')

--- a/vta/python/vta/libinfo.py
+++ b/vta/python/vta/libinfo.py
@@ -15,11 +15,13 @@ def find_libvta(optional=False):
     """Find VTA library"""
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
     lib_search = [curr_path]
+    lib_search += [os.path.join(curr_path, "..", "..", "..", "lib",)]
     lib_search += [os.path.join(curr_path, "..", "..", "..", "build",)]
     lib_search += [os.path.join(curr_path, "..", "..", "..", "build", "Release")]
     lib_name = _get_lib_name()
     lib_path = [os.path.join(x, lib_name) for x in lib_search]
     lib_found = [x for x in lib_path if os.path.exists(x)]
     if not lib_found and not optional:
-        raise RuntimeError("Cannot find libvta: candidates are: " % str(lib_path))
+        raise RuntimeError('Cannot find the files.\n' +
+                           'List of candidates:\n' + str('\n'.join(lib_path)))
     return lib_found


### PR DESCRIPTION
### Changes

* assign default RPC port to 9091, which is used in the client and described in the document
* bug fix in printing RuntimeError and add an additional search path for `libvta.so`
* pretty print rebuild runtime arguments
* PRC => RPC

@tmoreau89 would you please review this PR?