### PR TITLE
[Cleanliness] [Easy] Make TVM leak-sanitizer and Wnon-virtual-dtor clean.

### DIFF
--- a/src/codegen/codegen_source_base.h
+++ b/src/codegen/codegen_source_base.h
@@ -23,6 +23,7 @@ namespace codegen {
  */
 class CodeGenSourceBase {
  public:
+  virtual ~CodeGenSourceBase() = default;
   /*!
    * \brief Register constant value appeared in expresion tree
    *  This avoid generated a ssa id for each appearance of the value

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -160,10 +160,10 @@ runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
   config << "-mtriple=amdgcn-amd-amdhsa-hcc -mcpu=gfx"
          << DetectROCMComputeVersion(target)
          << target.substr(4, target.length() - 4);
-  llvm::TargetMachine* tm = GetLLVMTargetMachine(config.str());
+  std::unique_ptr<llvm::TargetMachine> tm = GetLLVMTargetMachine(config.str());
   std::unique_ptr<CodeGenAMDGPU> cg(new CodeGenAMDGPU());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
-  cg->Init(funcs[0]->name, tm, ctx.get(), false, false);
+  cg->Init(funcs[0]->name, tm.get(), ctx.get(), false, false);
   for (LoweredFunc f :  funcs) {
     cg->AddFunction(f);
   }

--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -171,10 +171,10 @@ runtime::Module BuildNVPTX(Array<LoweredFunc> funcs, std::string target) {
   config << "-mtriple=nvptx64-nvidia-cuda -mcpu=sm_"
          << compute_ver
          << target.substr(5, target.length() - 5);
-  llvm::TargetMachine* tm = GetLLVMTargetMachine(config.str());
+  std::unique_ptr<llvm::TargetMachine> tm = GetLLVMTargetMachine(config.str());
   std::unique_ptr<CodeGenNVPTX> cg(new CodeGenNVPTX());
   std::unique_ptr<llvm::LLVMContext> ctx(new llvm::LLVMContext());
-  cg->Init(funcs[0]->name, tm, ctx.get(), false, false);
+  cg->Init(funcs[0]->name, tm.get(), ctx.get(), false, false);
   for (LoweredFunc f :  funcs) {
     cg->AddFunction(f);
   }

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -114,7 +114,7 @@ void ParseLLVMTargetOptions(const std::string& target_str,
 }
 
 
-llvm::TargetMachine*
+std::unique_ptr<llvm::TargetMachine>
 GetLLVMTargetMachine(const std::string& target_str,
                      bool allow_null) {
   std::string target_triple, mcpu, mattr;
@@ -143,7 +143,7 @@ GetLLVMTargetMachine(const std::string& target_str,
   }
   llvm::TargetMachine* tm = target->createTargetMachine(
       target_triple, mcpu, mattr, opt, llvm::Reloc::PIC_);
-  return tm;
+  return std::unique_ptr<llvm::TargetMachine>(tm);
 }
 
 }  // namespace codegen

--- a/src/codegen/llvm/llvm_common.h
+++ b/src/codegen/llvm/llvm_common.h
@@ -78,7 +78,7 @@ void ParseLLVMTargetOptions(const std::string& target_str,
  * \param allow_null Whether allow null to be returned.
  * \return target machine
  */
-llvm::TargetMachine*
+std::unique_ptr<llvm::TargetMachine>
 GetLLVMTargetMachine(const std::string& target_str, bool allow_null = false);
 
 }  // namespace codegen

--- a/src/runtime/dsl_api.h
+++ b/src/runtime/dsl_api.h
@@ -16,6 +16,7 @@ namespace runtime {
  */
 class DSLAPI {
  public:
+  virtual ~DSLAPI() = default;
   virtual void NodeFree(NodeHandle handle) const = 0;
 
   virtual void NodeTypeKey2Index(const char* type_key,

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -34,8 +34,11 @@ struct Registry::Manager {
   }
 
   static Manager* Global() {
-    static Manager inst;
-    return &inst;
+    // We deliberately leak the Manager instance, to avoid leak sanitizers
+    // complaining about the entries in Manager::fmap being leaked at program
+    // exit.
+    static Manager* inst = new Manager();
+    return inst;
   }
 };
 


### PR DESCRIPTION
This is a minor set of commits to make TVM leak-sanitizer and Wnon-virtual-dtor clean. These are:

- Stop leaking the `llvm::TargetMachine` instance (`Target::createTargetMachine` returns a raw pointer with owning semantics, so the caller is responsible for free'ing it). Instead, it is now owned by the `LLVMModule` instance.
- Leak the `Manager::Global` singleton, instead of deleting it at program exit. This stops LSAN complaining about the leaked Registry* instances in `Manager::fmap`.
- Add virtual destructors to `runtime::DSLAPI` and `codegen::CodeGenSourceBase`, to avoid LLVM complaining when `-Wnon-virtual-dtor` is passed (I think this is a useful flag to enable in CI as well).

After these commits, TVM built with e.g. `-fsanitize=leak` raises no errors on `./tests/scripts/task_cpp_unittest.sh`.