### PR TITLE
[WIP][VTA] Add tensor-tile id pass

### DIFF
--- a/vta/include/vta/hw_spec.h
+++ b/vta/include/vta/hw_spec.h
@@ -133,6 +133,10 @@ extern "C" {
 #define VTA_ALUOP_IMM_BIT_WIDTH 16
 /*! GEMM/ALU Instruction: loop max iter bits */
 #define VTA_LOOP_ITER_WIDTH 14
+/*! VTA boundary tile width */
+#define VTA_BOUNDARY_TILE_BIT_WIDTH 2
+/*! VTA tensor_id width */
+#define VTA_TENSOR_ID_BIT_WIDTH 16
 
 /*! Mem ID constant: uop memory */
 #define VTA_MEM_ID_UOP 0
@@ -393,6 +397,10 @@ typedef struct {
   uint64_t x_pad_0        : VTA_MEMOP_PAD_BIT_WIDTH;
   /*! \brief 2D access pattern: end padding along x dimension */
   uint64_t x_pad_1        : VTA_MEMOP_PAD_BIT_WIDTH;
+  /*! \brief The global tensor id */
+  uint64_t tensor_id      : VTA_TENSOR_ID_BIT_WIDTH;
+  /*! \brief 1 if the tile is the first one, 2 if last, 0 o/w */
+  uint64_t boundary_tile  : VTA_BOUNDARY_TILE_BIT_WIDTH;
 } VTAMemInsn;
 
 /*! \brief VTA GEMM instruction

--- a/vta/include/vta/runtime.h
+++ b/vta/include/vta/runtime.h
@@ -133,7 +133,9 @@ void VTALoadBuffer2D(VTACommandHandle cmd,
                      uint32_t x_pad_after,
                      uint32_t y_pad_after,
                      uint32_t dst_sram_index,
-                     uint32_t dst_memory_type);
+                     uint32_t dst_memory_type,
+                     uint32_t tensor_id,
+                     uint32_t boundary_tile);
 
 /*!
  * \brief Perform a 2D data store into DRAM
@@ -154,7 +156,9 @@ void VTAStoreBuffer2D(VTACommandHandle cmd,
                       uint32_t dst_elem_offset,
                       uint32_t x_size,
                       uint32_t y_size,
-                      uint32_t x_stride);
+                      uint32_t x_stride,
+                      uint32_t tensor_id,
+                      uint32_t boundary_tile);
 
 /*!
  * \brief Push uop into kernel buffer.

--- a/vta/python/vta/build_module.py
+++ b/vta/python/vta/build_module.py
@@ -62,6 +62,7 @@ def build_config(debug_flag=0, **kwargs):
     if debug_flag:
         pass_list.append((1, add_debug))
     pass_list.append((2, ir_pass.inject_alu_intrin))
+    pass_list.append((2, ir_pass.register_tensors))
     pass_list.append((3, ir_pass.fold_uop_loop))
     pass_list.append((3, ir_pass.cpu_access_rewrite))
     return tvm.build_config(add_lower_pass=pass_list, **kwargs)

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -923,7 +923,9 @@ class CommandQueue {
                     uint32_t x_pad_after,
                     uint32_t y_pad_after,
                     uint32_t dst_sram_index,
-                    uint32_t dst_memory_type) {
+                    uint32_t dst_memory_type,
+                    uint32_t tensor_id,
+                    uint32_t boundary_tile) {
     VTAMemInsn* insn = insn_queue_.CreateMemInsn(dst_memory_type);
     insn->opcode = VTA_OPCODE_LOAD;
     insn->memory_type = dst_memory_type;
@@ -937,6 +939,8 @@ class CommandQueue {
     insn->y_pad_1 = y_pad_after;
     insn->x_pad_0 = x_pad_before;
     insn->x_pad_1 = x_pad_after;
+    insn->tensor_id = tensor_id;
+    insn->boundary_tile = boundary_tile;
     this->CheckInsnOverFlow();
   }
 
@@ -946,7 +950,9 @@ class CommandQueue {
                      uint32_t dst_elem_offset,
                      uint32_t x_size,
                      uint32_t y_size,
-                     uint32_t x_stride) {
+                     uint32_t x_stride,
+                     uint32_t tensor_id,
+                     uint32_t boundary_tile) {
     VTAMemInsn* insn = insn_queue_.CreateStoreInsn();
     insn->opcode = VTA_OPCODE_STORE;
     insn->memory_type = src_memory_type;
@@ -960,6 +966,8 @@ class CommandQueue {
     insn->y_pad_1 = 0;
     insn->x_pad_0 = 0;
     insn->x_pad_1 = 0;
+    insn->tensor_id = tensor_id;
+    insn->boundary_tile = boundary_tile;
     this->CheckInsnOverFlow();
   }
 
@@ -1287,13 +1295,16 @@ void VTALoadBuffer2D(VTACommandHandle cmd,
                      uint32_t x_pad_after,
                      uint32_t y_pad_after,
                      uint32_t dst_sram_index,
-                     uint32_t dst_memory_type) {
+                     uint32_t dst_memory_type,
+                     uint32_t tensor_id,
+                     uint32_t boundary_tile) {
   static_cast<vta::CommandQueue*>(cmd)->
       LoadBuffer2D(src_dram_addr, src_elem_offset,
                    x_size, y_size, x_stride,
                    x_pad_before, y_pad_before,
                    x_pad_after, y_pad_after,
-                   dst_sram_index, dst_memory_type);
+                   dst_sram_index, dst_memory_type,
+                   tensor_id, boundary_tile);
 }
 
 void VTAStoreBuffer2D(VTACommandHandle cmd,
@@ -1303,11 +1314,14 @@ void VTAStoreBuffer2D(VTACommandHandle cmd,
                       uint32_t dst_elem_offset,
                       uint32_t x_size,
                       uint32_t y_size,
-                      uint32_t x_stride) {
+                      uint32_t x_stride,
+                      uint32_t tensor_id,
+                      uint32_t boundary_tile) {
   static_cast<vta::CommandQueue*>(cmd)->
       StoreBuffer2D(src_sram_index, src_memory_type,
                     dst_dram_addr, dst_elem_offset,
-                    x_size, y_size, x_stride);
+                    x_size, y_size, x_stride,
+                    tensor_id, boundary_tile);
 }
 
 void VTAUopPush(uint32_t mode,


### PR DESCRIPTION
This PR adds a pass to VTA which extends the ISA to include tensor and tile identity info in DMA instructions.

In particular,
* each tensor in a scope has its own global id. a tensor accessed from independent scopes has a single id
* tiles are marked as being first or last

A caveat is that this pass will error in the rare chance that a tensor is written to in a scope where it's already being read or written. This is really only problematic for `scan`. The solution is to give each tile its own ID, but I haven't figured out how to make a test case for that yet.