### PR TITLE
Allow to use negative index of array in python

### DIFF
--- a/python/tvm/container.py
+++ b/python/tvm/container.py
@@ -24,7 +24,8 @@ class Array(NodeBase):
             return [self[idx] for idx in range(start, stop, step)]
 
         if i < -len(self) or i >= len(self):
-            raise IndexError("Array index out of range. Array size: {}, got index {}".format(len(self), i))
+            raise IndexError("Array index out of range. Array size: {}, got index {}"
+                             .format(len(self), i))
         if i < 0:
             i += len(self)
         return _api_internal._ArrayGetItem(self, i)

--- a/python/tvm/container.py
+++ b/python/tvm/container.py
@@ -23,10 +23,10 @@ class Array(NodeBase):
                 stop += len(self)
             return [self[idx] for idx in range(start, stop, step)]
 
+        if i < -len(self) or i >= len(self):
+            raise IndexError("Array index out of range. Array size: {}, got index {}".format(len(self), i))
         if i < 0:
             i += len(self)
-        if i < 0 or i >= len(self):
-            raise IndexError("array index out of range")
         return _api_internal._ArrayGetItem(self, i)
 
     def __len__(self):

--- a/python/tvm/container.py
+++ b/python/tvm/container.py
@@ -19,7 +19,9 @@ class Array(NodeBase):
             step = i.step if i.step is not None else 1
             return [self[idx] for idx in range(start, stop, step)]
 
-        if i >= len(self):
+        if i < 0:
+            i += len(self)
+        if i < 0 or i >= len(self):
             raise IndexError("array index out of range")
         return _api_internal._ArrayGetItem(self, i)
 

--- a/python/tvm/container.py
+++ b/python/tvm/container.py
@@ -17,6 +17,10 @@ class Array(NodeBase):
             start = i.start if i.start is not None else 0
             stop = i.stop if i.stop is not None else len(self)
             step = i.step if i.step is not None else 1
+            if start < 0:
+                start += len(self)
+            if stop < 0:
+                stop += len(self)
             return [self[idx] for idx in range(start, stop, step)]
 
         if i < 0:

--- a/tests/python/unittest/test_lang_container.py
+++ b/tests/python/unittest/test_lang_container.py
@@ -3,6 +3,7 @@ import tvm
 def test_array():
     a = tvm.convert([1,2,3])
     assert len(a) == 3
+    assert a[-1].value == 3
 
 def test_array_save_load_json():
     a = tvm.convert([1,2,3])

--- a/tests/python/unittest/test_lang_container.py
+++ b/tests/python/unittest/test_lang_container.py
@@ -4,6 +4,8 @@ def test_array():
     a = tvm.convert([1,2,3])
     assert len(a) == 3
     assert a[-1].value == 3
+    a_slice = a[-3:-1]
+    assert (a_slice[0].value, a_slice[1].value) == (1, 2)
 
 def test_array_save_load_json():
     a = tvm.convert([1,2,3])


### PR DESCRIPTION
Allow to use negative index like `arr[-1]` in python. This makes the usage of `Array` consistent with Python list/tuple
cc @tqchen 