### PR TITLE
Fix a crash in android_deploy demo.

### DIFF
--- a/apps/android_deploy/app/src/main/java/ml/dmlc/tvm/android/demo/MainActivity.java
+++ b/apps/android_deploy/app/src/main/java/ml/dmlc/tvm/android/demo/MainActivity.java
@@ -298,7 +298,7 @@ public class MainActivity extends AppCompatActivity {
 
                     // get the function from the module(get output data)
                     Log.i(TAG, "get output data");
-                    NDArray outputNdArray = NDArray.empty(new long[]{1000}, new TVMType("float32"));
+                    NDArray outputNdArray = NDArray.empty(new long[]{1, 1000}, new TVMType("float32"));
                     Function getOutputFunc = graphRuntimeModule.getFunction("get_output");
                     getOutputFunc.pushArg(OUTPUT_INDEX).pushArg(outputNdArray).invoke();
                     float[] output = outputNdArray.asFloatArray();


### PR DESCRIPTION
Fix a crash caused by array size mismatch:

graph_runtime.cc:119: Check failed: data->ndim == data_out->ndim (2 vs. 1) 