### PR TITLE
[OPENCL] Make use of cpu device when gpu device doesn't exist.

### DIFF
--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -245,6 +245,9 @@ void OpenCLWorkspace::Init(const std::string& type_key, const std::string& devic
       continue;
     }
     std::vector<cl_device_id> devices_matched = cl::GetDeviceIDs(platform_id, device_type);
+    if (devices_matched.size() == 0) {
+      devices_matched = cl::GetDeviceIDs(platform_id, "cpu");
+    }
     if (devices_matched.size() > 0) {
       this->type_key = type_key;
       this->platform_id = platform_id;

--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -245,7 +245,8 @@ void OpenCLWorkspace::Init(const std::string& type_key, const std::string& devic
       continue;
     }
     std::vector<cl_device_id> devices_matched = cl::GetDeviceIDs(platform_id, device_type);
-    if (devices_matched.size() == 0) {
+    if ((devices_matched.size() == 0) && (device_type == "gpu")) {
+      LOG(WARNING) << "Using CPU OpenCL device";
       devices_matched = cl::GetDeviceIDs(platform_id, "cpu");
     }
     if (devices_matched.size() > 0) {


### PR DESCRIPTION
XEON cpu doesn't have graphic core, but it can support OpenCL. We should be able to use it.