### PR TITLE
[NNPACK] Test NNPACK integration in continuous build.

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -35,4 +35,8 @@ RUN bash /install/ubuntu_install_redis.sh
 COPY install/ubuntu_install_golang.sh /install/ubuntu_install_golang.sh
 RUN bash /install/ubuntu_install_golang.sh
 
+# NNPACK deps
+COPY install/ubuntu_install_nnpack.sh /install/ubuntu_install_nnpack.sh
+RUN bash /install/ubuntu_install_nnpack.sh
+
 ENV PATH $PATH:$CARGO_HOME/bin:/usr/lib/go-1.10/bin

--- a/docker/install/ubuntu_install_nnpack.sh
+++ b/docker/install/ubuntu_install_nnpack.sh
@@ -1,0 +1,13 @@
+apt-get update && apt-get install -y --no-install-recommends --force-yes git cmake
+
+
+git clone https://github.com/Maratyszcza/NNPACK NNPACK
+cd NNPACK
+# TODO: specific tag?
+git checkout 1e005b0c2
+cd -
+
+mkdir -p NNPACK/build
+cd NNPACK/build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=. -DNNPACK_INFERENCE_ONLY=OFF -DNNPACK_CONVOLUTION_ONLY=OFF -DNNPACK_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && make -j4 && make install
+cd -


### PR DESCRIPTION
The previous integration ended up bitrotting, so this approach of adding NNPACK in the CI should be helpful. 

The code should be tested by the existing nosestests, but instead of silently skipping the NNPACK tests they should be executed.

This is my first time modifying the Docker/Jenkins aspects of this system, so I'm not really sure if this is the right approach.