### PR TITLE
[RELAY][OP] Fix doc of strided_slice

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -133,7 +133,7 @@ struct StridedSliceAttrs : public tvm::AttrsNode<StridedSliceAttrs> {
     TVM_ATTR_FIELD(begin)
         .describe("Indices for begin of slice, begin index is also inclusive");
     TVM_ATTR_FIELD(end)
-        .describe("Indices for end of slice, end index is also inclusive");
+        .describe("Indices for end of slice, end index is exclusive");
     TVM_ATTR_FIELD(strides).set_default(Array<Integer>({}))
         .describe("Stride values of the slice");
   }


### PR DESCRIPTION
According to the [topi computation](https://github.com/dmlc/tvm/blob/1b863732ddd91423b1083626c64fba0523204a70/topi/include/topi/transform.h#L471), I believe the end index should be exclusive.

cc @tqchen @siju-samuel 