### PR TITLE
[TVM] Fix GatherBound to avoid allocating too much

### DIFF
--- a/tests/python/unittest/test_schedule_bound_inference.py
+++ b/tests/python/unittest/test_schedule_bound_inference.py
@@ -259,6 +259,26 @@ def test_gemm_bound():
     assert(bounds[CC.op.axis[0]].extent.value == 8)
     assert(bounds[CC.op.axis[1]].extent.value == 8)
 
+def test_bound_simplification_failure():
+    # Check that the bounds are not expanded
+    A = tvm.compute((2,), lambda j: j, "A")
+
+    def _check(B, A=A):
+        s = tvm.create_schedule(B.op)
+        s = s.normalize()
+        bounds = tvm.schedule.InferBound(s)
+        stmt = tvm.lower(s, [B, A], simple_mode=True)
+        if not bounds[A.op.axis[0]].extent.value <= 2:
+            print(stmt)
+            assert bounds[A.op.axis[0]].extent.value <= 2
+
+    # These are hard to simplify, moreover we don't simplify them
+    _check(tvm.compute((10,), lambda i: A[tvm.min(3*i, 4*i) + tvm.min(-3*i, -2*i)]))
+    _check(tvm.compute((10,), lambda i: A[tvm.min(3*i, 4*i) + tvm.max(-3*i, -4*i)]))
+    _check(tvm.compute((10,), lambda i: A[-2*(i/2) - tvm.min(i, 0-i)]))
+    _check(tvm.compute((10,), lambda i: A[i + (0 - i)]))
+    # This would cause out of bounds, but we nevertheless include it
+    _check(tvm.compute((10,), lambda i: A[i]))
 
 if __name__ == "__main__":
     test_bound_nest_thread()
@@ -273,3 +293,4 @@ if __name__ == "__main__":
     test_bound2()
     test_gemm_bound()
     test_bound_warp()
+    test_bound_simplification_failure()

--- a/tests/python/unittest/test_schedule_schedule_ops.py
+++ b/tests/python/unittest/test_schedule_schedule_ops.py
@@ -264,19 +264,6 @@ def test_schedule_cache_relayout4():
     stmt = tvm.schedule.ScheduleOps(s, bounds)
 
 
-def test_schedule_bound_condition():
-   A = tvm.placeholder((64,), name='A', dtype="float32")
-   Apad = tvm.compute((66,), lambda i: tvm.select(tvm.all(i>0, i < 65), A[i-1], tvm.const(0.)), name='Apad')
-   Apad2 = tvm.compute((66,), lambda i: Apad[i]*2, name='Apad2')
-   s = tvm.create_schedule(Apad2.op)
-   AL1 = s.cache_read(A,"local",[Apad])
-   s = s.normalize()
-   bounds = tvm.schedule.InferBound(s)
-   stmt = tvm.schedule.ScheduleOps(s, bounds)
-   stmt = tvm.ir_pass.Simplify(stmt)
-   assert (isinstance(stmt.body.body.first.body.body.then_case, tvm.stmt.IfThenElse))
-
-
 def intrin_gemv(m, n):
     w = tvm.placeholder((m, n), name='w')
     x = tvm.placeholder((n,), name='x')
@@ -420,7 +407,6 @@ if __name__ == "__main__":
     test_schedule1()
     test_schedule2()
     test_schedule_cache()
-    test_schedule_bound_condition()
     test_schedule_tensor_compute1()
     test_schedule_tensor_compute2()
     test_schedule_tensor_compute3()


### PR DESCRIPTION
This is a fix for the problem mentioned [here on the forum](https://discuss.tvm.ai/t/strange-expansion-of-tensors-bounds/1077).

During compilation TVM sometimes reshapes tensors using the information from its uses. This is a very important feature because sometimes a schedule may introduce a new tensor (e.g. via `cache_write`), but use only a handful of elements out of it, in which case this transformation may reduce the tensor's size and remove unnecessary computations of unused elements. However, the same transformation sometimes expands tensor sizes. This happens because computing precise ranges for expressions is impossible in general, and often leads to overapproximation. In the example from the forum the expression is `i + (0 - i)`, for which the range is evaluated to be [-9; 9] because the range evaluation algorithm assumes that subexpressions `i` and `-i` are independent. Of course, this particular example may be simplified but it is always possible to construct an example that the simplifier won't be able to simplify.

The solution I propose is to compare the range computed from the uses and the original range from the tensor declaration, and use the smaller one. There are several concerns though:
- I am not sure if the are any passes or schedules that rely on tensor expansion. If there are, this may lead to out-of-bounds errors.
- Sometimes we cannot compare the ranges. It happens when there are variables involved. In this case I decided to fallback to the old behavior because otherwise the test `test_bound_nest_thread` from `test_schedule_bound_inference.py` fails (it uses a global variable `m` as a tensor size).
- The test `test_bound_nest_thread` may also be caused to fail by fixing `m` to be any integer less than 32. The failure is due to additional checks at `message_passing.cc:36` and `schedule_ops.cc:184`, and I'm not sure if they are really necessary.
- The test `test_schedule_bound_condition` fails because with this fix it cannot reproduce the original problem anymore (#1014). I removed it for now.


(Also I considered another solution, namely intersect the two ranges. In theory this should be perfect, but in practice it results in too complex expressions, which eventually lead to messages like this:
`loop_partition.cc:356: Cannot prove: ((((((1 + min((c.outer.h.fused/112), 7)) - max((c.outer.h.fused/112), 0)) - 1) - (8 - max((c.outer.h.fused/112), 0))) + 1) >= 0), when generating the post doubt loop`
and also to errors like this:
`TVMError: [17:49:02] split_host_device.cc:116: Check failed: !use_count_.count(v) variable c.outer.h.fused has been used before definition!`.
The reason is that some local variables leak into tensor bounds which are then used to generate certain conditions.)

@tqchen Could you please provide some comments regarding this issue?