### PR TITLE
[TOPI] Improve performance for dilated convolution

### DIFF
--- a/topi/python/topi/mali/conv2d.py
+++ b/topi/python/topi/mali/conv2d.py
@@ -118,7 +118,10 @@ def _schedule_spatial_pack(cfg, s, output, conv, data_vec, kernel_vec):
         s[data_pad].compute_inline()
 
     # schedule data packing
-    _, h, w, ci, vh, vw = s[data_vec].op.axis
+    if isinstance(data_vec.op, tvm.tensor.ComputeOp) and data_vec.op.name == 'data_vec_undilated':
+        _, h, w, ci, _, _, vh, vw = s[data_vec].op.axis
+    else:
+        _, h, w, ci, vh, vw = s[data_vec].op.axis
     tile_and_bind3d(s, data_vec, h, w, ci, 1)
     if vh.dom.extent.value < max_unroll:
         s[data_vec].unroll(vh)


### PR DESCRIPTION
#1887 
Eliminates unnecessary zero multiplications introduced by dilated kernel.
As discussed in issue 1887, there is still one more perf issue left: cache_read only supports continuous range, so in dilated conv cases, it will lead to extra memory loading which is not necessary for computation. But after profiling, I found this is not quite a bottleneck compared with zero multiplication issue, and workaround this limitation will make code more complicate, so it's not included in this PR.

@merrymercy please help review, thanks!