### PR TITLE
[X86] [NNVM] [TOPI] Implement NCHWc Winograd convolutions

### DIFF
--- a/nnvm/include/nnvm/top/nn.h
+++ b/nnvm/include/nnvm/top/nn.h
@@ -174,10 +174,18 @@ struct Conv2DParam : public dmlc::Parameter<Conv2DParam> {
 
 struct WinogradWeightTransformParam : public dmlc::Parameter<WinogradWeightTransformParam> {
     int tile_size;
-
+    std::string kernel_layout;
     DMLC_DECLARE_PARAMETER(WinogradWeightTransformParam) {
-      DMLC_DECLARE_FIELD(tile_size)
-        .describe("Tile size of winograd. E.g. 2 for F(2x2, 3x3) and 4 for F(4x4, 3x3)");
+      DMLC_DECLARE_FIELD(tile_size).describe("Tile size of winograd. E.g. 2 "
+                                             "for F(2x2, 3x3) and 4 for F(4x4, "
+                                             "3x3)");
+      DMLC_DECLARE_FIELD(kernel_layout)
+          .set_default("OIHW")
+          .describe(
+              "Dimension ordering of weight. Can be 'OIHW', 'OIHW16o16i', etc."
+              "'O', 'I', 'H', 'W' stands for num_filter, input_channel, "
+              "height, and width"
+              "dimensions respectively.");
     }
 
     static const constexpr int kWeight = 0;

--- a/nnvm/python/nnvm/top/nn.py
+++ b/nnvm/python/nnvm/top/nn.py
@@ -204,6 +204,54 @@ def schedule_contrib_conv2d_NCHWc(attrs, outs, target):
 
 reg.register_pattern("_contrib_conv2d_NCHWc", OpPattern.OUT_ELEMWISE_FUSABLE)
 
+@reg.register_compute("_contrib_conv2d_NCHWc_winograd_weight_transform")
+def compute_contrib_conv2d_NCHWc_winograd_weight_transform(attrs, inputs, _):
+    return topi.nn.conv2d_NCHWc_winograd_weight_transform(
+        inputs[0], attrs.get_int('tile_size'), attrs.get_string("kernel_layout"))
+
+@reg.register_schedule("_contrib_conv2d_NCHWc_winograd_weight_transform")
+def schedule_contrib_conv2d_NCHWc_winograd_weight_transform(attrs, outs, target):
+    with tvm.target.create(target):
+        return topi.generic.schedule_conv2d_NCHWc_winograd_weight_transform(outs)
+
+reg.register_pattern(
+    "_contrib_conv2d_NCHWc_winograd_weight_transform",
+    OpPattern.OUT_ELEMWISE_FUSABLE
+)
+
+@reg.register_compute("_contrib_conv2d_NCHWc_winograd_without_weight_transform")
+def compute_contrib_conv2d_NCHWc_winograd_without_weight_transform(attrs, inputs, _):
+    """Compute definition of conv2d NCHWc"""
+    padding = attrs.get_int_tuple("padding")
+    strides = attrs.get_int_tuple("strides")
+    dilation = attrs.get_int_tuple("dilation")
+    groups = attrs.get_int("groups")
+    layout = attrs.get_string("layout")
+    out_layout = attrs.get_string("out_layout")
+    out_dtype = attrs.get_string("out_dtype")
+    tile_size = attrs.get_int("tile_size")
+    out_dtype = inputs[0].dtype if out_dtype == "same" else out_dtype
+    assert dilation == (1, 1), "Do not support dilate now"
+    assert groups == 1, "Do not supoort arbitrary group number"
+
+    # pylint: disable=assignment-from-no-return
+    out = topi.nn.conv2d_NCHWc_winograd_without_weight_transform(
+        inputs[0], inputs[1], strides, padding, dilation, layout, out_layout,
+        out_dtype, tile_size)
+
+    if attrs.get_bool("use_bias"):
+        bias = inputs[2]
+        bias = topi.expand_dims(bias, axis=1, num_newaxis=2)
+        out = topi.add(out, bias)
+    return out
+
+@reg.register_schedule("_contrib_conv2d_NCHWc_winograd_without_weight_transform")
+def schedule_contrib_conv2d_NCHWc_winograd_without_weight_transform(attrs, outs, target):
+    with tvm.target.create(target):
+        return topi.generic.schedule_conv2d_NCHWc_winograd_without_weight_transform(outs)
+
+reg.register_pattern("_contrib_conv2d_NCHWc_winograd_without_weight_transform",
+                     OpPattern.OUT_ELEMWISE_FUSABLE)
 
 @reg.register_compute("_contrib_conv2d_winograd_weight_transform")
 def compute_contrib_conv2d_winograd_weight_transform(attrs, inputs, _):

--- a/topi/python/topi/arm_cpu/conv2d.py
+++ b/topi/python/topi/arm_cpu/conv2d.py
@@ -4,14 +4,13 @@ from __future__ import absolute_import as _abs
 
 import warnings
 
-import numpy as np
-
 import tvm
 from tvm import autotvm
 
 from ..generic import schedule_conv2d_nchw, schedule_conv2d_winograd_without_weight_transform
-from ..util import traverse_inline, get_const_tuple, const_matrix
+from ..util import traverse_inline, get_const_tuple
 from ..nn import dilate, pad, conv2d, conv2d_alter_layout, conv2d_winograd_without_weight_transform
+from ..nn.winograd_util import winograd_transform_matrices
 from ..nn.util import get_const_int, get_pad_tuple
 
 @autotvm.register_topi_compute(conv2d, 'arm_cpu', ['direct'])
@@ -304,53 +303,8 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
     assert layout == 'NCHW'
     assert KH == 3 and KW == 3 and HPAD == 1 and WPAD == 1 and HSTR == 1 and WSTR == 1
     data_pad = pad(data, (0, 0, HPAD, WPAD), name="data_pad")
-
-    if tile_size == 4:
-        G_data = np.array([
-            [1 / 4.0, 0, 0],
-            [-1 / 6.0, -1 / 6.0, -1 / 6.0],
-            [-1 / 6.0, 1 / 6.0, -1 / 6.0],
-            [1 / 24.0, 1 / 12.0, 1 / 6.0],
-            [1 / 24.0, -1 / 12.0, 1 / 6.0],
-            [0, 0, 1]], dtype=np.float32)
-
-        B_data = np.array([
-            [4, 0, 0, 0, 0, 0],
-            [0, -4, 4, -2, 2, 4],
-            [-5, -4, -4, -1, -1, 0],
-            [0, 1, -1, 2, -2, -5],
-            [1, 1, 1, 1, 1, 0],
-            [0, 0, 0, 0, 0, 1]], out_dtype)
-
-        A_data = np.array([
-            [1, 0, 0, 0],
-            [1, 1, 1, 1],
-            [1, -1, 1, -1],
-            [1, 2, 4, 8],
-            [1, -2, 4, -8],
-            [0, 0, 0, 1]], out_dtype)
-    elif tile_size == 2:
-        G_data = np.array([
-            [1, 0, 0],
-            [1.0/2, 1.0/2, 1.0/2],
-            [1.0/2, -1.0/2, 1.0/2],
-            [0, 0, 1]], np.float32)
-
-        B_data = np.array([
-            [1, 0, 0, 0],
-            [0, 1, -1, 1],
-            [-1, 1, 1, 0],
-            [0, 0, 0, -1]], out_dtype)
-
-        A_data = np.array([
-            [1, 0],
-            [1, 1],
-            [1, -1],
-            [0, -1]], out_dtype)
-    else:
-        raise ValueError("Unsupported tile size for winograd: " + str(tile_size))
-
-    m = A_data.shape[1]
+    A, B, G = winograd_transform_matrices(tile_size, out_dtype)
+    m = tile_size
     r = 3
     alpha = m + r - 1
     K = CO
@@ -377,7 +331,6 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
     if pre_computed:
         U = kernel
     else:
-        G = const_matrix(G_data, 'G')
         r_kh = tvm.reduce_axis((0, KH), 'r_kh')
         r_kw = tvm.reduce_axis((0, KW), 'r_kw')
         U = tvm.compute((alpha, alpha, K // VK, C, VK), lambda eps, nu, k, c, kk:
@@ -385,7 +338,6 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
                                 G[eps][r_kh] * G[nu][r_kw], axis=[r_kh, r_kw]), name='U')
 
     # transform image
-    B = const_matrix(B_data, 'B')
     r_eps = tvm.reduce_axis((0, alpha), 'r_eps')
     r_nu = tvm.reduce_axis((0, alpha), 'r_nu')
     V = tvm.compute((alpha, alpha, P // VP, C, VP), lambda eps, nu, b, c, bb:
@@ -399,7 +351,6 @@ def _decl_winograd(cfg, data, kernel, strides, padding, dilation, layout, out_dt
                             V[eps][nu][b // VP][c][b % VP], axis=c), name='M')
 
     # inverse transform
-    A = const_matrix(A_data, 'A')
     r_eps = tvm.reduce_axis((0, alpha), 'r_eps')
     r_nu = tvm.reduce_axis((0, alpha), 'r_nu')
     Y = tvm.compute((K, P, m, m), lambda k, b, vh, vw:

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -120,6 +120,15 @@ def schedule_conv2d_winograd_without_weight_transform(outs):
     """
     return _default_schedule(outs, False)
 
+@tvm.target.generic_func
+def schedule_conv2d_NCHWc_winograd_weight_transform(outs):
+    return _default_schedule(outs, False)
+
+
+@tvm.target.generic_func
+def schedule_conv2d_NCHWc_winograd_without_weight_transform(outs):
+    return _default_schedule(outs, False)
+
 
 @tvm.target.generic_func
 def schedule_conv2d_transpose_nchw(outs):

--- a/topi/python/topi/nn/winograd_util.py
+++ b/topi/python/topi/nn/winograd_util.py
@@ -1,0 +1,122 @@
+"""Utility functions for implementing Winograd convolutions"""
+import numpy as np
+from ..util import const_matrix
+
+
+def winograd_transform_matrices(tile_size, out_dtype):
+    """Compute the A, B, and G transform matrices for
+    the tile size `m` as a `tvm.Expr`.
+    """
+
+    if tile_size not in (2, 4, 6):
+        raise ValueError("Unsupported tile size for Winograd: {}".format(
+            tile_size))
+    if tile_size == 4:
+        g_data = np.array(
+            [
+                [1 / 4.0, 0, 0],
+                [-1 / 6.0, -1 / 6.0, -1 / 6.0],
+                [-1 / 6.0, 1 / 6.0, -1 / 6.0],
+                [1 / 24.0, 1 / 12.0, 1 / 6.0],
+                [1 / 24.0, -1 / 12.0, 1 / 6.0],
+                [0, 0, 1],
+            ],
+            dtype=np.float32,
+        )
+
+        b_data = np.array(
+            [
+                [4, 0, 0, 0, 0, 0],
+                [0, -4, 4, -2, 2, 4],
+                [-5, -4, -4, -1, -1, 0],
+                [0, 1, -1, 2, -2, -5],
+                [1, 1, 1, 1, 1, 0],
+                [0, 0, 0, 0, 0, 1],
+            ],
+            dtype=out_dtype,
+        )
+
+        a_data = np.array(
+            [
+                [1, 0, 0, 0],
+                [1, 1, 1, 1],
+                [1, -1, 1, -1],
+                [1, 2, 4, 8],
+                [1, -2, 4, -8],
+                [0, 0, 0, 1],
+            ],
+            dtype=out_dtype,
+        )
+
+    elif tile_size == 6:
+        g_data = np.array(
+            [
+                [1, 0, 0],
+                [-2 / 9, -2 / 9, -2 / 9],
+                [-2 / 9, 2 / 9, -2 / 9],
+                [1 / 90, 1 / 45, 2 / 45],
+                [1 / 90, -1 / 45, 2 / 45],
+                [1 / 45, 1 / 90, 1 / 180],
+                [1 / 45, -1 / 90, 1 / 180],
+                [0, 0, 1],
+            ],
+            dtype=np.float32,
+        )
+
+        assert np.dtype(out_dtype) == np.float32, "Only support floats in F(6x6, 3x3)"
+        b_data = np.array(
+            [
+                [1, 0, -21 / 4, 0, 21 / 4, 0, -1, 0],
+                [0, 1, 1, -17 / 4, -17 / 4, 1, 1, 0],
+                [0, -1, 1, 17 / 4, -17 / 4, -1, 1, 0],
+                [0, 1 / 2, 1 / 4, -5 / 2, -5 / 4, 2, 1, 0],
+                [0, -1 / 2, 1 / 4, 5 / 2, -5 / 4, -2, 1, 0],
+                [0, 2, 4, -5 / 2, -5, 1 / 2, 1, 0],
+                [0, -2, 4, 5 / 2, -5, -1 / 2, 1, 0],
+                [0, -1, 0, 21 / 4, 0, -21 / 4, 0, 1],
+            ],
+            dtype=out_dtype,
+        ).T
+
+        a_data = np.array(
+            [
+                [1, 1, 1, 1, 1, 32, 32, 0],
+                [0, 1, -1, 2, -2, 16, -16, 0],
+                [0, 1, 1, 4, 4, 8, 8, 0],
+                [0, 1, -1, 8, -8, 4, -4, 0],
+                [0, 1, 1, 16, 16, 2, 2, 0],
+                [0, 1, -1, 32, -32, 1, -1, 1],
+            ],
+            dtype=out_dtype,
+        ).T
+    elif tile_size == 2:
+        g_data = np.array(
+            [
+                [1, 0, 0],
+                [1.0 / 2, 1.0 / 2, 1.0 / 2],
+                [1.0 / 2, -1.0 / 2, 1.0 / 2],
+                [0, 0, 1],
+            ],
+            dtype=np.float32,
+        )
+
+        b_data = np.array(
+            [
+                [1, 0, 0, 0],
+                [0, 1, -1, 1],
+                [-1, 1, 1, 0],
+                [0, 0, 0, -1],
+            ],
+            dtype=out_dtype,
+        )
+
+        a_data = np.array(
+            [[1, 0], [1, 1], [1, -1], [0, -1]],
+            dtype=out_dtype
+        )
+
+    return (
+        const_matrix(a_data, "A"),
+        const_matrix(b_data, "B"),
+        const_matrix(g_data, "G"),
+    )

--- a/topi/tests/python/test_topi_conv2d_NCHWc_winograd.py
+++ b/topi/tests/python/test_topi_conv2d_NCHWc_winograd.py
@@ -1,0 +1,202 @@
+"""Example code to do convolution."""
+
+import numpy as np
+import tvm
+from tvm import autotvm
+from tvm.autotvm.task.space import FallbackConfigEntity
+import topi
+import topi.testing
+from tvm.contrib.pickle_memoize import memoize
+from topi.util import get_const_tuple
+
+
+def _transform_data(data, bn):
+    # NCHW -> NCHW[x]c
+    batch_size, channel, height, width = data.shape
+    data = np.reshape(data, (batch_size, channel//bn, bn, height, width))
+    data = np.transpose(data, (0, 1, 3, 4, 2))
+    return data
+
+def _transform_kernel(kernel, ic_bn, oc_bn):
+    # OIHW -> OIHW[x]i[x]o
+    out_channel, in_channel, kh, kw = kernel.shape
+    kernel = np.reshape(kernel, (out_channel//oc_bn, oc_bn, in_channel//ic_bn, ic_bn, kh, kw))
+    kernel = np.transpose(kernel, (0, 2, 4, 5, 3, 1))
+    return kernel
+
+def _transform_bias(bias, bn):
+    # [num_filter, 1, 1] -> [num_filter//bn, 1, 1, bn]
+    num_filter, h, w = bias.shape
+    bias = np.reshape(bias, (num_filter//bn, bn, h, w))
+    bias = np.transpose(bias, (0, 2, 3, 1))
+    return bias
+
+
+def verify_conv2d_NCHWc_winograd(
+        batch, in_channel, in_size, num_filter, kernel,
+        stride, padding, dilation=1, add_bias=False, add_relu=False, tile_size=2):
+    print("Workload: (%d, %d, %d, %d, %d, %d, %d, %d, ts=%d)" %
+          (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation, tile_size))
+
+    in_height = in_width = in_size
+
+    # for testing functionality,
+    # we choose arbitrary block size that can divide the channel,
+    # regardless of the performance.
+    oc_block = 1
+    for bn in range(16, 0, -1):
+        if num_filter % bn == 0:
+            oc_block = bn
+            break
+
+    ic_block = 1
+    for bn in range(oc_block, 0, -1):
+        if in_channel % bn == 0:
+            ic_block = bn
+            break
+
+    A = tvm.placeholder((batch, in_channel // ic_block, in_height, in_width, ic_block), name='A')
+    W = tvm.placeholder((num_filter // oc_block, in_channel // ic_block, kernel, kernel, ic_block, oc_block), name='W')
+    bias = tvm.placeholder((num_filter // oc_block, 1, 1, oc_block), name='bias')
+
+    a_shape = get_const_tuple(A.shape)
+    w_shape = get_const_tuple(W.shape)
+    bias_shape = get_const_tuple(bias.shape)
+    dtype = A.dtype
+    kernel_layout = \
+        "OIHW{ic_block}i{oc_block}o".format(ic_block=ic_block, oc_block=oc_block)
+    layout = "NCHW{ic_block}c".format(ic_block=ic_block)
+    out_layout = "NCHW{oc_block}c".format(oc_block=oc_block)
+
+    @memoize("topi.tests.test_topi_conv2d_NCHWc_winograd.verify_conv2d_NCHWc_winograd")
+    def get_ref_data():
+        a_np = np.random.uniform(size=(batch, in_channel, in_height, in_width)).astype(dtype)
+        w_np = np.random.uniform(size=(num_filter, in_channel, kernel, kernel)).astype(dtype) * 0.01
+        b_np = np.random.uniform(size=(num_filter, 1, 1)).astype(dtype)
+        c_np = topi.testing.conv2d_nchw_python(a_np, w_np, stride, padding)
+        if add_bias:
+            c_np += b_np
+        if add_relu:
+            c_np = np.maximum(c_np, 0)
+        return _transform_data(a_np, ic_block), _transform_kernel(w_np, ic_block, oc_block), \
+               _transform_bias(b_np, oc_block), _transform_data(c_np, oc_block)
+
+    a_np, w_np, b_np, c_np = get_ref_data()
+
+    def check_device_without_weight_transform(device):
+        ctx = tvm.context(device, 0)
+        if not ctx.exist:
+            print("Skip because %s is not enabled" % device)
+            return
+        print("Running on target: %s" % device)
+
+        with tvm.target.create(device):
+            WT = topi.nn.conv2d_NCHWc_winograd_weight_transform(
+                W,
+                tile_size=tile_size,
+                kernel_layout=kernel_layout
+            )
+            C = topi.nn.conv2d_NCHWc_winograd_without_weight_transform(
+                A, WT, (stride, stride), (padding, padding),
+                (dilation, dilation),
+                layout=layout,
+                out_layout=out_layout,
+                out_dtype=dtype,
+                tile_size=tile_size)
+            if add_bias:
+                C = topi.add(C, bias)
+            if add_relu:
+                C = topi.nn.relu(C)
+            s = topi.generic.schedule_conv2d_NCHWc_winograd_without_weight_transform([C])
+
+        a = tvm.nd.array(a_np, ctx)
+        w = tvm.nd.array(w_np, ctx)
+        b = tvm.nd.array(b_np, ctx)
+        c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), ctx)
+        if add_bias:
+            func = tvm.build(s, [A, W, bias, C], device, name="relu_bias_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func(a, w, b, c)
+        else:
+            func = tvm.build(s, [A, W, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func(a, w, c)
+        print(np.max(np.abs(((c.asnumpy() - c_np) / (np.abs(c_np) + 0.001)))))
+
+        tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=1e-5)
+
+    def check_device_with_weight_transform(device):
+        ctx = tvm.context(device, 0)
+        if not ctx.exist:
+            print("Skip because %s is not enabled" % device)
+            return
+        print("Running on target: %s" % device)
+
+        with tvm.target.create(device):
+            C = topi.nn.conv2d_NCHWc(
+                A, W, (stride, stride), (padding, padding),
+                (dilation, dilation),
+                layout=layout,
+                out_layout=out_layout,
+                out_dtype=dtype)
+            if add_bias:
+                C = topi.add(C, bias)
+            if add_relu:
+                C = topi.nn.relu(C)
+            s = topi.generic.schedule_conv2d_NCHWc([C])
+
+        a = tvm.nd.array(a_np, ctx)
+        w = tvm.nd.array(w_np, ctx)
+        b = tvm.nd.array(b_np, ctx)
+        c = tvm.nd.array(np.zeros(get_const_tuple(C.shape), dtype=C.dtype), ctx)
+        if add_bias:
+            func = tvm.build(s, [A, W, bias, C], device, name="relu_bias_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func(a, w, b, c)
+        else:
+            func = tvm.build(s, [A, W, C], device, name="relu_%d_%d_%d_%d_%d_%d_%d_%d" % (batch, in_channel, in_size, num_filter, kernel, stride, padding, dilation))
+            func(a, w, c)
+        print(np.max(np.abs(((c.asnumpy() - c_np) / (np.abs(c_np) + 0.001)))))
+
+
+        tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=1e-5)
+
+    # test llvm only for now since conv2d_NCHWc_winograd is only implemented on this backend.
+    for device in ['llvm']:
+        check_device_with_weight_transform(device)
+        check_device_without_weight_transform(device)
+
+
+class WinogradFallback(autotvm.FallbackContext):
+    def _query_inside(self, target, workload):
+        key = (target, workload)
+        if key in self.memory:
+            return self.memory[key]
+        cfg = FallbackConfigEntity()
+        cfg.template_key = 'winograd'
+        self.memory[key] = cfg
+        return cfg
+
+
+def test_conv2d_nchw():
+    autotvm.DispatchContext.current.silent = True
+
+    with WinogradFallback():
+        # resnet 18 workloads
+        verify_conv2d_NCHWc_winograd(1, 64, 56, 64, 3, 1, 1)
+        verify_conv2d_NCHWc_winograd(1, 128, 28, 128, 3, 1, 1, tile_size=4)
+        verify_conv2d_NCHWc_winograd(1, 256, 14, 256, 3, 1, 1, tile_size=4)
+        verify_conv2d_NCHWc_winograd(1, 512, 7, 512, 3, 1, 1)
+
+        # batch size = 2
+        verify_conv2d_NCHWc_winograd(2, 64, 56, 64, 3, 1, 1)
+
+        # relu, bias
+        verify_conv2d_NCHWc_winograd(2, 64, 56, 64, 3, 1, 1, add_bias=True)
+        verify_conv2d_NCHWc_winograd(2, 64, 56, 64, 3, 1, 1, add_relu=True)
+        verify_conv2d_NCHWc_winograd(2, 64, 56, 64, 3, 1, 1, add_relu=True, add_bias=True)
+
+        # werid workloads
+        verify_conv2d_NCHWc_winograd(1, 1, 1, 1, 3, 1, 1)
+        verify_conv2d_NCHWc_winograd(3, 3, 3, 3, 3, 1, 1)
+        verify_conv2d_NCHWc_winograd(2, 13, 71, 59, 3, 1, 1)
+
+if __name__ == "__main__":
+    test_conv2d_nchw()


### PR DESCRIPTION
This is the implementation alluded to in
https://discuss.tvm.ai/t/improved-direct-winograd-nchwc-cpu-implementation-with-resnet-50-results/

It is a pretty standard Winograd implementation, modified for NCHWc
layout. It achieves reasonable speedups (up to 2x vs current
implementation) on a number of ResNet 3x3 layers on SKL and AVX.

Benchmarks:

- Single-threaded, GCE Skylake instance, ~120GFLOP/s peak fp32 throughput.
- 1000 iterations of AutoTVM tuning per task.

| Workload  | Baseline (GFLOP/s) | Winograd (eff GFLOP/s)
| ------------- | ------------- | ------------ |
| 3x3s1p1, 1x64x56x56 -> 1x64x56x56 | 104 | 193 |
| 3x3s1p1, 1x128x28x28 -> 1x128x28x28 | 110  | 221  |
| 3x3s1p1, 1x256x14x14 -> 1x256x14x14 | 107 | 182 |
| 3x3s1p1, 1x512x7x7 -> 1x512x7x7 | 93 | 176 |

TODO:

- [x] Unit tests.
- [x] Modifications to `tune_nnvm_x86.py`.
- [x] Implement parallelism.
- [x] More benchmarking results.
