### PR TITLE
[RELAY][PASS] Make FoldConst context and target invariant

### DIFF
--- a/src/relay/backend/compile_engine.cc
+++ b/src/relay/backend/compile_engine.cc
@@ -82,8 +82,6 @@ class ScheduleGetter :
       }
     }
     readable_name_stream_ << "fused";
-    // enter the target context
-    TargetContext target_ctx(target_);
     cache_node->outputs = this->VisitExpr(prim_func->body);
     cache_node->func_name = readable_name_stream_.str();
     CachedFunc cfunc(cache_node);
@@ -284,6 +282,9 @@ class CompileEngineImpl : public CompileEngineNode {
       value->use_count = 0;
       cache_[key] = value;
     }
+    // Enforce use the target.
+    TargetContext target_ctx(key->target);
+
     CHECK(!value->cached_func.defined());
     auto spair = CreateSchedule(key->source_func, key->target);
     auto cache_node = make_node<CachedFuncNode>(

--- a/src/relay/pass/fold_constant.cc
+++ b/src/relay/pass/fold_constant.cc
@@ -107,6 +107,10 @@ Expr FoldConstant(const Expr& expr) {
   ctx.device_type = kDLCPU;
   ctx.device_id = 0;
   Target target = Target::create("llvm");
+  // use a fresh build context
+  // in case we are already in a build context.
+  BuildConfigContext fresh_build_ctx(build_config());
+
   return ConstantFolder(CreateInterpreter(
       Module(nullptr), ctx, target)).Mutate(expr);
 }


### PR DESCRIPTION
Previously, the constant folder can be disturbed by the existing build and target context.
cc @jroesch 