### PR TITLE
clarify tvm llvm dependency for gpu/cuda targets

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -42,7 +42,8 @@ The minimal building requirements are
 - A recent c++ compiler supporting C++ 11 (g++-4.8 or higher)
 - CMake 3.5 or higher
 - We highly recommend to build with LLVM to enable all the features.
-- It is possible to build without llvm dependency if we only want to use CUDA/OpenCL
+- It is possible to build TVM without the LLVM dependency if we only want to use CUDA/OpenCL
+- If we want to use the NNVM compiler, then LLVM is required
 
 We use cmake to build the library.
 The configuration of tvm can be modified by `config.cmake`.


### PR DESCRIPTION
From this line in the TVM build docs:

> LLVM is required for CPU codegen that needs LLVM

It isn't obvious that the cuda target would necessarily require the llvm dependency, and while the current doc doesn't explicitly state otherwise, having a note to clarify this up front for "hello world" tutorials could help avoid some confusion.

As discussed here:

https://discuss.tvm.ai/t/does-tvm-use-llvm-while-compiling-for-cuda/458

> Yes, even for CUDA target, the host side code needs to be generated. For that, LLVM is used. In this case, LLVM will not be involved in device code generation.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
