### PR TITLE
 [RPC] clean up uploaded modules

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -467,6 +467,12 @@ def run_through_rpc(measure_input, build_result,
             ctx.sync()
 
         costs = time_f(*args).results
+
+        # clean up remote files
+        remote.remove(build_result.filename)
+        remote.remove(os.path.splitext(build_result.filename)[0] + '.so')
+        remote.remove('')
+
         if len(costs) > 2:  # remove largest and smallest value to reduce variance
             costs = list(costs)
             costs.sort()

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -105,7 +105,7 @@ class RPCSession(object):
 
     def remove(self, path):
         """Remove file from remote temp folder.
-    
+
         Parameters
         ----------
         path: str

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -103,6 +103,19 @@ class RPCSession(object):
                 "tvm.rpc.server.download")
         return self._remote_funcs["download"](path)
 
+    def remove(self, path):
+        """Remove fiole from remote temp folder.
+    
+        Parameters
+        ----------
+        path: str
+            The relative location to remote temp folder.
+        """
+        if "remove" not in self._remote_funcs:
+            self._remote_funcs["remove"] = self.get_function(
+                "tvm.rpc.server.remove")
+        self._remote_funcs["remove"](path)
+
     def load_module(self, path):
         """Load a remote module, the file need to be uploaded first.
 

--- a/python/tvm/rpc/client.py
+++ b/python/tvm/rpc/client.py
@@ -104,7 +104,7 @@ class RPCSession(object):
         return self._remote_funcs["download"](path)
 
     def remove(self, path):
-        """Remove fiole from remote temp folder.
+        """Remove file from remote temp folder.
     
         Parameters
         ----------

--- a/src/runtime/file_util.cc
+++ b/src/runtime/file_util.cc
@@ -142,5 +142,9 @@ void LoadMetaDataFromFile(
   fs.close();
 }
 
+void RemoveFile(const std::string& file_name) {
+  std::remove(file_name.c_str());
+}
+
 }  // namespace runtime
 }  // namespace tvm

--- a/src/runtime/file_util.h
+++ b/src/runtime/file_util.h
@@ -79,5 +79,4 @@ void LoadMetaDataFromFile(
 void RemoveFile(const std::string& file_name);
 }  // namespace runtime
 }  // namespace tvm
-
 #endif  // TVM_RUNTIME_FILE_UTIL_H_

--- a/src/runtime/file_util.h
+++ b/src/runtime/file_util.h
@@ -71,6 +71,13 @@ void SaveMetaDataToFile(
 void LoadMetaDataFromFile(
     const std::string& file_name,
     std::unordered_map<std::string, FunctionInfo>* fmap);
+
+/*!
+ * \brief Remove (unlink) a file.
+ * \param file_name The file name.
+ */
+void RemoveFile(const std::string& file_name);
 }  // namespace runtime
 }  // namespace tvm
+
 #endif  // TVM_RUNTIME_FILE_UTIL_H_

--- a/src/runtime/rpc/rpc_server_env.cc
+++ b/src/runtime/rpc/rpc_server_env.cc
@@ -35,5 +35,12 @@ TVM_REGISTER_GLOBAL("tvm.rpc.server.download")
     *rv = arr;
   });
 
+TVM_REGISTER_GLOBAL("tvm.rpc.server.remove")
+.set_body([](TVMArgs args, TVMRetValue *rv) {
+    std::string file_name = RPCGetPath(args[0]);
+    LOG(INFO) << "Remove " << file_name;
+    RemoveFile(file_name);
+  });
+
 }  // namespace runtime
 }  // namespace tvm


### PR DESCRIPTION
Currently we don't do any explicit cleanup of uploaded modules during autotuning. For devices with limited memory/storage, this can lead to failures when we run out of space to store uploaded modules.

This is a PR to delete modules after they have been used.
The current approach is to delete every file that could have been uploaded by the RPC client, which is a bit hacky (we need to consider `.so`, `.dll`, `your_extension_here`... C++17 supports simply removing the RPC working directory with `std::experimental::remove_all`, but this doesn't seem to be available in C++11.

CC @merrymercy @tmoreau89 