### PR TITLE
[Relay][Op] Add test for batch_flatten

### DIFF
--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -9,6 +9,7 @@ from ..op import OpPattern, schedule_injective
 reg.register_schedule("nn.relu", schedule_injective)
 reg.register_pattern("nn.relu", OpPattern.ELEMWISE)
 
+# softmax
 @reg.register_schedule("nn.softmax")
 def schedule_softmax(_, outputs, target):
     """Schedule definition of softmax"""

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -43,7 +43,8 @@ def test_unary_op():
                    (tvm.relay.sqrt, np.sqrt),
                    (tvm.relay.sigmoid, sigmoid),
                    (tvm.relay.tanh, np.tanh),
-                   (relay.nn.relu, relu)]:
+                   (relay.nn.relu, relu),
+                   (relay.nn.softmax, topi.testing.softmax_python)]:
         check_single_op(opfunc, ref)
 
 

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -43,8 +43,7 @@ def test_unary_op():
                    (tvm.relay.sqrt, np.sqrt),
                    (tvm.relay.sigmoid, sigmoid),
                    (tvm.relay.tanh, np.tanh),
-                   (relay.nn.relu, relu),
-                   (relay.nn.softmax, topi.testing.softmax_python)]:
+                   (relay.nn.relu, relu)]:
         check_single_op(opfunc, ref)
 
 


### PR DESCRIPTION
This commit adds unit tests for `nn.batch_flatten`, for which a compute primitive had been registered.