### PR TITLE
[TEAM] adityaatluri -> committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ See the [community structure document](http://docs.tvm.ai/contribute/community.h
 We add tag along with committer name to show areas that they are familiar with.
 We do encourage everyone to work anything they are interested in.
 
+- [Aditya Atluri](https://github.com/adityaatluri): @adityaatluri - rocm
 - [Tianqi Chen](https://github.com/tqchen) (PMC): @tqchen - topi, compiler, relay, docs
 - [Yuwei Hu](https://github.com/Huyuwei): @Huyuwei - topi, frontends
 - [Yizhi Liu](https://github.com/yzhliu) (PMC): @yzhliu - jvm, topi, relay


### PR DESCRIPTION
This PR welcomes @adityaatluri as a committer of TVM. aditya was code-owner of the rocm module.

- [Commit history](https://github.com/dmlc/tvm/commits?author=adityaatluri)

c.f. per https://github.com/dmlc/tvm/issues/2017