### PR TITLE
[Relay] Reverse shape dims of weight type in LSTM

### DIFF
--- a/python/tvm/relay/testing/lstm.py
+++ b/python/tvm/relay/testing/lstm.py
@@ -49,7 +49,7 @@ def lstm_cell(num_hidden, batch_size=1, dtype="float32", name=""):
     builder = relay.ScopeBuilder()
 
     input_type = relay.TensorType((batch_size, num_hidden), dtype)
-    weight_type = relay.TensorType((num_hidden, 4*num_hidden), dtype)
+    weight_type = relay.TensorType((4*num_hidden, num_hidden), dtype)
     bias_type = relay.TensorType((4*num_hidden,), dtype)
 
     dense_type = relay.TensorType((batch_size, 4*num_hidden), dtype)
@@ -116,7 +116,7 @@ def lstm_cell(num_hidden, batch_size=1, dtype="float32", name=""):
 def get_net(iterations, num_hidden, batch_size=1, dtype="float32"):
     '''Constructs an unrolled RNN with LSTM cells'''
     input_type = relay.TensorType((batch_size, num_hidden), dtype)
-    weight_type = relay.TensorType((num_hidden, 4*num_hidden), dtype)
+    weight_type = relay.TensorType((4*num_hidden, num_hidden), dtype)
     bias_type = relay.TensorType((4*num_hidden,), dtype)
 
     state_type = relay.TupleType([input_type, input_type])


### PR DESCRIPTION
The LSTM benchmark port inadvertently introduced a test failure because the relations for certain operators changed between its being written and its being merged. This small change should fix it.