### PR TITLE
[COMMUNITY] @phisiart -> Committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ We do encourage everyone to work anything they are interested in.
 - [Ziheng Jiang](https://github.com/ZihengJiang) (PMC): @ZihengJiang - relay, compiler
 - [Thierry Moreau](https://github.com/tmoreau89) (PMC): @tmoreau89 - vta
 - [Haichen Shen](https://github.com/icemelon9) (PMC): @icemelon9 - relay, topi
+- [Zhixun Tan](https://github.com/phisiart): @phisiart - opengl, web
 - [Leyuan Wang](https://github.com/Laurawly): @Laurawly: - topi
 - [Nick Hynes](https://github.com/nhynes): @nhynes: - sgx, rust
 - [Lianmin Zheng](https://github.com/merrymercy): @merrymercy - autotvm, topi


### PR DESCRIPTION
This PR welcomes @phisiart as committer of TVM stack. He was code-owner of the WebGL module and he created the webgl support.

- [Commit history](https://github.com/dmlc/tvm/commits?author=phisiart)
- [Code reviews](https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by%3Aphisiart)
