### PR TITLE
[Relay] Add support for tuple node in operator fusion

### DIFF
--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -740,7 +740,7 @@ class FuseMutator : private ExprMutator {
     Tuple new_tuple = TupleNode::make(new_fields);
     if (ret_group == gmap_.at(tuple)) {
       bool isolated = true;
-	  for (int i = 0; i < new_fields.size(); ++i) {
+      for (int i = 0; i < new_fields.size(); ++i) {
         isolated &= (new_fields[i] == ginfo_[ret_group].params[i]);
       }
       if (isolated) {

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -752,7 +752,7 @@ class FuseMutator : private ExprMutator {
         return ExprMutator::VisitExpr_(tuple);
       }
       // This tuple has been fused other ops before it
-      return MakeNewFunction(ret_group, TupleType(), new_tuple);
+      return MakeNewFunction(ret_group, tuple->checked_type(), new_tuple);
     }
     return new_tuple;
   }

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -754,7 +754,7 @@ class FuseMutator : private ExprMutator {
       // This tuple has been fused other ops before it
       return MakeNewFunction(ret_group, TupleType(), new_tuple);
     }
-	return new_tuple;
+    return new_tuple;
   }
 
   Expr MakeNewFunction(GraphPartitioner::Group* group, Type ret_type, Expr body) {

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -744,7 +744,8 @@ class FuseMutator : private ExprMutator {
     return TupleNode::make(new_fields);
   }
 
-  Array<Expr> GetNewArguments(const tvm::Array<Expr>& args, GraphPartitioner::Group* current_group) {
+  Array<Expr> GetNewArguments(const tvm::Array<Expr>& args,
+                              GraphPartitioner::Group* current_group) {
     Array<Expr> new_args;
     for (auto arg : args) {
       auto* arg_group = gmap_.at(arg.get())->FindRoot();

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -740,7 +740,7 @@ class FuseMutator : private ExprMutator {
     Tuple new_tuple = TupleNode::make(new_fields);
     if (ret_group == gmap_.at(tuple)) {
       bool isolated = true;
-      for (int i = 0; i < new_fields.size(); ++i) {
+      for (size_t i = 0; i < new_fields.size(); ++i) {
         isolated &= (new_fields[i] == ginfo_[ret_group].params[i]);
       }
       if (isolated) {

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -741,7 +741,7 @@ class FuseMutator : private ExprMutator {
     if (ret_group == gmap_.at(tuple)) {
       bool isolated = true;
       for (size_t i = 0; i < new_fields.size(); ++i) {
-        isolated &= (new_fields[i] == ginfo_[ret_group].params[i]);
+        isolated &= (new_fields[i].same_as(ginfo_[ret_group].params[i]));
       }
       if (isolated) {
         // Do not put a isolated tuple into a function

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -145,7 +145,7 @@ def test_concatenate():
 
 
 def test_tuple_root():
-    """Test fusion case involving concat op and Tuple node"""
+    """Test fusion case where Tuple node is the root in its group"""
 
     def before(dshape):
         x = relay.var("x", shape=dshape)

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -28,8 +28,6 @@ def test_fuse_simple():
     assert relay.ir_pass.alpha_equal(zz, after)
 
 
-
-
 def test_conv2d_fuse():
     """Test fusion case of conv2d"""
     def before(dshape):
@@ -106,7 +104,44 @@ def test_conv2d_fuse():
     assert relay.ir_pass.alpha_equal(zz, after)
 
 
+def test_concatenate():
+    """Test fusion case involving concat op and Tuple node"""
+
+    def before(dshape):
+        x = relay.var("x", shape=dshape)
+        pooled = relay.nn.max_pool2d(x, pool_size=(2, 2), strides=(2, 2), padding=(0, 0))
+        upsampled = relay.nn.upsampling(pooled, scale=2, layout="NCHW")
+        concat = relay.concatenate((upsampled, x), axis=1)
+        out = relay.add(concat, relay.const(1, "float32"))
+        return relay.Function(relay.ir_pass.free_vars(out), out)
+
+    def expected(dshape):
+        x = relay.var("x", shape=dshape)
+        pooled = relay.nn.max_pool2d(x, pool_size=(2, 2), strides=(2, 2), padding=(0, 0))
+        f0 = relay.Function([x], pooled)
+
+        p0 = relay.var("p0", shape=(dshape[0], dshape[1], dshape[2]//2, dshape[3]//2))
+        p1 = relay.var("p1", shape=dshape)
+        upsampled = relay.nn.upsampling(p0, scale=2, layout="NCHW")
+        concat = relay.concatenate((upsampled, p1), axis=1)
+        out = relay.add(concat, relay.const(1, "float32"))
+        f1 = relay.Function([p0, p1], out)
+
+        x = relay.var("x", shape=dshape)
+        y = relay.Call(f0, [x])
+        z = relay.Call(f1, [y, x])
+        return relay.Function([x], z)
+
+    dshape = (1, 16, 64, 64)
+    z = before(dshape)
+    z = relay.ir_pass.infer_type(z)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=2)
+    zz = relay.ir_pass.infer_type(zz)
+    print(zz.astext())
+    after = relay.ir_pass.infer_type(expected(dshape))
+    assert relay.ir_pass.alpha_equal(zz, after)
 
 if __name__ == "__main__":
     test_fuse_simple()
     test_conv2d_fuse()
+    test_concatenate()

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -135,12 +135,55 @@ def test_concatenate():
     dshape = (1, 16, 64, 64)
     z = before(dshape)
     z = relay.ir_pass.infer_type(z)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=0)
+    assert not relay.ir_pass.free_vars(zz)
     zz = relay.ir_pass.fuse_ops(z, opt_level=2)
     zz = relay.ir_pass.infer_type(zz)
+    assert not relay.ir_pass.free_vars(zz)
     after = relay.ir_pass.infer_type(expected(dshape))
     assert relay.ir_pass.alpha_equal(zz, after)
+
+
+def test_tuple_root():
+    """Test fusion case involving concat op and Tuple node"""
+
+    def before(dshape):
+        x = relay.var("x", shape=dshape)
+        pooled = relay.nn.max_pool2d(x, pool_size=(2, 2), strides=(2, 2), padding=(0, 0))
+        upsampled = relay.nn.upsampling(pooled, scale=2, layout="NCHW")
+        out = relay.Tuple((upsampled, x))
+        return relay.Function(relay.ir_pass.free_vars(out), out)
+
+    def expected(dshape):
+        x = relay.var("x", shape=dshape)
+        pooled = relay.nn.max_pool2d(x, pool_size=(2, 2), strides=(2, 2), padding=(0, 0))
+        f0 = relay.Function([x], pooled)
+
+        p0 = relay.var("p0", shape=(dshape[0], dshape[1], dshape[2]//2, dshape[3]//2))
+        p1 = relay.var("p1", shape=(dshape[0], dshape[1], dshape[2], dshape[3]))
+        upsampled = relay.nn.upsampling(p0, scale=2, layout="NCHW")
+        out = relay.Tuple((upsampled, p1))
+        f1 = relay.Function([p0, p1], out)
+
+        x = relay.var("x", shape=dshape)
+        y = relay.Call(f0, [x])
+        z = relay.Call(f1, [y, x])
+        return relay.Function([x], z)
+
+    dshape = (1, 16, 64, 64)
+    z = before(dshape)
+    z = relay.ir_pass.infer_type(z)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=0)
+    assert not relay.ir_pass.free_vars(zz)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=2)
+    zz = relay.ir_pass.infer_type(zz)
+    assert not relay.ir_pass.free_vars(zz)
+    after = relay.ir_pass.infer_type(expected(dshape))
+    assert relay.ir_pass.alpha_equal(zz, after)
+
 
 if __name__ == "__main__":
     test_fuse_simple()
     test_conv2d_fuse()
     test_concatenate()
+    test_tuple_root()

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -137,7 +137,6 @@ def test_concatenate():
     z = relay.ir_pass.infer_type(z)
     zz = relay.ir_pass.fuse_ops(z, opt_level=2)
     zz = relay.ir_pass.infer_type(zz)
-    print(zz.astext())
     after = relay.ir_pass.infer_type(expected(dshape))
     assert relay.ir_pass.alpha_equal(zz, after)
 


### PR DESCRIPTION
Fixes #2183. It enables fusing a concat node with other ops before it.
@tqchen please review.

Example: Upsampling + Concat
```
fn (%x: Tensor[(1, 16, 64, 64), float32])
    -> Tensor[(1, 32, 64, 64), float32] {
  %0 = fn(%p0: Tensor[(1, 16, 64, 64), float32])
          -> Tensor[(1, 16, 32, 32), float32] {
    %1 = nn.max_pool2d(%p0, pool_size=[2, 2], strides=[2, 2]) # ty=Tensor[(1, 16, 32, 32), float32]
    %1
  }
  %2 = %0(%x) # ty=Tensor[(1, 16, 32, 32), float32]
  %3 = fn(%p01: Tensor[(1, 16, 32, 32), float32],
          %p1: Tensor[(1, 16, 64, 64), float32])
          -> Tensor[(1, 32, 64, 64), float32] {
    %4 = nn.upsampling(%p01, scale=2) # ty=Tensor[(1, 16, 64, 64), float32]
    %5 = (%4, %p1)
    %6 = concatenate(%5, axis=1) # ty=Tensor[(1, 32, 64, 64), float32]
    %6
  }
  %7 = %3(%2, %x) # ty=Tensor[(1, 32, 64, 64), float32]
  %7
}

```