### PR TITLE
Python security issue about mktemp() and abspath()

### DIFF
--- a/python/tvm/_ffi/libinfo.py
+++ b/python/tvm/_ffi/libinfo.py
@@ -25,7 +25,7 @@ def find_lib_path(name=None, search_path=None, optional=False):
     # inplace) or the install directory (if TVM is installed).
     # An installed TVM's curr_path will look something like:
     #   $PREFIX/lib/python3.6/site-packages/tvm/_ffi
-    ffi_dir = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    ffi_dir = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
     source_dir = os.path.join(ffi_dir, "..", "..", "..")
     install_lib_dir = os.path.join(ffi_dir, "..", "..", "..", "..")
 
@@ -49,7 +49,7 @@ def find_lib_path(name=None, search_path=None, optional=False):
 
     dll_path.append(install_lib_dir)
 
-    dll_path = [os.path.abspath(x) for x in dll_path]
+    dll_path = [os.path.realpath(x) for x in dll_path]
     if search_path is not None:
         if search_path is list:
             dll_path = dll_path + search_path

--- a/python/tvm/contrib/debugger/debug_runtime.py
+++ b/python/tvm/contrib/debugger/debug_runtime.py
@@ -146,7 +146,7 @@ class GraphModuleDebug(graph_runtime.GraphModule):
         """
         # make the dump folder if not given
         if not self._dump_root:
-            self._dump_root = tempfile.mktemp(prefix=_DUMP_ROOT_PREFIX)
+            self._dump_root = tempfile.mkstemp(prefix=_DUMP_ROOT_PREFIX)
 
         # format the context
         ctx = self._format_context(ctx)

--- a/python/tvm/contrib/debugger/debug_runtime.py
+++ b/python/tvm/contrib/debugger/debug_runtime.py
@@ -146,7 +146,7 @@ class GraphModuleDebug(graph_runtime.GraphModule):
         """
         # make the dump folder if not given
         if not self._dump_root:
-            self._dump_root = tempfile.mkstemp(prefix=_DUMP_ROOT_PREFIX)
+            self._dump_root = tempfile.mkdtemp(prefix=_DUMP_ROOT_PREFIX)
 
         # format the context
         ctx = self._format_context(ctx)

--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -103,7 +103,7 @@ def find_cuda_path():
     (out, _) = proc.communicate()
     out = py_str(out)
     if proc.returncode == 0:
-        return os.path.abspath(os.path.join(str(out).strip(), "../.."))
+        return os.path.realpath(os.path.join(str(out).strip(), "../.."))
     cuda_path = "/usr/local/cuda"
     if os.path.exists(os.path.join(cuda_path, "bin/nvcc")):
         return cuda_path

--- a/python/tvm/contrib/verilog.py
+++ b/python/tvm/contrib/verilog.py
@@ -111,7 +111,7 @@ class VPIHandle(NodeBase):
 
 
 def _find_vpi_path():
-    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    curr_path = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
     api_path = os.path.join(curr_path, '../../../lib/')
     vpi_path = [curr_path, api_path]
     vpi_path = [os.path.join(p, 'tvm_vpi.vpi') for p in vpi_path]
@@ -123,7 +123,7 @@ def _find_vpi_path():
 
 def search_path():
     """Get the search directory."""
-    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    curr_path = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
     ver_path = [os.path.join(curr_path, '../../../verilog/')]
     ver_path += [os.path.join(curr_path, '../../../tests/verilog/unittest/')]
     ver_path += [os.path.join(curr_path, '../../../tests/verilog/integration/')]

--- a/python/tvm/contrib/xcode.py
+++ b/python/tvm/contrib/xcode.py
@@ -206,9 +206,9 @@ def popen_test_rpc(host,
     if "TVM_IOS_RPC_ROOT" in os.environ:
         rpc_root = os.environ["TVM_IOS_RPC_ROOT"]
     else:
-        curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+        curr_path = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
         rpc_root = os.path.join(curr_path, "../../../apps/ios_rpc")
-    proj_path = os.path.abspath(os.path.join(rpc_root, "tvmrpc.xcodeproj"))
+    proj_path = os.path.realpath(os.path.join(rpc_root, "tvmrpc.xcodeproj"))
     if not os.path.exists(proj_path):
         raise RuntimeError("Cannot find tvmrpc.xcodeproj in %s," +
                            (" please set env TVM_IOS_RPC_ROOT correctly" % rpc_root))

--- a/python/tvm/exec/rpc_proxy.py
+++ b/python/tvm/exec/rpc_proxy.py
@@ -12,7 +12,7 @@ from ..rpc.proxy import Proxy
 
 def find_example_resource():
     """Find resource examples."""
-    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    curr_path = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
     base_path = os.path.join(curr_path, "../../../")
     index_page = os.path.join(base_path, "web/example_rpc.html")
     js_files = [

--- a/topi/python/topi/cpp.py
+++ b/topi/python/topi/cpp.py
@@ -15,7 +15,7 @@ def _get_lib_names():
 
 def _load_lib():
     """Load libary by searching possible path."""
-    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+    curr_path = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
     lib_search = curr_path
     lib_path = libinfo.find_lib_path(_get_lib_names(), lib_search, optional=True)
     if lib_path is None:


### PR DESCRIPTION
Python security issue about mktemp() and abspath()
With abspath, an attacker can exploit a directory traversal or an equivalent path to attack, making it safer to use realpath.
The temporary file name returned by the mktemp function contains the process ID number, which makes the temporary file name easy to guess. An attacker could exploit this vulnerability to perform a symbolic link attack. Use mkstemp to replace it safer