### PR TITLE
[RELAY][PASS] Memorize FoldScaleAxis backward transform result

### DIFF
--- a/src/relay/pass/fold_scale_axis.cc
+++ b/src/relay/pass/fold_scale_axis.cc
@@ -556,9 +556,7 @@ class BackwardTransformerNode :
    * \return The result of transformation.
    */
   Expr Transform(const Expr& expr, AxesSet axes, Expr scale) {
-    // NOTE: the result of Transform is not memoized.
-    // However, in the current rule, Transform will
-    // only be called to expr that is referred once.
+    // NOTE: the result of Transform is memoized.
     if (const CallNode* call_node = expr.as<CallNode>()) {
       return Transform(call_node, axes, scale);
     } else {
@@ -572,7 +570,13 @@ class BackwardTransformerNode :
    * \return the result of the call Mutation.
    */
   Expr NormalCallTransform(const CallNode* call_node) {
-    return ExprMutator::VisitExpr_(call_node);
+    const Call call = GetRef<Call>(call_node);
+    const auto it = memo_.find(call);
+    if (it != memo_.end())
+      return it->second;
+    Expr new_expr = ExprMutator::VisitExpr_(call_node);
+    memo_[call] = new_expr;
+    return new_expr;
   }
   /*!
    * \brief Get the expected axes on expr.
@@ -620,10 +624,16 @@ Expr BackwardTransformerNode::Transform(
       Op::GetAttr<FBackwardTransform>("FScaleAxisBackwardTransform");
   auto f = ftransform.get(call_node->op, nullptr);
   if (f != nullptr) {
-    return f(GetRef<Call>(call_node),
-             axes,
-             scale,
-             GetRef<BackwardTransformer>(this));
+    const Call call = GetRef<Call>(call_node);
+    const auto it = memo_.find(call);
+    if (it != memo_.end())
+      return it->second;
+    Expr new_expr = f(GetRef<Call>(call_node),
+                      axes,
+                      scale,
+                      GetRef<BackwardTransformer>(this));
+    memo_[call] = new_expr;
+    return new_expr;
   } else {
     CHECK(!axes.defined()) << "outstanding scale";
     return NormalCallTransform(call_node);


### PR DESCRIPTION
Fixed the issue in https://discuss.tvm.ai/t/relay-duplicated-maxpool-in-multiple-branches/1235/12.

We need to memorize results of backward transformation of FoldScaleAxis. If nodes in multiple branches are rewritten, the common parent will be transformed multiple times, which results in duplicated nodes if the parent of the parent changes.

Note that the test case here can pass even without this patch. This is a limitation of `AlphaEqual`. We cannot detect whether the two `expr` in `f(expr, expr)` is duplicated (evaluated two times).
Before this patch:
```
fn (%x: Tensor[(2, 4, 10, 10), float32],
    %weight: Tensor[(4, 4, 3, 3), float32],
    %out_bias: Tensor[(4,), float32],
    %out_scale: Tensor[(4,), float32])
    -> Tensor[(2, 4, 10, 10), float32] {
  %0 = expand_dims(%out_scale, axis=1, num_newaxis=2) # ty=Tensor[(4, 1, 1), float32]
  %1 = squeeze(%0, axis=[1, 2]) # ty=Tensor[(4,), float32]
  %2 = expand_dims(%1, axis=1, num_newaxis=3) # ty=Tensor[(4, 1, 1, 1), float32]
  %3 = multiply(%weight, %2) # ty=Tensor[(4, 4, 3, 3), float32]
  %4 = nn.conv2d(%x, %3, padding=[1, 1], channels=4, kernel_size=[3, 3]) # ty=Tensor[(2, 4, 10, 10), float32]
  %5 = nn.relu(%4) # ty=Tensor[(2, 4, 10, 10), float32]
  %6 = squeeze(%0, axis=[1, 2]) # ty=Tensor[(4,), float32]
  %7 = expand_dims(%6, axis=1, num_newaxis=3) # ty=Tensor[(4, 1, 1, 1), float32]
  %8 = multiply(%weight, %7) # ty=Tensor[(4, 4, 3, 3), float32]
  %9 = nn.conv2d(%5, %8, padding=[1, 1], channels=4, kernel_size=[3, 3]) # ty=Tensor[(2, 4, 10, 10), float32]
  %10 = nn.relu(%9) # ty=Tensor[(2, 4, 10, 10), float32]
  %11 = nn.relu(%4) # ty=Tensor[(2, 4, 10, 10), float32]
  %12 = squeeze(%0, axis=[1, 2]) # ty=Tensor[(4,), float32]
  %13 = expand_dims(%12, axis=1, num_newaxis=3) # ty=Tensor[(4, 1, 1, 1), float32]
  %14 = multiply(%weight, %13) # ty=Tensor[(4, 4, 3, 3), float32]
  %15 = nn.conv2d(%11, %14, padding=[1, 1], channels=4, kernel_size=[3, 3]) # ty=Tensor[(2, 4, 10, 10), float32]
  %16 = nn.relu(%15) # ty=Tensor[(2, 4, 10, 10), float32]
  %17 = add(%10, %16) # ty=Tensor[(2, 4, 10, 10), float32]
  %17
}
```
Expected:
```
fn (%x: Tensor[(2, 4, 10, 10), float32],
    %weight: Tensor[(4, 4, 3, 3), float32],
    %out_bias: Tensor[(4,), float32],
    %out_scale: Tensor[(4,), float32])
    -> Tensor[(2, 4, 10, 10), float32] {
  %0 = expand_dims(%out_scale, axis=1, num_newaxis=2) # ty=Tensor[(4, 1, 1), float32]
  %1 = squeeze(%0, axis=[1, 2]) # ty=Tensor[(4,), float32]
  %2 = expand_dims(%1, axis=1, num_newaxis=3) # ty=Tensor[(4, 1, 1, 1), float32]
  %3 = multiply(%weight, %2) # ty=Tensor[(4, 4, 3, 3), float32]
  %4 = nn.conv2d(%x, %3, padding=[1, 1], channels=4, kernel_size=[3, 3]) # ty=Tensor[(2, 4, 10, 10), float32]
  %5 = nn.relu(%4) # ty=Tensor[(2, 4, 10, 10), float32]
  %6 = squeeze(%0, axis=[1, 2]) # ty=Tensor[(4,), float32]
  %7 = expand_dims(%6, axis=1, num_newaxis=3) # ty=Tensor[(4, 1, 1, 1), float32]
  %8 = multiply(%weight, %7) # ty=Tensor[(4, 4, 3, 3), float32]
  %9 = nn.conv2d(%5, %8, padding=[1, 1], channels=4, kernel_size=[3, 3]) # ty=Tensor[(2, 4, 10, 10), float32]
  %10 = nn.relu(%9) # ty=Tensor[(2, 4, 10, 10), float32]
  %11 = squeeze(%0, axis=[1, 2]) # ty=Tensor[(4,), float32]
  %12 = expand_dims(%11, axis=1, num_newaxis=3) # ty=Tensor[(4, 1, 1, 1), float32]
  %13 = multiply(%weight, %12) # ty=Tensor[(4, 4, 3, 3), float32]
  %14 = nn.conv2d(%5, %13, padding=[1, 1], channels=4, kernel_size=[3, 3]) # ty=Tensor[(2, 4, 10, 10), float32]
  %15 = nn.relu(%14) # ty=Tensor[(2, 4, 10, 10), float32]
  %16 = add(%10, %15) # ty=Tensor[(2, 4, 10, 10), float32]
  %16
}
```

Please review @tqchen @masahi @jroesch 