### PR TITLE
Add a the ability to trigger debugging in the interpreter without recompiling

### DIFF
--- a/include/tvm/relay/attrs/debug.h
+++ b/include/tvm/relay/attrs/debug.h
@@ -1,0 +1,29 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file tvm/relay/attrs/debug.h
+ * \brief Auxiliary attributes for debug operators.
+ */
+#ifndef TVM_RELAY_ATTRS_DEBUG_H_
+#define TVM_RELAY_ATTRS_DEBUG_H_
+
+#include <tvm/attrs.h>
+#include <string>
+
+namespace tvm {
+namespace relay {
+
+/*!
+ * \brief Options for the debug operators.
+ */
+struct DebugAttrs : public tvm::AttrsNode<DebugAttrs> {
+  EnvFunc debug_func;
+
+  TVM_DECLARE_ATTRS(DebugAttrs, "relay.attrs.DebugAttrs") {
+    TVM_ATTR_FIELD(debug_func)
+        .describe("The function to use when debugging.");
+  }
+};
+
+}  // namespace relay
+}  // namespace tvm
+#endif  // TVM_RELAY_ATTRS_DEBUG_H_

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -49,6 +49,11 @@ using TOpPattern = int;
 using TOpIsStateful = bool;
 
 /*!
+ * \brief Mark the operator as non-computational.
+ */
+using TNonComputational = bool;
+
+/*!
  * \brief Computation description interface.
  *
  * \note This function have a special convention

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -9,6 +9,7 @@ from . import module
 from . import ir_pass
 from .build_module import build, build_config, create_executor
 from . import parser
+from . import debug
 
 # Root operators
 from .op import Op
@@ -57,12 +58,6 @@ TupleGetItem = expr.TupleGetItem
 var = expr.var
 const = expr.const
 bind = expr.bind
-
-# pylint: disable=unused-argument
-@register_func("relay.debug")
-def _debug(*args):
-    import pdb
-    pdb.set_trace()
 
 # Parser
 fromtext = parser.fromtext

--- a/python/tvm/relay/backend/interpreter.py
+++ b/python/tvm/relay/backend/interpreter.py
@@ -21,6 +21,7 @@ class Value(NodeBase):
         return TensorValue(const(value, dtype).data)
 
 
+
 @register_relay_node
 class TupleValue(Value):
     """A tuple value produced by the interpreter."""

--- a/python/tvm/relay/backend/interpreter.py
+++ b/python/tvm/relay/backend/interpreter.py
@@ -21,7 +21,6 @@ class Value(NodeBase):
         return TensorValue(const(value, dtype).data)
 
 
-
 @register_relay_node
 class TupleValue(Value):
     """A tuple value produced by the interpreter."""

--- a/python/tvm/relay/debug.py
+++ b/python/tvm/relay/debug.py
@@ -19,7 +19,7 @@ def _debug(*args):
     _, _, _, ist = args
     print("Relay Debugger")
     print("  You can manipulate the expression under evaluation with the name `expr`.")
-    print("  You can manipulate the call stack by the name `stack`.")
+    print("  You can manipulate the call stack with the name `stack`.")
     print("--------------")
     print("--------------")
     _debugger_init(ist.current_expr, ist.stack)

--- a/python/tvm/relay/debug.py
+++ b/python/tvm/relay/debug.py
@@ -1,0 +1,24 @@
+# pylint: disable=wildcard-import, redefined-builtin, invalid-name
+"""The Relay IR namespace containing the IR definition and compiler."""
+from __future__ import absolute_import
+from .base import NodeBase, register_relay_node
+from ..api import register_func
+
+@register_relay_node
+class InterpreterState(NodeBase):
+    pass
+
+def _debugger_init(expr, stack):
+    import pdb
+    pdb.set_trace()
+
+# pylint: disable=unused-argument
+@register_func("relay.debug")
+def _debug(*args):
+    _, _, _, ist = args
+    print("Relay Debugger")
+    print("  You can manipulate the expression under evaluation by the name `expr`.")
+    print("  You can manipulate the call stack by the name `stack`.")
+    print("--------------")
+    print("--------------")
+    _debugger_init(ist.current_expr , ist.stack)

--- a/python/tvm/relay/debug.py
+++ b/python/tvm/relay/debug.py
@@ -8,6 +8,7 @@ from ..api import register_func
 class InterpreterState(NodeBase):
     pass
 
+# pylint: disable=unused-argument
 def _debugger_init(expr, stack):
     import pdb
     pdb.set_trace()
@@ -21,4 +22,4 @@ def _debug(*args):
     print("  You can manipulate the call stack by the name `stack`.")
     print("--------------")
     print("--------------")
-    _debugger_init(ist.current_expr , ist.stack)
+    _debugger_init(ist.current_expr, ist.stack)

--- a/python/tvm/relay/debug.py
+++ b/python/tvm/relay/debug.py
@@ -18,7 +18,7 @@ def _debugger_init(expr, stack):
 def _debug(*args):
     _, _, _, ist = args
     print("Relay Debugger")
-    print("  You can manipulate the expression under evaluation by the name `expr`.")
+    print("  You can manipulate the expression under evaluation with the name `expr`.")
     print("  You can manipulate the call stack by the name `stack`.")
     print("--------------")
     print("--------------")

--- a/python/tvm/relay/op/__init__.py
+++ b/python/tvm/relay/op/__init__.py
@@ -3,6 +3,7 @@
 # operator defs
 from .op import get, register, register_schedule, register_compute, register_alter_op_layout, \
     Op
+from .op import debug
 
 # Operators
 from .reduce import *
@@ -12,6 +13,7 @@ from . import nn
 from . import image
 from . import vision
 from . import op_attrs
+
 
 # operator registry
 from . import _tensor

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -185,5 +185,16 @@ def schedule_injective(attrs, outputs, target):
     with target:
         return topi.generic.schedule_injective(outputs)
 
+__DEBUG_COUNTER__ = 0
+
 def debug(expr, debug_func=None):
-    return _make.debug(expr)
+    global __DEBUG_COUNTER__
+
+    if debug_func:
+        name = "debugger_func{}".format(__DEBUG_COUNTER__)
+        register_func(name, debug_func)
+        __DEBUG_COUNTER__ += 1
+    else:
+        name = ''
+
+    return _make.debug(expr, name)

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -8,6 +8,7 @@ from ..base import register_relay_node
 from ..expr import Expr
 from ...api import register_func
 from ...build_module import lower, build
+from . import _make
 
 @register_relay_node
 class Op(Expr):
@@ -183,3 +184,6 @@ def schedule_injective(attrs, outputs, target):
     """Generic schedule for binary broadcast."""
     with target:
         return topi.generic.schedule_injective(outputs)
+
+def debug(expr, debug_func=None):
+    return _make.debug(expr)

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -188,6 +188,7 @@ def schedule_injective(attrs, outputs, target):
 __DEBUG_COUNTER__ = 0
 
 def debug(expr, debug_func=None):
+    """The main entry point to the debugger."""
     global __DEBUG_COUNTER__
 
     if debug_func:

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -246,6 +246,7 @@ class Interpreter :
   Value InvokePrimitiveOp(Function func,
                           const Array<Value>& args) {
     auto call_node = func->body.as<CallNode>();
+
     if (call_node && call_node->op == Op::Get("debug")) {
       auto dattrs = call_node->attrs.as<DebugAttrs>();
       auto interp_state = this->get_state(call_node->args[0]);
@@ -256,12 +257,7 @@ class Interpreter :
         RELAY_DEBUG(interp_state);
       }
 
-      auto kont = FunctionNode::make(
-        func->params,
-        call_node->args[0],
-        Type(), {}, Attrs());
-
-      return this->Eval(kont);
+      return args[0];
     }
 
     // Marshal the arguments.

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -449,7 +449,7 @@ class Interpreter :
       InterpreterStateNode::Frame frame = fr.locals;
       stack.push_back(frame);
     }
-    auto state = InterpreterStateNode::make(Expr(), stack);
+    auto state = InterpreterStateNode::make(e, stack);
     return state;
   }
 

--- a/src/relay/op/debug.cc
+++ b/src/relay/op/debug.cc
@@ -1,0 +1,46 @@
+
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file nn.cc
+ * \brief Property def of nn operators.
+ */
+
+#include <tvm/relay/op.h>
+#include <tvm/relay/attrs/nn.h>
+#include <tvm/relay/attrs/image.h>
+#include <topi/nn.h>
+#include <topi/nn/softmax.h>
+#include <topi/nn/flatten.h>
+#include <vector>
+#include "./type_relations.h"
+#include "./op_common.h"
+#include "./layout.h"
+
+namespace tvm {
+namespace relay {
+
+RELAY_REGISTER_OP("debug")
+.describe(R"code(Enter the interpreter's debugger.
+
+)code" TVM_ADD_FILELINE)
+.set_num_inputs(1)
+.add_argument("data", "Tuple", "The input list of tensors.")
+.set_support_level(1)
+.add_type_rel("Debug", IdentityRel)
+.set_attr<TNonComputational>("TNonComputational", true)
+.set_attr<TOpPattern>("TOpPattern", kInjective);
+
+Expr MakeDebug(Expr expr) {
+  static const Op& op = Op::Get("debug");
+  return CallNode::make(op, {expr}, Attrs(), {});
+}
+
+TVM_REGISTER_API("relay.op._make.debug")
+.set_body([](const TVMArgs& args, TVMRetValue* rv) {
+    runtime::detail::unpack_call<Expr, 1>(MakeDebug, args, rv);
+  });
+
+
+}  // namespace relay
+}  // namespace tvm
+

--- a/src/relay/op/debug.cc
+++ b/src/relay/op/debug.cc
@@ -1,4 +1,3 @@
-
 /*!
  *  Copyright (c) 2018 by Contributors
  * \file nn.cc
@@ -6,11 +5,7 @@
  */
 
 #include <tvm/relay/op.h>
-#include <tvm/relay/attrs/nn.h>
-#include <tvm/relay/attrs/image.h>
-#include <topi/nn.h>
-#include <topi/nn/softmax.h>
-#include <topi/nn/flatten.h>
+#include <tvm/relay/attrs/debug.h>
 #include <vector>
 #include "./type_relations.h"
 #include "./op_common.h"
@@ -30,16 +25,21 @@ RELAY_REGISTER_OP("debug")
 .set_attr<TNonComputational>("TNonComputational", true)
 .set_attr<TOpPattern>("TOpPattern", kInjective);
 
-Expr MakeDebug(Expr expr) {
+Expr MakeDebug(Expr expr, std::string name) {
+  auto dattrs = make_node<DebugAttrs>();
+  if (name.size() > 0) {
+    dattrs->debug_func = EnvFunc::Get(name);
+  } else {
+      dattrs->debug_func = EnvFunc();
+  }
   static const Op& op = Op::Get("debug");
-  return CallNode::make(op, {expr}, Attrs(), {});
+  return CallNode::make(op, {expr}, Attrs(dattrs), {});
 }
 
 TVM_REGISTER_API("relay.op._make.debug")
 .set_body([](const TVMArgs& args, TVMRetValue* rv) {
-    runtime::detail::unpack_call<Expr, 1>(MakeDebug, args, rv);
+    runtime::detail::unpack_call<Expr, 2>(MakeDebug, args, rv);
   });
-
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/op/debug.cc
+++ b/src/relay/op/debug.cc
@@ -30,7 +30,7 @@ RELAY_REGISTER_OP("debug")
 .add_argument("program", "Tuple", "The program to execute before debugging.")
 .set_support_level(1)
 .add_type_rel("Debug", IdentityRel)
-.set_attr<TOpPattern>("TOpPattern", kInjective)
+.set_attr<TOpPattern>("TOpPattern", kOpaque)
 .set_attr<FTVMCompute>("FTVMCompute", DebugCompute);
 
 Expr MakeDebug(Expr expr, std::string name) {

--- a/src/relay/op/debug.cc
+++ b/src/relay/op/debug.cc
@@ -38,7 +38,7 @@ Expr MakeDebug(Expr expr, std::string name) {
   if (name.size() > 0) {
     dattrs->debug_func = EnvFunc::Get(name);
   } else {
-      dattrs->debug_func = EnvFunc();
+    dattrs->debug_func = EnvFunc();
   }
   static const Op& op = Op::Get("debug");
   return CallNode::make(op, {expr}, Attrs(dattrs), {});

--- a/src/relay/op/debug.cc
+++ b/src/relay/op/debug.cc
@@ -6,6 +6,7 @@
 
 #include <tvm/relay/op.h>
 #include <tvm/relay/attrs/debug.h>
+#include <topi/elemwise.h>
 #include <vector>
 #include "./type_relations.h"
 #include "./op_common.h"
@@ -14,16 +15,23 @@
 namespace tvm {
 namespace relay {
 
+Array<Tensor> DebugCompute(const Attrs& attrs,
+                               const Array<Tensor>& inputs,
+                               const Type& out_type,
+                               const Target& target) {
+  return Array<Tensor>{ topi::identity(inputs[0]) };
+}
+
 RELAY_REGISTER_OP("debug")
 .describe(R"code(Enter the interpreter's debugger.
 
 )code" TVM_ADD_FILELINE)
 .set_num_inputs(1)
-.add_argument("data", "Tuple", "The input list of tensors.")
+.add_argument("program", "Tuple", "The program to execute before debugging.")
 .set_support_level(1)
 .add_type_rel("Debug", IdentityRel)
-.set_attr<TNonComputational>("TNonComputational", true)
-.set_attr<TOpPattern>("TOpPattern", kInjective);
+.set_attr<TOpPattern>("TOpPattern", kInjective)
+.set_attr<FTVMCompute>("FTVMCompute", DebugCompute);
 
 Expr MakeDebug(Expr expr, std::string name) {
   auto dattrs = make_node<DebugAttrs>();

--- a/tests/python/relay/test_debug.py
+++ b/tests/python/relay/test_debug.py
@@ -2,13 +2,16 @@ from tvm.relay import var, const, create_executor
 from tvm.relay.op import debug
 
 
+_test_debug_hit = False
+
 def test_debug():
+    global _test_debug_hit
     exec = create_executor()
     x = var('x', shape=(), dtype='int32')
-    hit = False
+    _test_debug_hit = False
     def did_exec(x):
-        global hit
-        hit = True
+        global _test_debug_hit
+        _test_debug_hit = True
     prog = debug(x, debug_func=did_exec)
     exec.evaluate(prog, { x: const(1) })
-    assert hit
+    assert _test_debug_hit

--- a/tests/python/relay/test_debug.py
+++ b/tests/python/relay/test_debug.py
@@ -1,0 +1,14 @@
+from tvm.relay import var, const, create_executor
+from tvm.relay.op import debug
+
+
+def test_debug():
+    exec = create_executor()
+    x = var('x', shape=(), dtype='int32')
+    hit = False
+    def did_exec(x):
+        global hit
+        hit = True
+    prog = debug(x, debug_func=did_exec)
+    exec.evaluate(prog, { x: const(1) })
+    assert hit

--- a/tests/python/relay/test_debug.py
+++ b/tests/python/relay/test_debug.py
@@ -13,5 +13,6 @@ def test_debug():
         global _test_debug_hit
         _test_debug_hit = True
     prog = debug(x, debug_func=did_exec)
-    exec.evaluate(prog, { x: const(1) })
+    result = exec.evaluate(prog, { x: const(1) })
     assert _test_debug_hit
+    assert result.asnumpy() == 1

--- a/tests/python/relay/test_debug.py
+++ b/tests/python/relay/test_debug.py
@@ -16,3 +16,17 @@ def test_debug():
     result = exec.evaluate(prog, { x: const(1) })
     assert _test_debug_hit
     assert result.asnumpy() == 1
+
+def test_debug_with_expr():
+    global _test_debug_hit
+    _test_debug_hit = False
+    exec = create_executor()
+    x = var('x', shape=(), dtype='int32')
+    _test_debug_hit = False
+    def did_exec(x):
+        global _test_debug_hit
+        _test_debug_hit = True
+    prog = debug(x + x * x, debug_func=did_exec)
+    result = exec.evaluate(prog, { x: const(2) })
+    assert _test_debug_hit
+    assert result.asnumpy() == 6

--- a/tests/python/relay/test_debug.py
+++ b/tests/python/relay/test_debug.py
@@ -6,27 +6,27 @@ _test_debug_hit = False
 
 def test_debug():
     global _test_debug_hit
-    exec = create_executor()
+    ex = create_executor()
     x = var('x', shape=(), dtype='int32')
     _test_debug_hit = False
     def did_exec(x):
         global _test_debug_hit
         _test_debug_hit = True
     prog = debug(x, debug_func=did_exec)
-    result = exec.evaluate(prog, { x: const(1) })
+    result = ex.evaluate(prog, { x: const(1) })
     assert _test_debug_hit
     assert result.asnumpy() == 1
 
 def test_debug_with_expr():
     global _test_debug_hit
     _test_debug_hit = False
-    exec = create_executor()
+    ex = create_executor()
     x = var('x', shape=(), dtype='int32')
     _test_debug_hit = False
     def did_exec(x):
         global _test_debug_hit
         _test_debug_hit = True
     prog = debug(x + x * x, debug_func=did_exec)
-    result = exec.evaluate(prog, { x: const(2) })
+    result = ex.evaluate(prog, { x: const(2) })
     assert _test_debug_hit
     assert result.asnumpy() == 6


### PR DESCRIPTION
This PR adds an operator `debug` (i.e `debug<T>(t) : T`), which triggers the interpreter's debugger. The function is an identity function which pauses execution with the ability to inspect the current expression (the argument to debug) as well as the evaluation stack. 

I will add a little more support for visualizing the execution and stepping through execution. 

cc @ZihengJiang 
