### PR TITLE
[TOPHUB] Add vulkan to PACKAGE VERSION

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -39,6 +39,7 @@ def _alias(name):
         'vtacpu': 'vta',
 
         'metal': 'opencl',
+        'vulkan': 'opencl',
         'nvptx': 'cuda',
     }
     return table.get(name, name)


### PR DESCRIPTION
The test_lang_tensor_overload_op.py fails when device is vulkan.
```
Traceback (most recent call last):
 14   File "tests/python/unittest/test_lang_tensor_overload_op.py", line 250, in <module>
 15     test_conv2d_scalar_bop()
 16   File "tests/python/unittest/test_lang_tensor_overload_op.py", line 239, in test_conv2d_scalar_bop
 17     verify_conv2d_scalar_bop(1, 16, 4, 4, 3, 1, 1, typ="add")
 18   File "tests/python/unittest/test_lang_tensor_overload_op.py", line 220, in verify_conv2d_scalar_bop
 19     check_device(device)
 20   File "tests/python/unittest/test_lang_tensor_overload_op.py", line 193, in check_device
 21     s = topi.generic.schedule_conv2d_nchw([C])
 22   File "<decorator-gen-41>", line 2, in schedule_conv2d_nchw
 23   File "/tvm/python/tvm/target.py", line 356, in dispatch_func
 24     return dispatch_dict[k](*args, **kwargs)
 25   File "<decorator-gen-85>", line 2, in config_dispatcher
 26   File "tvm/python/tvm/autotvm/task/dispatcher.py", line 199, in dispatch_func
 27     return dispatch_dict['direct'](cfg, *args, **kwargs)
 28   File "/tvm/python/tvm/autotvm/task/topi_integration.py", line 183, in template_call
 29     return f(cfg, outs, *args, **kwargs)
 30   File "/tvm/topi/python/topi/cuda/conv2d.py", line 136, in schedule_conv2d_nchw_cuda
 31     traverse_inline(s, outs[0].op, _callback)
 32   File "/tvm/topi/python/topi/util.py", line 35, in traverse_inline
 33     _traverse(final_op)
 34   File "/tvm/topi/python/topi/util.py", line 32, in _traverse
 35     _traverse(tensor.op)
 36   File "/tvm/topi/python/topi/util.py", line 33, in _traverse
 37     callback(op)
 38   File "/tvm/topi/python/topi/cuda/conv2d.py", line 130, in _callback
 39     schedule_direct_cuda(cfg, s, op.output(0))
 40   File "/tvm/topi/python/topi/cuda/conv2d_direct.py", line 30, in schedule_direct_cuda
 41     target.target_name, target.model, 'conv2d', 'direct')
 42   File "/tvm/python/tvm/autotvm/tophub.py", line 162, in load_reference_log
 43     version = PACKAGE_VERSION[backend]
 44 KeyError: 'vulkan'
```

I'm not sure that the cuda directory is the right place to generate a scheduler for vulkan, but since scheduler for rocm is in the same directory, I've just added vulkan version to packet version to fix the error.
