### PR TITLE
Fix missing sigmoid intrinsic in C++

### DIFF
--- a/python/tvm/intrin.py
+++ b/python/tvm/intrin.py
@@ -492,6 +492,3 @@ def _rule_float_direct(op):
 register_intrin_rule("opencl", "exp", _rule_float_direct, override=True)
 # default pattern for exp
 register_intrin_rule("default", "exp", _rule_float_suffix, override=True)
-
-# default pattern for sigmoid
-register_intrin_rule("default", "sigmoid", lambda op: 1.0 / (1.0 + exp(-op.args[0])))

--- a/src/codegen/intrin_rule.cc
+++ b/src/codegen/intrin_rule.cc
@@ -24,6 +24,16 @@ TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.sqrt")
 TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.pow")
 .set_body(DispatchExtern<FloatSuffix>);
 
+TVM_REGISTER_GLOBAL("tvm.intrin.rule.default.sigmoid")
+.set_body([](const TVMArgs& args, TVMRetValue* rv){
+    Expr e = args[0];
+    const Call* call = e.as<Call>();
+    CHECK(call != nullptr);
+
+    auto one = make_const(call->args[0].type(), 1);
+    *rv = one / (one + exp(-call->args[0]));
+  });
+
 }  // namespace intrin
 }  // namespace codegen
 }  // namespace tvm


### PR DESCRIPTION
This PR solves missing sigmoid intrinsic problem, visible when running C++ program, e.g. [1]. Python code is not affected because python libraries used to register their own fallback as follows:

https://github.com/dmlc/tvm/blob/master/python/tvm/intrin.py#L497

We solve the problem by moving default intrinsic from Python to C++

[1] - https://gist.github.com/grwlf/fafa70cde68cfc33b11c36bd20b3e6f0 failed program
