### PR TITLE
[COMMUNITY] @masahi -> Committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ We do encourage everyone to work anything they are interested in.
 - [Leyuan Wang](https://github.com/Laurawly): @Laurawly: - topi
 - [Nick Hynes](https://github.com/nhynes): @nhynes: - sgx, rust
 - [Lianmin Zheng](https://github.com/merrymercy): @merrymercy - autotvm, topi
+- [Masahiro Masuda](https://github.com/masahi): @masahi - topi, relay
 
 ## Reviewers
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,15 +14,15 @@ We do encourage everyone to work anything they are interested in.
 - [Aditya Atluri](https://github.com/adityaatluri): @adityaatluri - rocm
 - [Tianqi Chen](https://github.com/tqchen) (PMC): @tqchen - topi, compiler, relay, docs
 - [Yuwei Hu](https://github.com/Huyuwei): @Huyuwei - topi, frontends
-- [Yizhi Liu](https://github.com/yzhliu) (PMC): @yzhliu - jvm, topi, relay
+- [Nick Hynes](https://github.com/nhynes): @nhynes: - sgx, rust
 - [Ziheng Jiang](https://github.com/ZihengJiang) (PMC): @ZihengJiang - relay, compiler
+- [Yizhi Liu](https://github.com/yzhliu) (PMC): @yzhliu - jvm, topi, relay
+- [Masahiro Masuda](https://github.com/masahi): @masahi - topi, relay
 - [Thierry Moreau](https://github.com/tmoreau89) (PMC): @tmoreau89 - vta
 - [Haichen Shen](https://github.com/icemelon9) (PMC): @icemelon9 - relay, topi
 - [Zhixun Tan](https://github.com/phisiart): @phisiart - opengl, web
 - [Leyuan Wang](https://github.com/Laurawly): @Laurawly: - topi
-- [Nick Hynes](https://github.com/nhynes): @nhynes: - sgx, rust
 - [Lianmin Zheng](https://github.com/merrymercy): @merrymercy - autotvm, topi
-- [Masahiro Masuda](https://github.com/masahi): @masahi - topi, relay
 
 ## Reviewers
 


### PR DESCRIPTION
This PR  adds @masahi as a committer of TVM.

Masahiro has contributed a lot to operator improvement for several backend, including x86, cuda, etc, as well as NNVM/Relay pass enhancement (e.g., fusion). He also behaves actively on code review, forum, blogposts and public talks, help both experienced developers and beginners.

Commits:
https://github.com/dmlc/tvm/commits?author=masahi

Code Review:
https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by%3Amasahi

Forum:
https://discuss.tvm.ai/u/masahi/activity