### PR TITLE
add c backend to CreateTarget

### DIFF
--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -58,7 +58,7 @@ Target CreateTarget(const std::string& target_name,
   }
   t->device_type = kDLCPU;
   t->thread_warp_size = 1;
-  if (target_name == "llvm") {
+  if (target_name == "c" || target_name == "llvm") {
     t->keys_array.push_back(ir::StringImm::make("cpu"));
   } else if (target_name == "cuda" || target_name == "nvptx") {
     t->device_type = kDLGPU;


### PR DESCRIPTION
add c backend to CreateTarget to disable the error "Unknown target name c".

How could I add a test case to prove the error log has gone?
