### PR TITLE
correct mistake in muladd function logic

### DIFF
--- a/docs/dev/relay_intro.rst
+++ b/docs/dev/relay_intro.rst
@@ -54,7 +54,7 @@ shows an example of a function calling another function.
 
    def @muladd(%x, %y, %z) {
      %1 = mul(%x, %y)
-     %2 = add(%x, %z)
+     %2 = add(%1, %z)
      %2
    }
    def @myfunc(%x) {


### PR DESCRIPTION
Doesn't make sense to have %1 = mul(%x, %y) computed but never use the result %1

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
