### PR TITLE
[AUTOTVM] Use range in AnnotateSpace to fix JSON serialization

### DIFF
--- a/python/tvm/autotvm/task/space.py
+++ b/python/tvm/autotvm/task/space.py
@@ -423,7 +423,7 @@ class AnnotateSpace(TransformSpace):
         elif policy == 'locate_cache':
             self.num_axis = len(axes)
             num_anchor = kwargs["num_anchor"]
-            self.anns = list(itertools.combinations(np.arange(self.num_axis), num_anchor))
+            self.anns = list(itertools.combinations(range(self.num_axis), num_anchor))
             self.entities = [AnnotateEntity(x) for x in self.anns]
         else:  # none, vec, unroll, try_vec, try_unroll, try_vec_unroll, ...
             anns = policy.replace('try', 'none').split('_')


### PR DESCRIPTION
It throws an error in https://github.com/dmlc/tvm/blob/df9d3ad299d550e0f42504fedc149866a87e1c0b/python/tvm/autotvm/record.py#L85 if data is numpy.int64.

related Python issue https://bugs.python.org/issue24313

cc @merrymercy 