### PR TITLE
[PASS] Avoid recursion in FoldScaleAxis

### DIFF
--- a/src/relay/pass/pass_util.h
+++ b/src/relay/pass/pass_util.h
@@ -22,6 +22,15 @@ namespace relay {
 std::unordered_map<const Node*, size_t>
 GetExprRefCount(const Expr& body);
 
+
+/*!
+ * \brief Check if expr is positive constant.
+ * \param expr The expression to be checked.
+ * \return Whether all elements of expr is positive constant.
+ */
+bool IsAllPositiveConstant(const Expr& expr);
+
+
 /*!
  * \brief Substitute var with subst.
  * \param type The type to be substituted.

--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -190,57 +190,6 @@ Expr MakeConcatenate(Expr data, int axis);
 
 Expr MakeStridedSlice(Expr data, Array<Integer> begin, Array<Integer> end, Array<Integer> strides);
 
-
-template <typename T>
-bool IsNDArrayAllGreaterEqual(const runtime::NDArray& tensor, T value) {
-  CHECK_EQ(tensor->ctx.device_type, kDLCPU);
-  CHECK(tensor->strides == nullptr);
-  CHECK_EQ(tensor->byte_offset, 0);
-  const T* data = static_cast<const T*>(tensor->data);
-  int64_t num_elems = 1;
-  for (int i = 0; i < tensor->ndim; ++i) {
-    num_elems *= tensor->shape[i];
-  }
-
-  for (int64_t i = 0; i < num_elems; i++) {
-    if (*data < value) {
-      return false;
-    }
-    data++;
-  }
-  return true;
-}
-
-
-inline bool IsPositiveConstant(const Expr& expr) {
-  const auto* constant = expr.as<ConstantNode>();
-  if (!constant) return false;
-  const auto& tensor = constant->data;
-  const auto& dtype = tensor->dtype;
-
-  if (dtype.lanes != 1) {
-    // pass
-  } else if (dtype.code == kDLFloat && dtype.bits == 32) {
-    return IsNDArrayAllGreaterEqual<float>(tensor, 0);
-  } else if (dtype.code == kDLFloat && dtype.bits == 64) {
-    return IsNDArrayAllGreaterEqual<double>(tensor, 0);
-  } else if (dtype.code == kDLInt && dtype.bits == 8) {
-    return IsNDArrayAllGreaterEqual<int8_t>(tensor, 0);
-  } else if (dtype.code == kDLInt && dtype.bits == 32) {
-    return IsNDArrayAllGreaterEqual<int32_t>(tensor, 0);
-  } else if (dtype.code == kDLUInt && dtype.bits == 8) {
-    return IsNDArrayAllGreaterEqual<uint8_t>(tensor, 0);
-  } else if (dtype.code == kDLUInt && dtype.bits == 32) {
-    return IsNDArrayAllGreaterEqual<uint32_t>(tensor, 0);
-  }
-
-  LOG(WARNING) << "Unsupported data type (code = " << dtype.code
-               << ", bits = " << dtype.bits << ", lanes = " << dtype.lanes
-               << ")";
-  return false;
-}
-
-
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_PASS_PATTERN_UTIL_H_


### PR DESCRIPTION
The previous pass relies on recursion to check relu and other things and it slows things down as reported by @jroesch . Modifies the pass to only fold when the constant is positive and don't do folding at all it is not.

cc @vinx13 