### PR TITLE
[DOC] add relay and autotvm in readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,12 +5,14 @@ There can be internal header files within each module that sit in src.
 
 ## Modules
 - common: Internal common utilities.
-- api: API function registration
-- lang: The definition of DSL related data structure
-- arithmetic: Arithmetic expression and set simplification
-- op: The detail implementations about each operation(compute, scan, placeholder)
+- api: API function registration.
+- lang: The definition of DSL related data structure.
+- arithmetic: Arithmetic expression and set simplification.
+- op: The detail implementations about each operation(compute, scan, placeholder).
 - schedule: The operations on the schedule graph before converting to IR.
-- pass: The optimization pass on the IR structure
+- pass: The optimization pass on the IR structure.
 - codegen: The code generator.
-- runtime: Minimum runtime related codes
-- contrib: Contrib extension libraries
+- runtime: Minimum runtime related codes.
+- autotvm: The auto-tuning module.
+- relay: Implementation of Relay. The second generation of NNVM, a new IR for deep learning frameworks.
+- contrib: Contrib extension libraries.


### PR DESCRIPTION
Add brief description for relay and autotvm  in the src/README.md.