### PR TITLE
[ROCM] Make sure all bit code files exist

### DIFF
--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -1,6 +1,6 @@
 """Utility for ROCm backend"""
 import subprocess
-from os.path import join
+from os.path import join, exists
 from . import util
 from .._ffi.base import py_str
 from ..api import register_func, convert
@@ -79,4 +79,5 @@ def callback_rocm_bitcode_path(rocdl_dir="/opt/rocm/lib/"):
         "oclc_unsafe_math_off.amdgcn.bc",
         "oclc_unsafe_math_on.amdgcn.bc"
     ]
-    return convert([join(rocdl_dir, bitcode) for bitcode in bitcode_files])
+    paths = [join(rocdl_dir, bitcode) for bitcode in bitcode_files]
+    return convert([path for path in paths if exists(path)])


### PR DESCRIPTION
ROCm 2.0 apparently removed one of the bit code files we link against (irif.amdgcn.bc, see [here](https://github.com/RadeonOpenCompute/ROCm-Device-Libs/commit/b4ccf2cb36870ad2e45ac95e5499705668ea4426)). Without this PR, we get segfault if we try to use the rocm backend on ROCm 2.0. Took me some time to figure out where the segfault was coming from.

@eqy please review.