### PR TITLE
[DOCS] typo "@func myfunc" => "func @myfunc"

### DIFF
--- a/docs/dev/relay_intro.rst
+++ b/docs/dev/relay_intro.rst
@@ -75,7 +75,7 @@ GlobalVar decouples the definition/declaration and enables recursion and delayed
 
 .. code ::
 
-  @def myfunc(%x) {
+  def @myfunc(%x) {
     %1 = equal(%x, 1)
      if (%1) {
         %x


### PR DESCRIPTION
typo "@func myfunc" => "func @myfunc"
