### PR TITLE
[NNVM] Fix dtype of output of mean.

### DIFF
--- a/nnvm/src/top/tensor/reduce.cc
+++ b/nnvm/src/top/tensor/reduce.cc
@@ -352,7 +352,7 @@ Example::
 
     Expr count = make_const(inputs[0]->dtype, 1);
     for (auto& i : r_axes) {
-      count *= inputs[0]->shape[i];
+      count *= cast(inputs[0]->dtype, inputs[0]->shape[i]);
     }
 
     return Array<Tensor>{


### PR DESCRIPTION
  dtype of count is the same as dtype of inputs[0] when created, but its type may
  change when multiplied by inputs[0]->shape[i]. Which causes dtype of
  output is not same as dtype of input.
