### PR TITLE
Add Reference to Background Materials in Deep Learning

### DIFF
--- a/tutorials/README.txt
+++ b/tutorials/README.txt
@@ -1,3 +1,3 @@
 Tutorials
 =========
-This page contains the tutorials about TVM. If you are new to deep learning, please refer to `Dive into Deep Learning <http://diveintodeeplearning.org>`__.
+This page contains the tutorials about TVM. For background knowledge of deep learning, please refer to the open source book `Dive into Deep Learning <http://diveintodeeplearning.org>`__.

--- a/tutorials/README.txt
+++ b/tutorials/README.txt
@@ -1,3 +1,3 @@
 Tutorials
 =========
-This page contains the tutorials about TVM.
+This page contains the tutorials about TVM. If you are new to deep learning, please refer to `Dive into Deep Learning <http://diveintodeeplearning.org>`__.

--- a/tutorials/README.txt
+++ b/tutorials/README.txt
@@ -1,3 +1,3 @@
 Tutorials
 =========
-This page contains the tutorials about TVM. For background knowledge of deep learning, please refer to the open source book `Dive into Deep Learning <http://diveintodeeplearning.org>`__.
+This page contains the tutorials about TVM. For background knowledge of deep learning, please refer to the interactive book `Dive into Deep Learning <https://d2i.ai>`__, the `Deep Learning book <http://www.deeplearningbook.org/>`__, or `Stanford CS231n course <http://cs231n.stanford.edu/>`__.


### PR DESCRIPTION
Dive into Deep Learning (D2L) encourages DL beginners to refer to TVM if they are interested in frontiers in DL such as DL compiler:

https://github.com/diveintodeeplearning/d2l-zh/blob/master/README.md
https://github.com/diveintodeeplearning/d2l-en/blob/master/README.md

Some contents in the TVM tutorials may implicitly assumes that readers know DL: in case that they don't, they may benefit from D2L.