### PR TITLE
[TOPI, CUDA] Update cuda softmax schedule for spatial inputs

### DIFF
--- a/topi/tests/python/test_topi_softmax.py
+++ b/topi/tests/python/test_topi_softmax.py
@@ -9,6 +9,21 @@ from topi.util import get_const_tuple
 
 from common import get_all_backend
 
+def check_device(A, B, a_np, b_np, device, name):
+    ctx = tvm.context(device, 0)
+    if not ctx.exist:
+        print("Skip because %s is not enabled" % device)
+        return
+    print("Running on target: %s" % device)
+    with tvm.target.create(device):
+        s = topi.generic.schedule_softmax(B)
+
+    a = tvm.nd.array(a_np, ctx)
+    b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), ctx)
+    f = tvm.build(s, [A, B], device, name="softmax")
+    f(a, b)
+    tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
+
 def verify_softmax(m, n, dtype="float32"):
     A = tvm.placeholder((m, n), dtype=dtype, name='A')
     B = topi.nn.softmax(A)
@@ -19,28 +34,26 @@ def verify_softmax(m, n, dtype="float32"):
     a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
     b_np = topi.testing.softmax_python(a_np)
 
-    def check_device(device):
-        ctx = tvm.context(device, 0)
-        if not ctx.exist:
-            print("Skip because %s is not enabled" % device)
-            return
-        print("Running on target: %s" % device)
-        with tvm.target.create(device):
-            s = topi.generic.schedule_softmax(B)
+    for device in ['cuda', 'opencl', 'metal', 'rocm', 'vulkan', 'nvptx']:
+        check_device(A, B, a_np, b_np, device, "softmax")
 
-        a = tvm.nd.array(a_np, ctx)
-        b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), ctx)
-        foo = tvm.build(s, [A, B], device, name="softmax")
-        foo(a, b)
-        tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
+def verify_softmax_4d(shape, dtype="float32"):
+    A = tvm.placeholder(shape, dtype=dtype, name='A')
+    B = topi.nn.softmax(A, axis=1)
+
+    _, c, h, w = shape
+    a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
+    b_np = topi.testing.softmax_python(a_np.transpose(0, 2, 3, 1).reshape(h*w, c))
+    b_np = b_np.reshape(1, h, w, c).transpose(0, 3, 1, 2)
 
     for device in ['cuda', 'opencl', 'metal', 'rocm', 'vulkan', 'nvptx']:
-        check_device(device)
+        check_device(A, B, a_np, b_np, device, "softmax")
 
 def test_softmax():
     verify_softmax(32, 10)
     verify_softmax(3, 4)
     verify_softmax(32, 10, "float64")
+    verify_softmax_4d((1, 16, 256, 256))
 
 def verify_log_softmax(m, n, dtype="float32"):
     A = tvm.placeholder((m, n), dtype=dtype, name='A')
@@ -51,22 +64,8 @@ def verify_log_softmax(m, n, dtype="float32"):
     a_np = np.random.uniform(size=get_const_tuple(A.shape)).astype(A.dtype)
     b_np = topi.testing.log_softmax_python(a_np)
 
-    def check_device(device):
-        ctx = tvm.context(device, 0)
-        if not ctx.exist:
-            print("Skip because %s is not enabled" % device)
-            return
-        print("Running on target: %s" % device)
-        with tvm.target.create(device):
-            s = topi.generic.schedule_softmax(B)
-        a = tvm.nd.array(a_np, ctx)
-        b = tvm.nd.array(np.zeros(get_const_tuple(B.shape), dtype=B.dtype), ctx)
-        foo = tvm.build(s, [A, B], device, name="log_softmax")
-        foo(a, b)
-        tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5)
-
     for device in get_all_backend():
-        check_device(device)
+        check_device(A, B, a_np, b_np, device, "log_softmax")
 
 
 def test_log_softmax():


### PR DESCRIPTION
As pointed out in https://discuss.tvm.ai/t/softmax-is-really-slow/1365/4,

The current cuda softmax schedule is hard coded for 2D inputs (after fully connected layer), so it is super slow on spatial inputs (image segmentation, object detection etc). For (1, 16, 256, 256) input, it generates the following schedule.


```
// attr [compute] storage_scope = "global"
allocate compute[float32 * 1 * 256 * 256]
// attr [compute] storage_scope = "global"
allocate compute[float32 * 1 * 256 * 256]
produce compute {
  // attr [iter_var(blockIdx.x, , blockIdx.x)] thread_extent = 1
  for (i1, 0, 256) {
    for (i2, 0, 256) {
      compute[((i1*256) + i2)] = -340282346638528859811704183484516925440.000000f
      for (k, 0, 16) {
        compute[((i1*256) + i2)] = max(compute[((i1*256) + i2)], A[(((i1*256) + i2) + (k*65536))])
      }
    }
  }
}
produce compute {
  // attr [iter_var(blockIdx.x, , blockIdx.x)] thread_extent = 1
  // attr [compute.rf] storage_scope = "local"
  allocate compute.rf[float32 * 1 * 1 * 1 * 1]
  // attr [reduce_temp0] storage_scope = "local"
  allocate reduce_temp0[float32 * 1]
  for (ax1, 0, 256) {
    for (ax2, 0, 256) {
      // attr [iter_var(threadIdx.x, Range(min=0, extent=64), threadIdx.x)] thread_extent = 64
      produce compute.rf {
        compute.rf[0] = 0.000000f
        if ((threadIdx.x < 16)) {
          compute.rf[0] = (compute.rf[0] + exp((A[(((ax1*256) + ax2) + (threadIdx.x*65536))] - compute[((ax1*256) + ax2)])))
        }
      }
      // attr [comm_reducer(result=[(x + y)], lhs=[x], rhs=[y], identity_element=[0.000000f])] reduce_scope = reinterpret((uint64)0)
      tvm_thread_allreduce((uint32)1, compute.rf[0], (uint1)1, reduce_temp0, threadIdx.x)
      if ((threadIdx.x == 0)) {
        compute[((ax1*256) + ax2)] = reduce_temp0[0]
      }
    }
  }
}
produce compute {
  // attr [iter_var(blockIdx.x, , blockIdx.x)] thread_extent = 1
  // attr [iter_var(threadIdx.x, Range(min=0, extent=64), threadIdx.x)] thread_extent = 64
  for (i2, 0, 256) {
    for (i3, 0, 256) {
      if (likely((threadIdx.x < 16))) {
        compute[(((i2 + (threadIdx.x*256))*256) + i3)] = (exp((A[(((i2 + (threadIdx.x*256))*256) + i3)] - compute[((i2*256) + i3)]))/compute[((i2*256) + i3)])
      }
    }
  }
}

```
I updated the softmax schedule so that it works well for 4D and 5D inputs. Since the number of classes is 
 typically small for these inputs, I simply use injective schedule (i.e., without using shared memory reduce).  Below is the updated schedule with this PR. @vinx13  @merrymercy @eqy please review.

```
// attr [compute] storage_scope = "global"
allocate compute[float32 * 1 * 256 * 256]
// attr [compute] storage_scope = "global"
allocate compute[float32 * 1 * 256 * 256]
produce compute {
  // attr [iter_var(blockIdx.x, , blockIdx.x)] thread_extent = 128
  // attr [iter_var(threadIdx.x, , threadIdx.x)] thread_extent = 512
  compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))] = -340282346638528859811704183484516925440.000000f
  for (k, 0, 16) {
    compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))] = max(compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))], A[(((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256)) + (k*65536))])
  }
}
produce compute {
  // attr [iter_var(blockIdx.x, , blockIdx.x)] thread_extent = 128
  // attr [iter_var(threadIdx.x, , threadIdx.x)] thread_extent = 512
  compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))] = 0.000000f
  for (k, 0, 16) {
    compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))] = (compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))] + exp((A[(((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256)) + (k*65536))] - compute[((((blockIdx.x*2) + (threadIdx.x/256))*256) + (threadIdx.x % 256))])))
  }
}
produce compute {
  // attr [iter_var(blockIdx.x, , blockIdx.x)] thread_extent = 256
  // attr [iter_var(threadIdx.x, , threadIdx.x)] thread_extent = 512
  for (i0.i1.fused.i2.fused.i3.fused.outer, 0, 8) {
    compute[((((((blockIdx.x*2) + (threadIdx.x/256))/256)*65536) + (((((blockIdx.x*2) + (threadIdx.x/256)) % 256)*256) + (threadIdx.x % 256))) + (i0.i1.fused.i2.fused.i3.fused.outer*131072))] = (exp((A[((((((blockIdx.x*2) + (threadIdx.x/256))/256)*65536) + (((((blockIdx.x*2) + (threadIdx.x/256)) % 256)*256) + (threadIdx.x % 256))) + (i0.i1.fused.i2.fused.i3.fused.outer*131072))] - compute[(((((blockIdx.x*2) + (threadIdx.x/256)) % 256)*256) + (threadIdx.x % 256))]))/compute[(((((blockIdx.x*2) + (threadIdx.x/256)) % 256)*256) + (threadIdx.x % 256))])
  }
}
```