### PR TITLE
[RELAY][Errors][WIP] Add descriptive errors for Relay

### DIFF
--- a/cmake/modules/ANTLR.cmake
+++ b/cmake/modules/ANTLR.cmake
@@ -1,6 +1,6 @@
 if(USE_ANTLR)
-  if(EXISTS /usr/local/lib/antlr-4.7.1-complete.jar)
-    set(ANTLR4 "/usr/local/lib/antlr-4.7.1-complete.jar")
+  if(EXISTS /usr/local/Cellar/antlr/4.7.1_1/antlr-4.7.1-complete.jar)
+    set(ANTLR4 "/usr/local/Cellar/antlr/4.7.1_1/antlr-4.7.1-complete.jar")
 
     set(RELAY_PARSER_DIR
       ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm/relay/grammar)

--- a/include/tvm/relay/base.h
+++ b/include/tvm/relay/base.h
@@ -108,7 +108,9 @@ class SourceName : public NodeRef {
    * \brief access the internal node container
    * \return the pointer to the internal node container
    */
-  inline const SourceNameNode* operator->() const;
+  inline const SourceNameNode* operator->() const {
+    return static_cast<SourceNameNode*>(this->node_.get());
+  }
 
   /*!
    * \brief Get an SourceName for a given operator name.

--- a/include/tvm/relay/error.h
+++ b/include/tvm/relay/error.h
@@ -8,11 +8,13 @@
 
 #include <string>
 #include "./base.h"
+#include "./source_map.h"
 
 namespace tvm {
 namespace relay {
 
 struct Error : public dmlc::Error {
+  Span sp;
   explicit Error(const std::string &msg) : dmlc::Error(msg) {}
 };
 
@@ -26,6 +28,18 @@ struct FatalTypeError : public Error {
 
 struct TypecheckerError : public Error {
   explicit TypecheckerError(const std::string &msg) : Error(msg) {}
+};
+
+class ErrorReporter {
+public:
+  SourceMap src_map;
+  std::vector<Error> errors;
+
+  void Report(const Error& err) {
+    this->errors.push_back(err);
+  }
+
+  dmlc::Error Render();
 };
 
 }  // namespace relay

--- a/include/tvm/relay/error.h
+++ b/include/tvm/relay/error.h
@@ -35,6 +35,9 @@ public:
   SourceMap src_map;
   std::vector<Error> errors;
 
+  ErrorReporter() : src_map(), errors() {}
+  ErrorReporter(SourceMap src_map) : errors() {}
+
   void Report(const Error& err) {
     this->errors.push_back(err);
   }

--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -43,11 +43,16 @@ class ModuleNode : public RelayNode {
   /*! \brief A map from ids to all global functions. */
   tvm::Map<GlobalVar, Function> functions;
 
+  mutable ErrorReporter err_reporter;
+
+  mutable  GlobalVar entry_func;
+
   ModuleNode() {}
 
   void VisitAttrs(tvm::AttrVisitor* v) final {
     v->Visit("functions", &functions);
     v->Visit("global_var_map_", &global_var_map_);
+    v->Visit("entry_func", &entry_func);
   }
 
   TVM_DLL static Module make(tvm::Map<GlobalVar, Function> global_funcs);
@@ -101,6 +106,12 @@ class ModuleNode : public RelayNode {
    * \param other The other environment.
    */
   void Update(const Module& other);
+
+  /*!
+   * \brief Get the entry point of the module.
+   *
+   */
+  Expr EntryPoint();
 
   static constexpr const char* _type_key = "relay.Module";
   TVM_DECLARE_NODE_TYPE_INFO(ModuleNode, Node);

--- a/include/tvm/relay/pass.h
+++ b/include/tvm/relay/pass.h
@@ -28,6 +28,7 @@ namespace relay {
  * \return A type checked expression with its checked_type field populated.
  */
 Expr InferType(const Expr& expr, const Module& mod);
+
 /*!
  * \brief Infer the type of a function as if it is mapped to var in the mod.
  *

--- a/include/tvm/relay/source_map.h
+++ b/include/tvm/relay/source_map.h
@@ -16,13 +16,13 @@ namespace tvm {
 namespace relay {
 
 struct SourceFragment {
-  std::string file_name;
+  SourceName name;
   std::vector<std::string> source_lines;
 
-  SourceFragment(std::string file_name, std::string source);
+  SourceFragment(const SourceName& file_name, const std::string& source);
 
   SourceFragment(const SourceFragment& sf) {
-    this->file_name = sf.file_name;
+    this->name = sf.name;
     this->source_lines = sf.source_lines;
   }
 
@@ -36,7 +36,8 @@ class SourceMap {
   std::unordered_map<SourceName, SourceFragment, NodeHash> map_;
  public:
   SourceMap() : map_() {}
-  SourceName AddSource(std::string file_name, std::string source);
+  SourceName AddSource(const std::string& file_name, const std::string& source);
+  SourceName AddSource(const SourceName& source_name, const std::string& source);
   const SourceFragment & GetSource(SourceName id) const;
 };
 

--- a/include/tvm/relay/source_map.h
+++ b/include/tvm/relay/source_map.h
@@ -7,6 +7,7 @@
 #ifndef TVM_RELAY_SOURCE_MAP_H_
 #define TVM_RELAY_SOURCE_MAP_H_
 
+#include <tvm/relay/base.h>
 #include <tvm/relay/expr.h>
 #include <string>
 #include <vector>

--- a/include/tvm/relay/source_map.h
+++ b/include/tvm/relay/source_map.h
@@ -1,0 +1,44 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file source_map.h
+ * \brief A representation of source files and a data structure for
+ * storing them.
+ */
+#ifndef TVM_RELAY_SOURCE_MAP_H_
+#define TVM_RELAY_SOURCE_MAP_H_
+
+#include <tvm/relay/expr.h>
+#include <string>
+#include <vector>
+
+namespace tvm {
+namespace relay {
+
+struct SourceFragment {
+  std::string file_name;
+  std::vector<std::string> source_lines;
+
+  SourceFragment(std::string file_name, std::string source);
+
+  SourceFragment(const SourceFragment& sf) {
+    this->file_name = sf.file_name;
+    this->source_lines = sf.source_lines;
+  }
+
+  std::string SourceAt(Span sp, int lines);
+};
+
+/*! \brief Maps from FileId's to a SourceFragment.
+ */
+class SourceMap {
+  /*! \brief Map from unique token to a fragment of a source file. */
+  std::unordered_map<SourceName, SourceFragment, NodeHash> map_;
+ public:
+  SourceMap() : map_() {}
+  SourceName AddSource(std::string file_name, std::string source);
+  const SourceFragment & GetSource(SourceName id) const;
+};
+
+}  // namespace relay
+}  // namespace tvm
+#endif  // TVM_RELAY_SOURCE_MAP_H_

--- a/include/tvm/relay/source_map.h
+++ b/include/tvm/relay/source_map.h
@@ -26,7 +26,7 @@ struct SourceFragment {
     this->source_lines = sf.source_lines;
   }
 
-  std::string SourceAt(Span sp, int lines);
+  std::vector<std::string> LinesAt(Span sp, int lines);
 };
 
 /*! \brief Maps from FileId's to a SourceFragment.

--- a/python/tvm/relay/_base.py
+++ b/python/tvm/relay/_base.py
@@ -1,0 +1,5 @@
+# pylint: disable=no-else-return, unidiomatic-typecheck, undefined-variable
+"""The interface of expr function exposed from C++."""
+from tvm._ffi.function import _init_api
+
+_init_api("relay._base", __name__)

--- a/python/tvm/relay/_parser.py
+++ b/python/tvm/relay/_parser.py
@@ -462,8 +462,13 @@ def fromtext(data, source_name=None):
     # type: (str, str) -> Union[expr.Expr, env.Environment]
     """Parse a Relay program."""
     global __source_name_counter__
+
     if source_name is None:
         source_name = "source_file{0}".format(__source_name_counter__)
-    source_name = SourceName(source_name)
+
+    if isinstance(source_name, str):
+        source_name = SourceName(source_name)
+
     tree = make_parser(data).prog()
+    import pdb; pdb.set_trace()
     return ParseTreeToRelayIR(source_name).visit(tree)

--- a/python/tvm/relay/_parser.py
+++ b/python/tvm/relay/_parser.py
@@ -430,6 +430,9 @@ class ParseTreeToRelayIR(RelayVisitor):
 
         return ty.FuncType(arg_types, ret_type, [], None)
 
+    def visitGraphExpr(self, ctx):
+        import pdb; pdb.set_trace()
+
 def make_parser(data):
     # type: (str) -> RelayParser
     """Construct a RelayParser a given data stream."""

--- a/python/tvm/relay/_parser.py
+++ b/python/tvm/relay/_parser.py
@@ -469,6 +469,7 @@ def fromtext(data, source_name=None):
     if isinstance(source_name, str):
         source_name = SourceName(source_name)
 
-    tree = make_parser(data).prog()
     import pdb; pdb.set_trace()
+    print(data)
+    tree = make_parser(data).prog()
     return ParseTreeToRelayIR(source_name).visit(tree)

--- a/python/tvm/relay/base.py
+++ b/python/tvm/relay/base.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import as _abs
 from .._ffi.node import NodeBase, register_node as _register_tvm_node
 from . import _make
 from . import _expr
+from . import _base
 
 NodeBase = NodeBase
 
@@ -63,6 +64,9 @@ class RelayNode(NodeBase):
         """
         return _expr.RelayPrint(self, show_meta_data, annotate)
 
+    def set_span(self, span):
+        _base.set_span(self, span)
+
 
 @register_relay_node
 class Span(RelayNode):
@@ -71,6 +75,12 @@ class Span(RelayNode):
     def __init__(self, source, lineno, col_offset):
         self.__init_handle_by_constructor__(_make.Span, source, lineno, col_offset)
 
+@register_relay_node
+class SourceName(RelayNode):
+    """A identifier for a source location"""
+
+    def __init__(self, name):
+        self.__init_handle_by_constructor__(_make.SourceName, name)
 
 @register_relay_node
 class Id(NodeBase):

--- a/python/tvm/relay/grammar/Relay.g4
+++ b/python/tvm/relay/grammar/Relay.g4
@@ -20,7 +20,7 @@ NE: '!=' ;
 
 opIdent: CNAME ;
 GLOBAL_VAR: '@' CNAME ;
-LOCAL_VAR: '%' CNAME ;
+LOCAL_VAR: '%' (CNAME | INT);
 
 MUT: 'mut' ;
 
@@ -83,6 +83,7 @@ expr
 
   | ident                                     # identExpr
   | scalar                                    # scalarExpr
+  | LOCAL_VAR '=' expr                        # graphExpr
   // | expr '.' INT                              # project
   // | 'debug'                                   # debug
   ;

--- a/python/tvm/relay/grammar/Relay.g4
+++ b/python/tvm/relay/grammar/Relay.g4
@@ -83,9 +83,9 @@ expr
 
   | ident                                     # identExpr
   | scalar                                    # scalarExpr
-  | LOCAL_VAR '=' expr                        # graphExpr
-  // | expr '.' INT                              # project
-  // | 'debug'                                   # debug
+  | LOCAL_VAR '=' expr ';' expr               # graphExpr
+  // | expr '.' INT                           # project
+  // | 'debug'                                # debug
   ;
 
 func: 'fn'        varList ('->' type_)? body ;
@@ -132,7 +132,7 @@ identType: CNAME ;
 // Float16, Float32, Float64
 // Bool
 
-body: '{' expr '}' ;
+body: '{' expr ';' '}' ;
 
 scalar
   : FLOAT    # scalarFloat

--- a/python/tvm/relay/parser.py
+++ b/python/tvm/relay/parser.py
@@ -1,5 +1,6 @@
 """A parser for Relay's text format."""
 from __future__ import absolute_import
+from .. import register_func
 
 def enabled():
     """Is the parser enabled/Can we import the parser?"""
@@ -11,7 +12,8 @@ def enabled():
     except Exception:
         return False
 
-def fromtext(data):
+@register_func("relay.fromtext")
+def fromtext(data, source_name=None):
     """Parse a Relay program."""
     from tvm.relay import _parser
-    return _parser.fromtext(data)
+    return _parser.fromtext(data, source_name)

--- a/src/relay/ir/base.cc
+++ b/src/relay/ir/base.cc
@@ -32,6 +32,11 @@ SourceName SourceName::Get(const std::string& name) {
   return SourceName(GetSourceNameNode(name));
 }
 
+TVM_REGISTER_API("relay._make.SourceName")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
+    *ret = SourceName::Get(args[0]);
+  });
+
 TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
 .set_dispatch<SourceNameNode>([](const SourceNameNode* node, tvm::IRPrinter* p) {
     p->stream << "SourceName(" << node->name << ", " << node << ")";
@@ -65,6 +70,15 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
   });
 
 TVM_REGISTER_NODE_TYPE(IdNode);
+
+TVM_REGISTER_API("relay._base.set_span")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
+    NodeRef node_ref = args[0];
+    auto rn = node_ref.as_derived<RelayNode>();
+    CHECK(rn);
+    Span sp = args[1];
+    rn->span = sp;
+});
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/ir/error.cc
+++ b/src/relay/ir/error.cc
@@ -1,0 +1,48 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file error.cc
+ * \brief Relay type inference and checking.
+ *
+ */
+
+#include <tvm/relay/error.h>
+#include "../util/rang.h"
+
+namespace tvm {
+namespace relay {
+
+dmlc::Error ErrorReporter::Render() {
+    for (auto err : this->errors) {
+      auto sp = err.sp;
+      CHECK(sp.defined()) << "while attempting to report an error its span was null";
+      auto source_file = this->src_map.GetSource(err.sp->source);
+      auto file_name = source_file.name->name;
+      auto lines = source_file.LinesAt(err.sp, 1);
+      std::string error_marker = "error:";
+      auto line_info =
+          std::to_string(sp->lineno) + ":" + std::to_string(sp->col_offset);
+
+      std::cout << rang::style::bold << rang::fg::red << error_marker
+                << rang::fg::reset << file_name << ":" << line_info
+                << rang::style::reset << " " << lines[0] << std::endl;
+
+      // Build the cursor.
+
+      // Fix this code, hardwired to compute alignment of pointer.
+      size_t spaces = error_marker.size() + line_info.size() + file_name.size() +
+                      sp->col_offset - 3;
+
+      std::string cursor = "~~~~^~~~~";
+      for (size_t i = 0; i < spaces; i++) {
+        std::cout << " ";
+      }
+
+      std::cout << rang::fg::red << cursor << " " << err.what() << rang::style::reset
+                << std::endl;
+    }
+    return dmlc::Error("print me");
+  }
+
+
+} // relay
+} // tvm

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -279,5 +279,13 @@ TVM_REGISTER_API("relay._expr.TempExprRealize")
 });
 
 
+TVM_REGISTER_API("relay._expr.set_span")
+.set_body([](TVMArgs args, TVMRetValue* ret) {
+    Expr e = args[0];
+    Span sp = args[1];
+    *ret = temp->Realize();
+});
+
+
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -279,12 +279,7 @@ TVM_REGISTER_API("relay._expr.TempExprRealize")
 });
 
 
-TVM_REGISTER_API("relay._expr.set_span")
-.set_body([](TVMArgs args, TVMRetValue* ret) {
-    Expr e = args[0];
-    Span sp = args[1];
-    *ret = temp->Realize();
-});
+
 
 
 }  // namespace relay

--- a/src/relay/ir/module.cc
+++ b/src/relay/ir/module.cc
@@ -91,6 +91,10 @@ void ModuleNode::Update(const Module& mod) {
   }
 }
 
+Expr ModuleNode::EntryPoint() {
+  return this->Lookup(this->entry_func);
+}
+
 TVM_REGISTER_NODE_TYPE(ModuleNode);
 
 TVM_REGISTER_API("relay._make.Module")

--- a/src/relay/ir/source_map.cc
+++ b/src/relay/ir/source_map.cc
@@ -4,8 +4,8 @@
  * \brief Source maps for Relay.
  */
 
-#include <tvm/relay/logging.h>
 #include <tvm/relay/source_map.h>
+#include <tvm/relay/logging.h>
 #include <iostream>
 
 namespace tvm {
@@ -51,7 +51,7 @@ std::string SourceFragment::SourceAt(Span sp, int max_lines) {
 }
 
 SourceName SourceMap::AddSource(std::string file_name, std::string source) {
-  auto new_id = SourceNameNode::make(file_name);
+  auto new_id = SourceName::Get(file_name);
   SourceFragment sfile(file_name, source);
   this->map_.insert({new_id, sfile});
   return new_id;

--- a/src/relay/ir/source_map.cc
+++ b/src/relay/ir/source_map.cc
@@ -1,0 +1,70 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file source_map.cc
+ * \brief Source maps for Relay.
+ */
+
+#include <tvm/relay/logging.h>
+#include <tvm/relay/source_map.h>
+#include <iostream>
+
+namespace tvm {
+namespace relay {
+
+using tvm::IRPrinter;
+using namespace tvm::runtime;
+
+SourceFragment::SourceFragment(std::string file_name, std::string source)
+    : file_name(file_name), source_lines({}) {
+  RELAY_LOG(INFO)<< "SourceFragment::SourceFragment source=" << source << std::endl;
+  std::stringstream source_stream;
+  source_stream.str(source.c_str());
+  std::string line;
+
+  while (std::getline(source_stream, line)) {
+    RELAY_LOG(INFO) << "SourceFragment::SourceFragment: line=" << line << std::endl;
+    std::string copy(line);
+    source_lines.push_back(copy);
+  }
+}
+
+std::string SourceFragment::SourceAt(Span sp, int max_lines) {
+  std::stringstream out;
+
+  // We need to move from 1 based indexing to zero based indexing.
+  int starting_line = sp->lineno;
+
+  if (starting_line >= static_cast<int>(this->source_lines.size())) {
+    throw dmlc::Error("SourceFragment: index out of bounds");
+  }
+
+  auto lines = std::max(static_cast<size_t>(max_lines), source_lines.size() - starting_line);
+
+  for (size_t i = 0; i < lines; i++) {
+    out << std::endl << this->source_lines.at(starting_line + i);
+  }
+
+  auto source_slice = out.str();
+
+  RELAY_LOG(INFO) << "SourceFragment::SourceAt: source_slice=" << source_slice << std::endl;
+  return source_slice;
+}
+
+SourceName SourceMap::AddSource(std::string file_name, std::string source) {
+  auto new_id = SourceNameNode::make(file_name);
+  SourceFragment sfile(file_name, source);
+  this->map_.insert({new_id, sfile});
+  return new_id;
+}
+
+const SourceFragment& SourceMap::GetSource(SourceName id) const {
+  auto item = map_.find(id);
+  if (item != map_.end()) {
+    return (*item).second;
+  } else {
+      throw dmlc::Error("could not find requested source fragment");
+  }
+}
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/ir/source_map.cc
+++ b/src/relay/ir/source_map.cc
@@ -28,9 +28,7 @@ SourceFragment::SourceFragment(const SourceName& name, const std::string& source
   }
 }
 
-std::string SourceFragment::SourceAt(Span sp, int max_lines) {
-  std::stringstream out;
-
+std::vector<std::string> SourceFragment::LinesAt(Span sp, int max_lines) {
   // We need to move from 1 based indexing to zero based indexing.
   int starting_line = sp->lineno;
 
@@ -38,16 +36,17 @@ std::string SourceFragment::SourceAt(Span sp, int max_lines) {
     throw dmlc::Error("SourceFragment: index out of bounds");
   }
 
-  auto lines = std::max(static_cast<size_t>(max_lines), source_lines.size() - starting_line);
+  auto num_of_lines =
+    std::max(static_cast<size_t>(max_lines),
+      source_lines.size() - starting_line);
 
-  for (size_t i = 0; i < lines; i++) {
-    out << std::endl << this->source_lines.at(starting_line + i);
+  std::vector<std::string> lines;
+  for (size_t i = 0; i < num_of_lines; i++) {
+    lines.push_back(this->source_lines.at(starting_line + i));
   }
 
-  auto source_slice = out.str();
-
-  RELAY_LOG(INFO) << "SourceFragment::SourceAt: source_slice=" << source_slice << std::endl;
-  return source_slice;
+  // RELAY_LOG(INFO) << "SourceFragment::SourceAt: source_slice=" << source_slice << std::endl;
+  return lines;
 }
 
 SourceName SourceMap::AddSource(const SourceName& source_name, const std::string& source) {

--- a/src/relay/ir/text_printer.cc
+++ b/src/relay/ir/text_printer.cc
@@ -287,7 +287,7 @@ class TextPrinter :
     std::ostringstream os;
     os << id << " = fn";
     this->PrintFuncInternal(os.str(), GetRef<Function>(op));
-    this->PrintEndInst("\n");
+    this->PrintEndInst(";\n");
     return id;
   }
 
@@ -325,7 +325,7 @@ class TextPrinter :
     }
     this->PrintCallAttrs(op->op, op->attrs, stream_);
     stream_ << ")";
-    this->PrintEndInst("");
+    this->PrintEndInst(";");
     this->PrintOptionalInfo(GetRef<Expr>(op));
     stream_ << '\n';
     return id;
@@ -336,7 +336,7 @@ class TextPrinter :
     this->PrintIndent();
     stream_ << id << " = ";
     this->PrintScope(GetRef<Expr>(op));
-    this->PrintEndInst("\n");
+    this->PrintEndInst(";\n");
     return id;
   }
 
@@ -345,7 +345,7 @@ class TextPrinter :
     this->PrintIndent();
     stream_ << id << " = ";
     this->PrintScope(GetRef<Expr>(op));
-    this->PrintEndInst("\n");
+    this->PrintEndInst(";\n");
     return id;
   }
 
@@ -358,7 +358,7 @@ class TextPrinter :
     TextValue id = this->AllocTempVar();
     this->PrintIndent();
     stream_ << id << " = " << tuple << "." << op->index << "";
-    this->PrintEndInst("\n");
+    this->PrintEndInst(";\n");
     return id;
   }
 
@@ -492,7 +492,7 @@ class TextPrinter :
       stream_ << "let ";
       this->PrintVarDecl(let->var, stream_);
       stream_ << " = " << value;
-      this->PrintEndInst("\n");
+      this->PrintEndInst(";\n");
       this->PrintScopeBody(let->body);
     } else if (const IfNode* ifnode = body.as<IfNode>()) {
       TextValue cond = GetValue(ifnode->cond);
@@ -507,7 +507,7 @@ class TextPrinter :
       TextValue value = GetValue(body);
       this->PrintIndent();
       stream_ << value;
-      this->PrintEndInst("\n");
+      this->PrintEndInst(";\n");
     }
   }
 

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -225,14 +225,14 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)> {
     return op->op_type;
   }
 
-  Type VisitExpr_(const LetNode* op) final {
-    Type vtype = GetType(op->value);
-    if (op->var->type_annotation.defined()) {
-      vtype = Unify(vtype, op->var->type_annotation, op->span);
+  Type VisitExpr_(const LetNode* let) final {
+    Type vtype = GetType(let->value);
+    if (let->var->type_annotation.defined()) {
+      vtype = Unify(vtype, let->var->type_annotation, let->span);
     }
-    CHECK(!type_map_.count(op->var));
+    CHECK(!type_map_.count(let->var));
     // NOTE: no scoping is necessary because var are unique in program
-    type_map_[op->var].checked_type = vtype;
+    type_map_[let->var].checked_type = vtype;
     return GetType(op->body);
   }
 

--- a/src/relay/util/rang.h
+++ b/src/relay/util/rang.h
@@ -1,0 +1,503 @@
+// This code is a header only library, which can be found here: https://github.com/agauniyal/rang.
+#ifndef RANG_DOT_HPP
+#define RANG_DOT_HPP
+
+#if defined(__unix__) || defined(__unix) || defined(__linux__)
+#define OS_LINUX
+#elif defined(WIN32) || defined(_WIN32) || defined(_WIN64)
+#define OS_WIN
+#elif defined(__APPLE__) || defined(__MACH__)
+#define OS_MAC
+#else
+#error Unknown Platform
+#endif
+
+#if defined(OS_LINUX) || defined(OS_MAC)
+#include <unistd.h>
+
+#elif defined(OS_WIN)
+
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x0600)
+#error                                                                         \
+  "Please include rang.hpp before any windows system headers or set _WIN32_WINNT at least to _WIN32_WINNT_VISTA"
+#elif !defined(_WIN32_WINNT)
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#endif
+
+#include <windows.h>
+#include <io.h>
+#include <memory>
+
+// Only defined in windows 10 onwards, redefining in lower windows since it
+// doesn't gets used in lower versions
+// https://docs.microsoft.com/en-us/windows/console/getconsolemode
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
+#endif
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+namespace rang {
+
+/* For better compability with most of terminals do not use any style settings
+ * except of reset, bold and reversed.
+ * Note that on Windows terminals bold style is same as fgB color.
+ */
+enum class style {
+    reset     = 0,
+    bold      = 1,
+    dim       = 2,
+    italic    = 3,
+    underline = 4,
+    blink     = 5,
+    rblink    = 6,
+    reversed  = 7,
+    conceal   = 8,
+    crossed   = 9
+};
+
+enum class fg {
+    black   = 30,
+    red     = 31,
+    green   = 32,
+    yellow  = 33,
+    blue    = 34,
+    magenta = 35,
+    cyan    = 36,
+    gray    = 37,
+    reset   = 39
+};
+
+enum class bg {
+    black   = 40,
+    red     = 41,
+    green   = 42,
+    yellow  = 43,
+    blue    = 44,
+    magenta = 45,
+    cyan    = 46,
+    gray    = 47,
+    reset   = 49
+};
+
+enum class fgB {
+    black   = 90,
+    red     = 91,
+    green   = 92,
+    yellow  = 93,
+    blue    = 94,
+    magenta = 95,
+    cyan    = 96,
+    gray    = 97
+};
+
+enum class bgB {
+    black   = 100,
+    red     = 101,
+    green   = 102,
+    yellow  = 103,
+    blue    = 104,
+    magenta = 105,
+    cyan    = 106,
+    gray    = 107
+};
+
+enum class control {  // Behaviour of rang function calls
+    Off   = 0,  // toggle off rang style/color calls
+    Auto  = 1,  // (Default) autodect terminal and colorize if needed
+    Force = 2  // force ansi color output to non terminal streams
+};
+// Use rang::setControlMode to set rang control mode
+
+enum class winTerm {  // Windows Terminal Mode
+    Auto   = 0,  // (Default) automatically detects wheter Ansi or Native API
+    Ansi   = 1,  // Force use Ansi API
+    Native = 2  // Force use Native API
+};
+// Use rang::setWinTermMode to explicitly set terminal API for Windows
+// Calling rang::setWinTermMode have no effect on other OS
+
+namespace rang_implementation {
+
+    inline std::atomic<control> &controlMode() noexcept
+    {
+        static std::atomic<control> value(control::Auto);
+        return value;
+    }
+
+    inline std::atomic<winTerm> &winTermMode() noexcept
+    {
+        static std::atomic<winTerm> termMode(winTerm::Auto);
+        return termMode;
+    }
+
+    inline bool supportsColor() noexcept
+    {
+#if defined(OS_LINUX) || defined(OS_MAC)
+
+        static const bool result = [] {
+            const char *Terms[]
+              = { "ansi",    "color",  "console", "cygwin", "gnome",
+                  "konsole", "kterm",  "linux",   "msys",   "putty",
+                  "rxvt",    "screen", "vt100",   "xterm" };
+
+            const char *env_p = std::getenv("TERM");
+            if (env_p == nullptr) {
+                return false;
+            }
+            return std::any_of(std::begin(Terms), std::end(Terms),
+                               [&](const char *term) {
+                                   return std::strstr(env_p, term) != nullptr;
+                               });
+        }();
+
+#elif defined(OS_WIN)
+        // All windows versions support colors through native console methods
+        static constexpr bool result = true;
+#endif
+        return result;
+    }
+
+#ifdef OS_WIN
+
+
+    inline bool isMsysPty(int fd) noexcept
+    {
+        // Dynamic load for binary compability with old Windows
+        const auto ptrGetFileInformationByHandleEx
+          = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(
+            GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
+                           "GetFileInformationByHandleEx"));
+        if (!ptrGetFileInformationByHandleEx) {
+            return false;
+        }
+
+        HANDLE h = reinterpret_cast<HANDLE>(_get_osfhandle(fd));
+        if (h == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+
+        // Check that it's a pipe:
+        if (GetFileType(h) != FILE_TYPE_PIPE) {
+            return false;
+        }
+
+        // POD type is binary compatible with FILE_NAME_INFO from WinBase.h
+        // It have the same alignment and used to avoid UB in caller code
+        struct MY_FILE_NAME_INFO {
+            DWORD FileNameLength;
+            WCHAR FileName[MAX_PATH];
+        };
+
+        auto pNameInfo = std::unique_ptr<MY_FILE_NAME_INFO>(
+          new (std::nothrow) MY_FILE_NAME_INFO());
+        if (!pNameInfo) {
+            return false;
+        }
+
+        // Check pipe name is template of
+        // {"cygwin-","msys-"}XXXXXXXXXXXXXXX-ptyX-XX
+        if (!ptrGetFileInformationByHandleEx(h, FileNameInfo, pNameInfo.get(),
+                                             sizeof(MY_FILE_NAME_INFO))) {
+            return false;
+        }
+        std::wstring name(pNameInfo->FileName, pNameInfo->FileNameLength / sizeof(WCHAR));
+        if ((name.find(L"msys-") == std::wstring::npos
+             && name.find(L"cygwin-") == std::wstring::npos)
+            || name.find(L"-pty") == std::wstring::npos) {
+            return false;
+        }
+
+        return true;
+    }
+
+#endif
+
+    inline bool isTerminal(const std::streambuf *osbuf) noexcept
+    {
+        using std::cerr;
+        using std::clog;
+        using std::cout;
+#if defined(OS_LINUX) || defined(OS_MAC)
+        if (osbuf == cout.rdbuf()) {
+            static const bool cout_term = isatty(fileno(stdout)) != 0;
+            return cout_term;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_term = isatty(fileno(stderr)) != 0;
+            return cerr_term;
+        }
+#elif defined(OS_WIN)
+        if (osbuf == cout.rdbuf()) {
+            static const bool cout_term
+              = (_isatty(_fileno(stdout)) || isMsysPty(_fileno(stdout)));
+            return cout_term;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_term
+              = (_isatty(_fileno(stderr)) || isMsysPty(_fileno(stderr)));
+            return cerr_term;
+        }
+#endif
+        return false;
+    }
+
+    template <typename T>
+    using enableStd = typename std::enable_if<
+      std::is_same<T, rang::style>::value || std::is_same<T, rang::fg>::value
+        || std::is_same<T, rang::bg>::value || std::is_same<T, rang::fgB>::value
+        || std::is_same<T, rang::bgB>::value,
+      std::ostream &>::type;
+
+
+#ifdef OS_WIN
+
+    struct SGR {  // Select Graphic Rendition parameters for Windows console
+        BYTE fgColor;  // foreground color (0-15) lower 3 rgb bits + intense bit
+        BYTE bgColor;  // background color (0-15) lower 3 rgb bits + intense bit
+        BYTE bold;  // emulated as FOREGROUND_INTENSITY bit
+        BYTE underline;  // emulated as BACKGROUND_INTENSITY bit
+        BOOLEAN inverse;  // swap foreground/bold & background/underline
+        BOOLEAN conceal;  // set foreground/bold to background/underline
+    };
+
+    enum class AttrColor : BYTE {  // Color attributes for console screen buffer
+        black   = 0,
+        red     = 4,
+        green   = 2,
+        yellow  = 6,
+        blue    = 1,
+        magenta = 5,
+        cyan    = 3,
+        gray    = 7
+    };
+
+    inline HANDLE getConsoleHandle(const std::streambuf *osbuf) noexcept
+    {
+        if (osbuf == std::cout.rdbuf()) {
+            static const HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+            return hStdout;
+        } else if (osbuf == std::cerr.rdbuf() || osbuf == std::clog.rdbuf()) {
+            static const HANDLE hStderr = GetStdHandle(STD_ERROR_HANDLE);
+            return hStderr;
+        }
+        return INVALID_HANDLE_VALUE;
+    }
+
+    inline bool setWinTermAnsiColors(const std::streambuf *osbuf) noexcept
+    {
+        HANDLE h = getConsoleHandle(osbuf);
+        if (h == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+        DWORD dwMode = 0;
+        if (!GetConsoleMode(h, &dwMode)) {
+            return false;
+        }
+        dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        if (!SetConsoleMode(h, dwMode)) {
+            return false;
+        }
+        return true;
+    }
+
+    inline bool supportsAnsi(const std::streambuf *osbuf) noexcept
+    {
+        using std::cerr;
+        using std::clog;
+        using std::cout;
+        if (osbuf == cout.rdbuf()) {
+            static const bool cout_ansi
+              = (isMsysPty(_fileno(stdout)) || setWinTermAnsiColors(osbuf));
+            return cout_ansi;
+        } else if (osbuf == cerr.rdbuf() || osbuf == clog.rdbuf()) {
+            static const bool cerr_ansi
+              = (isMsysPty(_fileno(stderr)) || setWinTermAnsiColors(osbuf));
+            return cerr_ansi;
+        }
+        return false;
+    }
+
+    inline const SGR &defaultState() noexcept
+    {
+        static const SGR defaultSgr = []() -> SGR {
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            WORD attrib = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE),
+                                           &info)
+                || GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE),
+                                              &info)) {
+                attrib = info.wAttributes;
+            }
+            SGR sgr     = { 0, 0, 0, 0, FALSE, FALSE };
+            sgr.fgColor = attrib & 0x0F;
+            sgr.bgColor = (attrib & 0xF0) >> 4;
+            return sgr;
+        }();
+        return defaultSgr;
+    }
+
+    inline BYTE ansi2attr(BYTE rgb) noexcept
+    {
+        static const AttrColor rev[8]
+          = { AttrColor::black,  AttrColor::red,  AttrColor::green,
+              AttrColor::yellow, AttrColor::blue, AttrColor::magenta,
+              AttrColor::cyan,   AttrColor::gray };
+        return static_cast<BYTE>(rev[rgb]);
+    }
+
+    inline void setWinSGR(rang::bg col, SGR &state) noexcept
+    {
+        if (col != rang::bg::reset) {
+            state.bgColor = ansi2attr(static_cast<BYTE>(col) - 40);
+        } else {
+            state.bgColor = defaultState().bgColor;
+        }
+    }
+
+    inline void setWinSGR(rang::fg col, SGR &state) noexcept
+    {
+        if (col != rang::fg::reset) {
+            state.fgColor = ansi2attr(static_cast<BYTE>(col) - 30);
+        } else {
+            state.fgColor = defaultState().fgColor;
+        }
+    }
+
+    inline void setWinSGR(rang::bgB col, SGR &state) noexcept
+    {
+        state.bgColor = (BACKGROUND_INTENSITY >> 4)
+          | ansi2attr(static_cast<BYTE>(col) - 100);
+    }
+
+    inline void setWinSGR(rang::fgB col, SGR &state) noexcept
+    {
+        state.fgColor
+          = FOREGROUND_INTENSITY | ansi2attr(static_cast<BYTE>(col) - 90);
+    }
+
+    inline void setWinSGR(rang::style style, SGR &state) noexcept
+    {
+        switch (style) {
+            case rang::style::reset: state = defaultState(); break;
+            case rang::style::bold: state.bold = FOREGROUND_INTENSITY; break;
+            case rang::style::underline:
+            case rang::style::blink:
+                state.underline = BACKGROUND_INTENSITY;
+                break;
+            case rang::style::reversed: state.inverse = TRUE; break;
+            case rang::style::conceal: state.conceal = TRUE; break;
+            default: break;
+        }
+    }
+
+    inline SGR &current_state() noexcept
+    {
+        static SGR state = defaultState();
+        return state;
+    }
+
+    inline WORD SGR2Attr(const SGR &state) noexcept
+    {
+        WORD attrib = 0;
+        if (state.conceal) {
+            if (state.inverse) {
+                attrib = (state.fgColor << 4) | state.fgColor;
+                if (state.bold)
+                    attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+            } else {
+                attrib = (state.bgColor << 4) | state.bgColor;
+                if (state.underline)
+                    attrib |= FOREGROUND_INTENSITY | BACKGROUND_INTENSITY;
+            }
+        } else if (state.inverse) {
+            attrib = (state.fgColor << 4) | state.bgColor;
+            if (state.bold) attrib |= BACKGROUND_INTENSITY;
+            if (state.underline) attrib |= FOREGROUND_INTENSITY;
+        } else {
+            attrib = state.fgColor | (state.bgColor << 4) | state.bold
+              | state.underline;
+        }
+        return attrib;
+    }
+
+    template <typename T>
+    inline void setWinColorAnsi(std::ostream &os, T const value)
+    {
+        os << "\033[" << static_cast<int>(value) << "m";
+    }
+
+    template <typename T>
+    inline void setWinColorNative(std::ostream &os, T const value)
+    {
+        const HANDLE h = getConsoleHandle(os.rdbuf());
+        if (h != INVALID_HANDLE_VALUE) {
+            setWinSGR(value, current_state());
+            // Out all buffered text to console with previous settings:
+            os.flush();
+            SetConsoleTextAttribute(h, SGR2Attr(current_state()));
+        }
+    }
+
+    template <typename T>
+    inline enableStd<T> setColor(std::ostream &os, T const value)
+    {
+        if (winTermMode() == winTerm::Auto) {
+            if (supportsAnsi(os.rdbuf())) {
+                setWinColorAnsi(os, value);
+            } else {
+                setWinColorNative(os, value);
+            }
+        } else if (winTermMode() == winTerm::Ansi) {
+            setWinColorAnsi(os, value);
+        } else {
+            setWinColorNative(os, value);
+        }
+        return os;
+    }
+#else
+    template <typename T>
+    inline enableStd<T> setColor(std::ostream &os, T const value)
+    {
+        return os << "\033[" << static_cast<int>(value) << "m";
+    }
+#endif
+}  // namespace rang_implementation
+
+template <typename T>
+inline rang_implementation::enableStd<T> operator<<(std::ostream &os,
+                                                    const T value)
+{
+    const control option = rang_implementation::controlMode();
+    switch (option) {
+        case control::Auto:
+            return rang_implementation::supportsColor()
+                && rang_implementation::isTerminal(os.rdbuf())
+              ? rang_implementation::setColor(os, value)
+              : os;
+        case control::Force: return rang_implementation::setColor(os, value);
+        default: return os;
+    }
+}
+
+inline void setWinTermMode(const rang::winTerm value) noexcept
+{
+    rang_implementation::winTermMode() = value;
+}
+
+inline void setControlMode(const control value) noexcept
+{
+    rang_implementation::controlMode() = value;
+}
+
+}  // namespace rang
+
+#undef OS_LINUX
+#undef OS_WIN
+#undef OS_MAC
+
+#endif /* ifndef RANG_DOT_HPP */

--- a/tests/python/relay/test_error_reporting.py
+++ b/tests/python/relay/test_error_reporting.py
@@ -1,15 +1,9 @@
 from tvm.relay.parser import fromtext
-from tvm.relay.expr import ExprFunctor
+from tvm.relay.expr_functor import ExprFunctor
 from tvm.relay.op import Op
 from tvm import relay
 
 class SpanChecker(ExprFunctor):
-    def visit(self, expr):
-        if isinstance(expr, Op):
-            return self.visit_op(expr)
-        else:
-            return super().visit(expr)
-
     def visit_var(self, var):
         assert var.span
 
@@ -23,6 +17,9 @@ class SpanChecker(ExprFunctor):
         self.visit(func.body)
 
         assert func.span
+
+    def visit_call(self, call):
+        assert call.span
 
 def check_spans(expr):
     sp_ck = SpanChecker()
@@ -46,8 +43,9 @@ def test_type_check_call():
     func2 = relay.Function([y], call)
     print(func2.astext())
     call = annotate_spans(func2)
-    check_spans(func2)
-    relay.ir_pass.infer_type(func2)
+    check_spans(call)
+    import pdb; pdb.set_trace()
+    relay.ir_pass.infer_type(call)
 
 if __name__ == "__main__":
     test_var_span()

--- a/tests/python/relay/test_error_reporting.py
+++ b/tests/python/relay/test_error_reporting.py
@@ -1,0 +1,4 @@
+from tvm.relay.parser import fromtext
+
+def annotate_spans(expr):
+    return fromtext(expr.astext())

--- a/tests/python/relay/test_error_reporting.py
+++ b/tests/python/relay/test_error_reporting.py
@@ -1,5 +1,32 @@
 from tvm.relay.parser import fromtext
+from tvm.relay.expr import ExprFunctor
+from tvm.relay.op import Op
 from tvm import relay
+
+class SpanChecker(ExprFunctor):
+    def visit(self, expr):
+        if isinstance(expr, Op):
+            return self.visit_op(expr)
+        else:
+            return super().visit(expr)
+
+    def visit_var(self, var):
+        assert var.span
+
+    def visit_op(self, op):
+        pass
+
+    def visit_function(self, func):
+        for param in func.params:
+            self.visit(param)
+
+        self.visit(func.body)
+
+        assert func.span
+
+def check_spans(expr):
+    sp_ck = SpanChecker()
+    sp_ck.visit(expr)
 
 def annotate_spans(expr):
     # sn = SourceName("my_expr.relay")
@@ -9,4 +36,4 @@ def test_var():
     x = relay.var('x')
     func = relay.Function([x], x)
     func = annotate_spans(func)
-    import pdb; pdb.set_trace()
+    check_spans(func)

--- a/tests/python/relay/test_error_reporting.py
+++ b/tests/python/relay/test_error_reporting.py
@@ -3,7 +3,7 @@ from tvm import relay
 
 def annotate_spans(expr):
     # sn = SourceName("my_expr.relay")
-    return fromtext(expr.astext(), sn)
+    return fromtext(expr.astext())
 
 def test_var():
     x = relay.var('x')

--- a/tests/python/relay/test_error_reporting.py
+++ b/tests/python/relay/test_error_reporting.py
@@ -32,8 +32,23 @@ def annotate_spans(expr):
     # sn = SourceName("my_expr.relay")
     return fromtext(expr.astext())
 
-def test_var():
+def test_var_span():
     x = relay.var('x')
     func = relay.Function([x], x)
     func = annotate_spans(func)
     check_spans(func)
+
+def test_type_check_call():
+    x = relay.var('x', shape=(10, 10))
+    func = relay.Function([x], x)
+    y = relay.var('x', shape=(10, 11))
+    call = relay.Call(func, [y])
+    func2 = relay.Function([y], call)
+    print(func2.astext())
+    call = annotate_spans(func2)
+    check_spans(func2)
+    relay.ir_pass.infer_type(func2)
+
+if __name__ == "__main__":
+    test_var_span()
+    test_type_check_call()

--- a/tests/python/relay/test_error_reporting.py
+++ b/tests/python/relay/test_error_reporting.py
@@ -1,4 +1,12 @@
 from tvm.relay.parser import fromtext
+from tvm import relay
 
 def annotate_spans(expr):
-    return fromtext(expr.astext())
+    # sn = SourceName("my_expr.relay")
+    return fromtext(expr.astext(), sn)
+
+def test_var():
+    x = relay.var('x')
+    func = relay.Function([x], x)
+    func = annotate_spans(func)
+    import pdb; pdb.set_trace()


### PR DESCRIPTION
This pull request adds the ability to generate descriptive errors for Relay. An error can be reported on a `tam::relay::Span` which corresponds to a source location in the original program.

For programs which are built programmatically we recover a representation of the program which is useful for error reporting. We generate this representation using the text printer and then parse it to recover the span information. 

Once we have done this we can precisely mark an error on the original program, for example report the operator invocation which has a type error.

My goal is that we will only need to do this once when inputting the program, and store the program fragment in a `tvm::relay::Module`. 

This PR lays the initial groundwork to do this kind of error reporting. 

I will do more experimentation and clean up work before this is ready to merge. 

One large challenge is related to vars, due to vars appearing many times in the program, but only being allocated once we can not easily track the span information correctly for it using Relay's current representation. If we put the programs into ANF, we can provide very clear errors, but I think we will need to revisit how we track span information, but this will enable us to have informative errors in the mean time.

cc @joshpoll @MarisaKirisame @tqchen @ZihengJiang 