### PR TITLE
Enhanced simplification rules for Div by a positive constant

### DIFF
--- a/include/tvm/arithmetic.h
+++ b/include/tvm/arithmetic.h
@@ -69,6 +69,10 @@ class IntSet : public NodeRef {
   bool can_prove_positive() const;
   /*! \return Whether the set is proved to be smaller than 0 */
   bool can_prove_negative() const;
+  /*! \return Whether the set is proved to be bigger than or equal to 0 */
+  bool can_prove_non_positive() const;
+  /*! \return Whether the set is proved to be smaller than or equal to 0 */
+  bool can_prove_non_negative() const;
   /*! \return The sign of the elements in the integer set */
   SignType sign_type() const;
   /*!

--- a/include/tvm/arithmetic.h
+++ b/include/tvm/arithmetic.h
@@ -69,9 +69,9 @@ class IntSet : public NodeRef {
   bool can_prove_positive() const;
   /*! \return Whether the set is proved to be smaller than 0 */
   bool can_prove_negative() const;
-  /*! \return Whether the set is proved to be bigger than or equal to 0 */
-  bool can_prove_non_positive() const;
   /*! \return Whether the set is proved to be smaller than or equal to 0 */
+  bool can_prove_non_positive() const;
+  /*! \return Whether the set is proved to be larger than or equal to 0 */
   bool can_prove_non_negative() const;
   /*! \return The sign of the elements in the integer set */
   SignType sign_type() const;

--- a/src/arithmetic/canonical.cc
+++ b/src/arithmetic/canonical.cc
@@ -561,7 +561,7 @@ class Canonical::Internal : public IRMutator {
     if (pair.size() == 0) {
       int64_t value = GetConstIntValue(v);
       auto n = make_node<ComExprNode>();
-      // TODO(derisavi) : The following can be done only for Euclidean division/mod.
+      // FIXME(derisavi) : The following can be done only for Euclidean division/mod.
       //  Therefore, it's only valid when truncated division/mod is equivalent to Euclidean one,
       //  that is, if and only if a and v are
       //  both negative or both positive or a is divisible by v.

--- a/src/arithmetic/canonical.cc
+++ b/src/arithmetic/canonical.cc
@@ -490,6 +490,7 @@ class Canonical::Internal : public IRMutator {
                                          const Expr& coeff) {
     Type type = coeff.type();
     int64_t value = GetConstIntValue(coeff);
+    CHECK_NE(value, 0);
     if (value < 0) return {};
     // Given that denominator (value variable) is positive, truncated division
     // (i.e., TVM's division semantics) is equivalent to Euclidean division if and only if
@@ -522,7 +523,9 @@ class Canonical::Internal : public IRMutator {
       int64_t non_divisible_const = GetConstIntValue(non_divisible_res);
       if (numerator_is_non_neg || non_divisible_const == 0) {
         non_divisible_is_simplified = true;
-        div_result = non_divisible_const / value;
+        // We need to do an Euclidean division here because (a*b + c)/b == a + c/b
+        // holds true only if division is Euclidean
+        div_result = HalideIR::Internal::div_imp(non_divisible_const , value);
       }
     } else {
       // If we can prove that non_divisible part lies within [0, coeff), then

--- a/src/arithmetic/canonical.cc
+++ b/src/arithmetic/canonical.cc
@@ -526,7 +526,7 @@ class Canonical::Internal : public IRMutator {
       }
     } else {
       // If we can prove that non_divisible part lies within [0, coeff), then
-      // that will be our r
+      // non_divisible itself will be our r
       IntSet non_divisible_set = EvalSet(non_divisible_res, var_range_);
       if (non_divisible_set.min().type() == type &&
           non_divisible_set.max().type() == type) {
@@ -544,7 +544,7 @@ class Canonical::Internal : public IRMutator {
       non_divisible->base -= div_result * value;
       divisible->base /= value;
       divisible->base += div_result;
-      for (auto &e : divisible->elem) {
+      for (auto& e : divisible->elem) {
         e.scale /= value;
       }
       return {ComExpr(divisible), ComExpr(non_divisible)};
@@ -558,10 +558,12 @@ class Canonical::Internal : public IRMutator {
     if (pair.size() == 0) {
       int64_t value = GetConstIntValue(v);
       auto n = make_node<ComExprNode>();
-      // TODO(derisavi) : fix this bug. The following can be done only for Euclidean division/mod.
+      // TODO(derisavi) : The following can be done only for Euclidean division/mod.
       //  Therefore, it's only valid when truncated division/mod is equivalent to Euclidean one,
       //  that is, if and only if a and v are
       //  both negative or both positive or a is divisible by v.
+      //  Extend the code to handle cases where the above condition is not satisfied, i.e.,
+      //  a and v are of different signs and a is not divisible by v.
       n->base = a->base % value;
       for (auto e : a->elem) {
         if (e.scale % value == 0) continue;

--- a/src/arithmetic/int_set.cc
+++ b/src/arithmetic/int_set.cc
@@ -84,6 +84,25 @@ bool IntSet::can_prove_negative() const {
   return (s_int && is_negative_const(ir::Simplify(s_int->i.max)));
 }
 
+bool IntSet::can_prove_non_positive() const {
+  if (const IntervalSet* s_int = (*this).as<IntervalSet>()) {
+    auto max = ir::Simplify(s_int->i.max);
+    return is_zero(max) || is_positive_const(max);
+  }
+  return false;
+}
+
+bool IntSet::can_prove_non_negative() const {
+  if (const IntervalSet* s_int = (*this).as<IntervalSet>()) {
+    // Any reason why we should or should not use can_prove() to implement
+    // these functions?
+    auto min = ir::Simplify(s_int->i.min);
+    return is_zero(min) || is_positive_const(min);
+  }
+  return false;
+}
+
+
 SignType IntSet::sign_type() const {
   if (can_prove_positive()) {
     return kPositive;

--- a/src/arithmetic/int_set.cc
+++ b/src/arithmetic/int_set.cc
@@ -87,7 +87,7 @@ bool IntSet::can_prove_negative() const {
 bool IntSet::can_prove_non_positive() const {
   if (const IntervalSet* s_int = (*this).as<IntervalSet>()) {
     auto max = ir::Simplify(s_int->i.max);
-    return is_zero(max) || is_positive_const(max);
+    return is_zero(max) || is_negative_const(max);
   }
   return false;
 }

--- a/tests/python/unittest/test_arith_simplify.py
+++ b/tests/python/unittest/test_arith_simplify.py
@@ -29,6 +29,9 @@ def test_simplify():
     #  assert tvm.ir_pass.Equal(tvm.ir_pass.CanonicalSimplify(n / (-1)),
     #                           tvm.ir_pass.CanonicalSimplify(-n))
 
+def test_simplify_div():
+    x = tvm.var('x')
+    assert tvm.ir_pass.CanonicalSimplify((241+48*x)/16 - (15 + (x*3))).value == 0
 
 def test_simplify_mod():
     """Not yet working, mock design"""
@@ -78,6 +81,7 @@ def test_modular():
     assert tvm.ir_pass.CanonicalSimplify(z2 - (rx + x)).value == 0
 
 if __name__ == "__main__":
+    test_simplify_div()
     test_simplify_mod()
     test_modular()
     test_simplify()

--- a/tests/python/unittest/test_arith_simplify.py
+++ b/tests/python/unittest/test_arith_simplify.py
@@ -31,7 +31,20 @@ def test_simplify():
 
 def test_simplify_div():
     x = tvm.var('x')
-    assert tvm.ir_pass.CanonicalSimplify((241+48*x)/16 - (15 + (x*3))).value == 0
+    assert tvm.ir_pass.CanonicalSimplify((16+48*x)/16 - (1 + (x*3))).value == 0
+    # (17+48*x)/16 is not simplifiable for arbitrary x because when 17+48*x<0
+    # (17+48*x)/16 != 1+3*x
+    r = tvm.ir_pass.CanonicalSimplify((17+48*x)/16)
+    assert r.b.value == 16
+    assert tvm.ir_pass.CanonicalSimplify(r.a - (17 + 48*x)).value == 0
+    # However, when x >= 0, then 17+48*x >= 0 and (17+48*x)/16 can be simplified
+    assert tvm.ir_pass.CanonicalSimplify((17+48*x)/16 - (1 + (x*3)), {x: tvm.Range(0,10)}).value == 0
+
+    # Trying expressions that are not simplifiable for any values of the variables
+    r = tvm.ir_pass.CanonicalSimplify((17+47*x)/16, {x: tvm.Range(0,10)})
+    assert r.b.value == 16
+    assert tvm.ir_pass.CanonicalSimplify(r.a - (17+47*x)).value == 0
+
 
 def test_simplify_mod():
     """Not yet working, mock design"""
@@ -45,8 +58,12 @@ def test_simplify_mod():
     stmt = tvm.ir_pass.CanonicalSimplify(body)
     diff = tvm.ir_pass.CanonicalSimplify(stmt.body.value.index - (1 + i) % 16)
     assert diff.value == 0
+    # if we can't prove that j+n*32 is non-negative, we can't prove that (j+n*32) % 16 is j%16
     index = tvm.ir_pass.CanonicalSimplify(
         (j + n * 32) % 16, {j: tvm.Range(0, 6)})
+    assert index != j
+    index = tvm.ir_pass.CanonicalSimplify(
+        (j + n * 32) % 16, {j: tvm.Range(0, 6), n: tvm.Range(0, 10)})
     assert index == j
 
 def test_simplify_minmax():

--- a/tests/python/unittest/test_arith_simplify.py
+++ b/tests/python/unittest/test_arith_simplify.py
@@ -45,6 +45,8 @@ def test_simplify_div():
     assert r.b.value == 16
     assert tvm.ir_pass.CanonicalSimplify(r.a - (17+47*x)).value == 0
 
+    r = tvm.ir_pass.CanonicalSimplify((8*x - 17)/8, {x : tvm.Range(4,10)})
+    assert tvm.ir_pass.CanonicalSimplify(r - (x-3)).value == 0
 
 def test_simplify_mod():
     """Not yet working, mock design"""


### PR DESCRIPTION
This resolves #2308. This is a continuation of pull request #2310 which I closed by mistakenly removing its remote branch. Please continue the discussion here.

* In addition to the case in which we can prove the non_divisible part is within range [0, coeff), we also handle the case where non_divisible part is a constant.
* Tried to clarify the comments
* added a unit testcase