### PR TITLE
Mutate free variables in CommReducer in cache_write

### DIFF
--- a/tests/python/unittest/test_schedule_schedule_ops.py
+++ b/tests/python/unittest/test_schedule_schedule_ops.py
@@ -420,8 +420,22 @@ def test_loop_dep_reduce():
     f = tvm.build(s, [X, Y])
 
 
+def test_loop_dep_reduce_cache_write():
+    X = tvm.placeholder(shape=(10,), name="x")
+    def f(n):
+        rv = tvm.reduce_axis((0, n))
+        init = lambda dtype: tvm.select(n > 1, tvm.const(0, dtype), n.astype(dtype))
+        sum = tvm.comm_reducer(lambda x, y: tvm.max(x + y, n.astype('float32')), init, name='sum')
+        return sum(X[rv], axis=rv)
+    Y = tvm.compute(X.shape, f, name="y")
+    s = tvm.create_schedule([Y.op])
+    s.cache_write(Y, 'local')
+    f = tvm.build(s, [X, Y])
+
+
 if __name__ == "__main__":
     test_loop_dep_reduce()
+    test_loop_dep_reduce_cache_write()
     test_schedule_middle_cache()
     test_inline_multi_reduce()
     test_schedule_cache_relayout4()


### PR DESCRIPTION
VarReplacer in cache_write should mutate combiner of Reduce expression because CommReducer may contain free variables from outer loop.
see https://discuss.tvm.ai/t/cache-write-does-not-replace-vars-in-reducer-identity/1402

cc @tqchen 