### PR TITLE
Fix clock type in rpc_session timer

### DIFF
--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -1205,7 +1205,8 @@ PackedFunc WrapTimeEvaluator(PackedFunc pf,
     DeviceAPI::Get(ctx)->StreamSync(ctx, nullptr);
 
     for (int i = 0; i < repeat; ++i) {
-      std::chrono::time_point<std::chrono::high_resolution_clock, std::chrono::nanoseconds> tbegin, tend;
+      std::chrono::time_point<
+        std::chrono::high_resolution_clock, std::chrono::nanoseconds> tbegin, tend;
       double duration_ms = 0.0;
 
       do {

--- a/src/runtime/rpc/rpc_session.cc
+++ b/src/runtime/rpc/rpc_session.cc
@@ -1205,7 +1205,7 @@ PackedFunc WrapTimeEvaluator(PackedFunc pf,
     DeviceAPI::Get(ctx)->StreamSync(ctx, nullptr);
 
     for (int i = 0; i < repeat; ++i) {
-      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> tbegin, tend;
+      std::chrono::time_point<std::chrono::high_resolution_clock, std::chrono::nanoseconds> tbegin, tend;
       double duration_ms = 0.0;
 
       do {


### PR DESCRIPTION
This fixes the following compiler error on macos

```
no known conversion from 'time_point<std::__1::chrono::steady_clock, [...]>' to 'time_point<std::__1::chrono::system_clock, [...]>' for 1st argument
```