### PR TITLE
Remove duplicated functions in relay_integration

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -9,44 +9,12 @@ import warnings
 import logging
 
 
-from ... import tensor, placeholder, target as _target
+from ... import target as _target
 
 from .task import create
 from .topi_integration import TaskExtractEnv
 
 logger = logging.getLogger('autotvm')
-
-
-def serialize_args(args):
-    """serialize arguments of a topi function to a hashable tuple.
-
-    Parameters
-    ----------
-    args: list of hashable or Tensor
-    """
-    ret = []
-    for t in args:
-        if isinstance(t, tensor.Tensor):
-            ret.append(('TENSOR', get_const_tuple(t.shape), t.dtype))
-        else:
-            ret.append(t)
-    return tuple(ret)
-
-
-def deserialize_args(args):
-    """The inverse function of :code:`serialize_args`.
-
-    Parameters
-    ----------
-    args: list of hashable or Tensor
-    """
-    ret = []
-    for t in args:
-        if isinstance(t, tuple) and t[0] == 'TENSOR':
-            ret.append(placeholder(shape=t[1], dtype=t[2]))
-        else:
-            ret.append(t)
-    return ret
 
 
 def extract_from_program(func, params, ops, target, target_host=None):


### PR DESCRIPTION
Remove `serialize_args` and `deserialize_args` because they are duplicated by https://github.com/dmlc/tvm/blob/151f550b2ee5050c74f632679a1c1d86fcea2482/python/tvm/autotvm/task/topi_integration.py#L24

cc @merrymercy @eqy 