### PR TITLE
[TEST] Improve if_parser_enabled

### DIFF
--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -2,6 +2,7 @@ import tvm
 from tvm import relay
 from tvm.relay.parser import enabled
 from tvm.relay.ir_pass import alpha_equal
+from nose import SkipTest
 from nose.tools import nottest, raises
 from numpy import isclose
 from typing import Union
@@ -67,7 +68,7 @@ def if_parser_enabled(func):
     @wraps(func)
     def wrapper():
         if not enabled():
-            return
+            raise SkipTest("ANTLR is not installed!")
         func()
     return wrapper
 


### PR DESCRIPTION
With the fix, if people don't have `ANTLR` installed and run the test, they won't see any test ran instead of thinking their change pass the unit test. 

````
(tvm_env_3.6.3) ➜  TVM_FFI=ctypes python -m nose -v tests/python/relay/test_ir_parser.py

----------------------------------------------------------------------
Ran 0 tests in 0.000s
````