### PR TITLE
[RELAY] Set TOpPattern of Dropout.

### DIFF
--- a/src/relay/op/nn/nn.cc
+++ b/src/relay/op/nn/nn.cc
@@ -553,7 +553,8 @@ The whole array is rescaled by ``1/(1-p)`` to keep the expected sum of the input
 .add_argument("data", "Tensor", "Input to which dropout will be applied.")
 .set_support_level(1)
 .set_attr<FInferCorrectLayout>("FInferCorrectLayout", ElemwiseArbitraryLayout)
-.add_type_rel("Dropout", DropoutRel);
++.add_type_rel("Dropout", DropoutRel)
++.set_attr<TOpPattern>("TOpPattern", kElemWise);
 
 // batch_norm
 TVM_REGISTER_NODE_TYPE(BatchNormAttrs);


### PR DESCRIPTION
Otherwise relay.ir_pass.fuse_ops fails on network containing dropout.