### PR TITLE
[LLVM CodeGen] Solve LLVM CodeGen br instruction accept not-i1 type issue

### DIFF
--- a/src/pass/rewrite_unsafe_select.cc
+++ b/src/pass/rewrite_unsafe_select.cc
@@ -96,8 +96,8 @@ class UnsafeSelectRewriter : public IRMutator {
     op = expr.as<Select>();
     UnsafeExprDetector unsafe;
     bool cond_is_scalar_bool = op->condition.type().is_bool() && op->condition.type().is_scalar();
-    if (unsafe.VisitExpr(op->true_value) ||
-        unsafe.VisitExpr(op->false_value) &&
+    if ((unsafe.VisitExpr(op->true_value) ||
+        unsafe.VisitExpr(op->false_value)) &&
         cond_is_scalar_bool) {
       return Call::make(
           op->type,

--- a/src/pass/rewrite_unsafe_select.cc
+++ b/src/pass/rewrite_unsafe_select.cc
@@ -95,8 +95,10 @@ class UnsafeSelectRewriter : public IRMutator {
     Expr expr = IRMutator::Mutate_(op, e);
     op = expr.as<Select>();
     UnsafeExprDetector unsafe;
+    bool cond_is_scalar_bool = op->condition.type().is_bool() && op->condition.type().is_scalar();
     if (unsafe.VisitExpr(op->true_value) ||
-        unsafe.VisitExpr(op->false_value)) {
+        unsafe.VisitExpr(op->false_value) &&
+        cond_is_scalar_bool) {
       return Call::make(
           op->type,
           intrinsic::tvm_if_then_else,


### PR DESCRIPTION
see issue: #2364 

LLVM `br` instruction can only accept i1 type of condition (https://llvm.org/docs/LangRef.html#br-instruction), if the condition type is not i1, we couldn't  rewrite to tvm_if_then_else, which is converted to LLVM `br` instruction.  This situation could happen in the situation `conv2d + prelu` via auto tvm tunning on ARM CPU.

@tqchen please help to review it.
cc: @nttstar
