### PR TITLE
Fix LLVM initialization

### DIFF
--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -13,7 +13,7 @@ namespace codegen {
 
 struct LLVMEnv {
   std::mutex mu;
-  bool all_initialized{false};
+  volatile bool all_initialized{false};
 
   static LLVMEnv* Global() {
     static LLVMEnv inst;
@@ -26,12 +26,12 @@ void InitializeLLVM() {
   if (!e->all_initialized) {
     std::lock_guard<std::mutex> lock(e->mu);
     if (!e->all_initialized) {
-      e->all_initialized = true;
       llvm::InitializeAllTargetInfos();
       llvm::InitializeAllTargets();
       llvm::InitializeAllTargetMCs();
       llvm::InitializeAllAsmParsers();
       llvm::InitializeAllAsmPrinters();
+      e->all_initialized = true;
     }
   }
 }


### PR DESCRIPTION
Fix test-test-set in LLVM initialization to avoid racing.
Volatile is required to avoid cache or compiler optimization.
Moving the flag all_initialized to make sure all LLVM initialized before other threads bypassing.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
