### PR TITLE
Add functionality to optionally disable Select rewriting

### DIFF
--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -239,7 +239,7 @@ class BuildConfigNode : public Node {
     v->Visit("partition_const_loop", &partition_const_loop);
     v->Visit("dump_pass_ir", &dump_pass_ir);
     v->Visit("instrument_bound_checkers", &instrument_bound_checkers);
-	v->Visit("disable_select_rewriting", &disable_select_rewriting);
+    v->Visit("disable_select_rewriting", &disable_select_rewriting);
   }
 
   static constexpr const char* _type_key = "BuildConfig";

--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -222,6 +222,9 @@ class BuildConfigNode : public Node {
 
   /*! \brief Whether to instrument loads and stores with check for out of the bounds. */
   bool instrument_bound_checkers = false;
+  
+  /*! \brief Whether to disable select rewriting. */
+  bool disable_select_rewriting = false;
 
   void VisitAttrs(AttrVisitor* v) final {
     v->Visit("data_alignment", &data_alignment);
@@ -236,6 +239,7 @@ class BuildConfigNode : public Node {
     v->Visit("partition_const_loop", &partition_const_loop);
     v->Visit("dump_pass_ir", &dump_pass_ir);
     v->Visit("instrument_bound_checkers", &instrument_bound_checkers);
+	v->Visit("disable_select_rewriting", &disable_select_rewriting);
   }
 
   static constexpr const char* _type_key = "BuildConfig";

--- a/include/tvm/build_module.h
+++ b/include/tvm/build_module.h
@@ -222,7 +222,7 @@ class BuildConfigNode : public Node {
 
   /*! \brief Whether to instrument loads and stores with check for out of the bounds. */
   bool instrument_bound_checkers = false;
-  
+
   /*! \brief Whether to disable select rewriting. */
   bool disable_select_rewriting = false;
 

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -126,7 +126,8 @@ class BuildConfig(NodeBase):
         "restricted_func": True,
         "double_buffer_split_loop": 1,
         "dump_pass_ir": False,
-        "instrument_bound_checkers": False
+        "instrument_bound_checkers": False,
+        "disable_select_rewriting": False
     }
     _dump_ir = DumpIR()
 
@@ -368,7 +369,8 @@ def lower(sch,
     stmt = ir_pass.Simplify(stmt)
     stmt = ir_pass.LowerStorageAccessInfo(stmt)
     stmt = ir_pass.RemoveNoOp(stmt)
-    stmt = ir_pass.RewriteUnsafeSelect(stmt)
+    if not cfg.disable_select_rewriting:
+        stmt = ir_pass.RewriteUnsafeSelect(stmt)
     for f in lower_phase3:
         stmt = f(stmt)
     # Instrument BoundCheckers

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -381,7 +381,9 @@ Stmt BuildStmt(Schedule sch,
   stmt = ir::Simplify(stmt);
   stmt = ir::LowerStorageAccessInfo(stmt);
   stmt = ir::RemoveNoOp(stmt);
-  stmt = ir::RewriteUnsafeSelect(stmt);
+  
+  if (!(config->disable_select_rewriting))
+	stmt = ir::RewriteUnsafeSelect(stmt);
 
   if (config->instrument_bound_checkers)
     stmt = ir::InstrumentBoundCheckers(stmt);
@@ -535,6 +537,8 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
   p->stream << "detect_global_barrier=" << op->detect_global_barrier << ", ";
   p->stream << "partition_const_loop=" << op->partition_const_loop << ", ";
   p->stream << "dump_pass_ir=" << op->dump_pass_ir;
+  p->stream << "instrument_bound_checkers=" << op->instrument_bound_checkers;
+  p->stream << "disable_select_rewriting=" << op->disable_select_rewriting;
   p->stream << ")";
 });
 

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -381,7 +381,7 @@ Stmt BuildStmt(Schedule sch,
   stmt = ir::Simplify(stmt);
   stmt = ir::LowerStorageAccessInfo(stmt);
   stmt = ir::RemoveNoOp(stmt);
-  
+
   if (!(config->disable_select_rewriting))
     stmt = ir::RewriteUnsafeSelect(stmt);
 

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -536,8 +536,8 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
   p->stream << "restricted_func=" << op->restricted_func << ", ";
   p->stream << "detect_global_barrier=" << op->detect_global_barrier << ", ";
   p->stream << "partition_const_loop=" << op->partition_const_loop << ", ";
-  p->stream << "dump_pass_ir=" << op->dump_pass_ir;
-  p->stream << "instrument_bound_checkers=" << op->instrument_bound_checkers;
+  p->stream << "dump_pass_ir=" << op->dump_pass_ir << ", ";
+  p->stream << "instrument_bound_checkers=" << op->instrument_bound_checkers << ", ";
   p->stream << "disable_select_rewriting=" << op->disable_select_rewriting;
   p->stream << ")";
 });

--- a/src/codegen/build_module.cc
+++ b/src/codegen/build_module.cc
@@ -383,7 +383,7 @@ Stmt BuildStmt(Schedule sch,
   stmt = ir::RemoveNoOp(stmt);
   
   if (!(config->disable_select_rewriting))
-	stmt = ir::RewriteUnsafeSelect(stmt);
+    stmt = ir::RewriteUnsafeSelect(stmt);
 
   if (config->instrument_bound_checkers)
     stmt = ir::InstrumentBoundCheckers(stmt);


### PR DESCRIPTION
Implemented the forth bullet of Issue #2000.
Also fix BuildConfig printing for instrument_bound_checkers, which is not added previously.

-L