### PR TITLE
Added LLVM TargetIRAnalysis pass

### DIFF
--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -235,6 +235,16 @@ void CodeGenLLVM::InitPassManagerBuilder(llvm::PassManagerBuilder* builder) {
 }
 
 void CodeGenLLVM::Optimize() {
+  // pass manager
+  FPassManager fpass(module_.get());
+  MPassManager mpass;
+  mpass.add(llvm::createTargetTransformInfoWrapperPass(
+              target_machine_ ? target_machine_->getTargetIRAnalysis() :
+                                llvm::TargetIRAnalysis()));
+  fpass.add(llvm::createTargetTransformInfoWrapperPass(
+              target_machine_ ? target_machine_->getTargetIRAnalysis() :
+              llvm::TargetIRAnalysis()));
+
   // place optimization pass
   llvm::PassManagerBuilder builder;
   builder.OptLevel = 3;
@@ -252,9 +262,6 @@ void CodeGenLLVM::Optimize() {
   target_machine_->adjustPassManager(builder);
 #endif
 
-  // pass manager
-  FPassManager fpass(module_.get());
-  MPassManager mpass;
   builder.populateFunctionPassManager(fpass);
   builder.populateModulePassManager(mpass);
 

--- a/src/codegen/llvm/llvm_common.h
+++ b/src/codegen/llvm/llvm_common.h
@@ -9,6 +9,7 @@
 
 #include <llvm/ExecutionEngine/MCJIT.h>
 
+#include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/Support/SourceMgr.h>
 


### PR DESCRIPTION
Similar to Halide, added LLVM TargetIRAnalysis pass.
With the pass, we could have ~10X performance speedup
for some vectorization-friendly functions such as
fast_log from Halide.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
