### PR TITLE
Remove redundant FoldConstant pass

### DIFF
--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -153,10 +153,10 @@ def optimize(func, target, params=None):
         func = ir_pass.infer_type(func)
         func = ir_pass.combine_parallel_conv2d(func)
 
-    # The constant folding pass is necessary because FoldScaleAxis pass needs to
-    # check the constantness and positiveness of scales.
-    if cfg.pass_enabled("FoldConstant"):	
-        func = ir_pass.fold_constant(func)	
+    # The constant folding pass is necessary because FoldScaleAxis pass needs
+    # to check the constantness and positiveness of scales.
+    if cfg.pass_enabled("FoldConstant"):
+        func = ir_pass.fold_constant(func)
 
     if cfg.pass_enabled("FoldScaleAxis"):
         func = ir_pass.infer_type(func)

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -153,6 +153,11 @@ def optimize(func, target, params=None):
         func = ir_pass.infer_type(func)
         func = ir_pass.combine_parallel_conv2d(func)
 
+    # The constant folding pass is necessary because FoldScaleAxis pass needs to
+    # check the constantness and positiveness of scales.
+    if cfg.pass_enabled("FoldConstant"):	
+        func = ir_pass.fold_constant(func)	
+
     if cfg.pass_enabled("FoldScaleAxis"):
         func = ir_pass.infer_type(func)
         func = ir_pass.backward_fold_scale_axis(func)

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -153,9 +153,6 @@ def optimize(func, target, params=None):
         func = ir_pass.infer_type(func)
         func = ir_pass.combine_parallel_conv2d(func)
 
-    if cfg.pass_enabled("FoldConstant"):
-        func = ir_pass.fold_constant(func)
-
     if cfg.pass_enabled("FoldScaleAxis"):
         func = ir_pass.infer_type(func)
         func = ir_pass.backward_fold_scale_axis(func)


### PR DESCRIPTION
I think we just need one pass for const folding after other optimizations are done, right? If this is the case, we should remove the redundant one.

CC @tqchen @merrymercy @jroesch 