### PR TITLE
[PASS] Skip vectorize if_then_else

### DIFF
--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -647,6 +647,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const Call* op) {
   } else if (op->is_intrinsic(intrinsic::tvm_handle_is_null)) {
     return builder_->CreateIsNull(MakeValue(op->args[0]));
   } else if (op->is_intrinsic(intrinsic::tvm_if_then_else)) {
+    CHECK_EQ(op->args[0].type().lanes(), 1)
+        << "if_then_else can only take scalar condition";
     using llvm::BasicBlock;
     BasicBlock* then_block = BasicBlock::Create(
         *ctx_, "if_then", function_);

--- a/tests/python/unittest/test_pass_vectorize.py
+++ b/tests/python/unittest/test_pass_vectorize.py
@@ -53,7 +53,36 @@ def test_vectorize_with_if():
     assert stmt.then_case.value.dtype == "float32x4"
     assert isinstance(stmt.else_case, tvm.stmt.For)
 
+def test_vectorize_if_then_else():
+    n = tvm.var('n')
+    x = tvm.var('x')
+    ib = tvm.ir_builder.create()
+    A = ib.pointer("float32", name="A")
+    with ib.for_range(0, 4, for_type="vectorize") as i:
+        A[i] = tvm.call_intrin("float32", "tvm_if_then_else",
+                               i > 0,
+                               A[i] + 1, A[i])
+    stmt = ib.get()
+    stmt = tvm.ir_pass.VectorizeLoop(stmt)
+    assert isinstance(stmt, tvm.stmt.For)
+
+
+    ib = tvm.ir_builder.create()
+    A = ib.pointer("float32", name="A")
+    with ib.for_range(0, n) as k:
+        with ib.for_range(0, 4, for_type="vectorize") as i:
+            A[k * 4 + i] = tvm.call_intrin("float32", "tvm_if_then_else",
+                                           k > 0,
+                                           A[k * 4 + i], 0)
+    stmt = ib.get()
+    assert isinstance(stmt.body, tvm.stmt.For)
+    stmt = tvm.ir_pass.VectorizeLoop(stmt)
+    assert not isinstance(stmt.body, tvm.stmt.For)
+    assert isinstance(stmt.body.value.args[2], tvm.expr.Broadcast)
+
+
 if __name__ == "__main__":
     test_vectorize_vector()
     test_vectorize_with_if()
     test_vectorize_loop()
+    test_vectorize_if_then_else()


### PR DESCRIPTION
Previously all call are vectorized by default, which may cause trouble in our case when if_then_else is present in the expression. This PR simply skips vectorizing if_then_else, which should be OK for most cases. followup of https://github.com/dmlc/tvm/pull/2381