### PR TITLE
[X86][TOPI] Add AutoTVM template for dense

### DIFF
--- a/docs/api/python/topi.rst
+++ b/docs/api/python/topi.rst
@@ -40,6 +40,7 @@ List of operators
    topi.nn.global_pool
    topi.nn.upsampling
    topi.nn.softmax
+   topi.nn.dense
    topi.nn.log_softmax
    topi.nn.conv2d_nchw
    topi.nn.conv2d_hwcn
@@ -132,6 +133,7 @@ topi.nn
 .. autofunction:: topi.nn.global_pool
 .. autofunction:: topi.nn.upsampling
 .. autofunction:: topi.nn.softmax
+.. autofunction:: topi.nn.dense
 .. autofunction:: topi.nn.log_softmax
 .. autofunction:: topi.nn.conv2d_nchw
 .. autofunction:: topi.nn.conv2d_hwcn

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -136,7 +136,7 @@ def download_package(package_name):
                 os.mkdir(path)
 
     logger.info("Download pre-tuned parameters package %s", package_name)
-    download("https://raw.githubusercontent.com/uwsaml/tvm-distro/master/tophub/%s"
+    download("https://raw.githubusercontent.com/uwsampl/tvm-distro/master/tophub/%s"
              % package_name, os.path.join(rootpath, package_name), True, verbose=0)
 
 

--- a/src/runtime/rpc/rpc_server_env.cc
+++ b/src/runtime/rpc/rpc_server_env.cc
@@ -38,7 +38,6 @@ TVM_REGISTER_GLOBAL("tvm.rpc.server.download")
 TVM_REGISTER_GLOBAL("tvm.rpc.server.remove")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
     std::string file_name = RPCGetPath(args[0]);
-    LOG(INFO) << "Remove " << file_name;
     RemoveFile(file_name);
   });
 

--- a/topi/python/topi/x86/nn.py
+++ b/topi/python/topi/x86/nn.py
@@ -5,19 +5,20 @@ import tvm
 from tvm import autotvm
 from tvm.autotvm.task.space import SplitEntity
 
-from .. import generic, tag
-from ..util import traverse_inline, get_const_tuple
-from .. import nn
 from .util import get_fp32_len
+from .. import generic, tag, nn
+from ..util import traverse_inline, get_const_tuple
 
 @generic.schedule_softmax.register(["cpu"])
 def schedule_softmax(outs):
     """Schedule for softmax
+
     Parameters
     ----------
     outs: Array of Tensor
           The computation graph description of softmax
           in the format of an array of tensors.
+
     Returns
     -------
     sch: Schedule

--- a/topi/python/topi/x86/nn.py
+++ b/topi/python/topi/x86/nn.py
@@ -2,9 +2,12 @@
 """x86 nn operators"""
 from __future__ import absolute_import as _abs
 import tvm
-
-from .. import generic
-from ..util import traverse_inline
+from tvm import autotvm
+from .. import generic, tag
+from ..util import traverse_inline, get_const_tuple
+from .. import nn
+from .util import get_fp32_len
+from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
 
 @generic.schedule_softmax.register(["cpu"])
 def schedule_softmax(outs):
@@ -36,7 +39,7 @@ def schedule_softmax(outs):
     return s
 
 
-@generic.schedule_dense.register(["cpu"])
+@generic.schedule_dense.register(["cpu", 'test'])
 def schedule_dense(outs):
     """Schedule for dense
 
@@ -51,7 +54,7 @@ def schedule_dense(outs):
     sch: Schedule
         The computation schedule for the op.
     """
-
+    #print('schedule dense generic')
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
 
@@ -88,4 +91,117 @@ def schedule_dense(outs):
             s[CC].compute_at(s[output], fused)
 
     traverse_inline(s, outs[0].op, _callback)
+    return s
+
+
+@autotvm.register_topi_compute(nn.dense, 'cpu', 'direct')
+def _declaration_dense(cfg, data, weight, bias=None):
+    batch, in_dim = get_const_tuple(data.shape)
+    out_dim, _ = get_const_tuple(weight.shape)
+
+    # create tuning space
+    cfg.define_split('tile_y', batch, num_outputs=3)
+    cfg.define_split('tile_x', out_dim, num_outputs=3)
+    cfg.define_split('tile_k', in_dim, num_outputs=2)
+    # cfg.define_knob("auto_unroll_max_step", [0, 32, 512, 1500])
+    # cfg.define_knob("unroll_explicit", [0, 1])
+
+    packw_bn = cfg['tile_x'].size[-1]
+    packw_shape = (out_dim // packw_bn, in_dim, packw_bn)
+    packw = tvm.compute(packw_shape,
+                        lambda z, y, x: weight[z * packw_bn + x, y], name='packed_weight')
+
+    k = tvm.reduce_axis((0, in_dim), name='k')
+    matmul = tvm.compute((batch, out_dim),
+                         lambda y, x: tvm.sum(data[y, k] * packw[x // packw_bn, k, x % packw_bn], axis=k),
+                         tag='dense')
+    if bias is not None:
+        matmul = tvm.compute((batch, out_dim),
+                             lambda i, j: matmul[i, j] + bias[j],
+                             tag=tag.BROADCAST)
+
+    if cfg.is_fallback:
+        _fallback_schedule(cfg, batch, out_dim, in_dim)
+
+    return matmul
+
+
+@autotvm.register_topi_schedule(generic.schedule_dense, 'cpu', 'direct')
+def _schedule_dense(cfg, outs):
+    s = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
+    def _callback(op):
+        if 'dense' in op.tag:
+            _schedule_dense_template(cfg, s, op.output(0))
+
+    traverse_inline(s, outs[0].op, _callback)
+    return s
+
+
+def _fallback_schedule(cfg, M, N, K):
+    vec_width = get_fp32_len()
+
+    tilex_ii = 1
+    for bn in range(vec_width*2, 0, -1):
+        if N % bn == 0:
+            tilex_ii = bn
+            break
+    NN = N // tilex_ii
+    tilex_oi = 1
+    while NN // tilex_oi > 4:
+        if (NN // tilex_oi) % 2 == 1:
+            break
+        tilex_oi *= 2
+
+    tiley_ii = 8
+    while M % tiley_ii != 0:
+        tiley_ii //= 2
+    MM = M // tiley_ii
+    tiley_oi = 1
+    while MM // tiley_oi > 4:
+        if (MM // tiley_oi) % 2 == 1:
+            break
+        tiley_oi *= 2
+
+    cfg["tile_y"] = SplitEntity([MM // tiley_oi, tiley_oi, tiley_ii])
+    cfg["tile_x"] = SplitEntity([NN // tilex_oi, tilex_oi, tilex_ii])
+    cfg["tile_k"] = SplitEntity([K // 4, 4])
+    # cfg["auto_unroll_max_step"] = OtherOptionEntity(512)
+    # cfg["unroll_explicit"] = OtherOptionEntity(False)
+
+
+def _schedule_dense_template(cfg, s, C):
+    A, packedB = s[C].op.input_tensors
+
+    CC = s.cache_write(C, 'global')
+    y, x = s[C].op.axis
+    k, = s[CC].op.reduce_axis
+
+    yt, yo, yi = cfg['tile_y'].apply(s, C, y)
+    xt, xo, xi = cfg['tile_x'].apply(s, C, x)
+    s[C].reorder(yt, xt, yo, xo, yi, xi)
+
+    xyt = s[C].fuse(yt, xt)
+    s[C].parallel(xyt)
+    xyo = s[C].fuse(yo, xo)
+    s[C].vectorize(xi)
+
+    s[CC].compute_at(s[C], xyo)
+    y, x = s[CC].op.axis
+
+    ko, ki = cfg['tile_k'].apply(s, CC, k)
+    s[CC].reorder(ko, ki, y, x)
+    s[CC].vectorize(x)
+    s[CC].unroll(y)
+    s[CC].unroll(ki)
+
+    z, y, x = s[packedB].op.axis
+    s[packedB].reorder(z, x, y)
+    s[packedB].parallel(z)
+    s[packedB].vectorize(y)
+
+    # s[C].pragma(xyo, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)
+    # s[C].pragma(xyo, 'unroll_explicit', cfg['unroll_explicit'].val)
+
     return s

--- a/topi/python/topi/x86/nn.py
+++ b/topi/python/topi/x86/nn.py
@@ -7,139 +7,144 @@ from .. import generic, tag
 from ..util import traverse_inline, get_const_tuple
 from .. import nn
 from .util import get_fp32_len
-from tvm.autotvm.task.space import SplitEntity, OtherOptionEntity
-
-@generic.schedule_softmax.register(["cpu"])
-def schedule_softmax(outs):
-    """Schedule for softmax
-
-    Parameters
-    ----------
-    outs: Array of Tensor
-          The computation graph description of softmax
-          in the format of an array of tensors.
-
-    Returns
-    -------
-    sch: Schedule
-        The computation schedule for the op.
-    """
-    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
-    x = outs[0]
-    s = tvm.create_schedule([x.op for x in outs])
-    tvm.schedule.AutoInlineInjective(s)
-    if len(s[x].op.axis) >= 5:
-        fused = s[x].fuse(s[x].op.axis[0], s[x].op.axis[1], s[x].op.axis[2])
-        s[x].parallel(fused)
-    elif len(s[x].op.axis) >= 3:
-        fused = s[x].fuse(s[x].op.axis[0], s[x].op.axis[1])
-        s[x].parallel(fused)
-    else:
-        s[x].parallel(s[x].op.axis[0])
-    return s
+from tvm.autotvm.task.space import SplitEntity, ReorderEntity, OtherOptionEntity
 
 
-@generic.schedule_dense.register(["cpu", 'test'])
-def schedule_dense(outs):
-    """Schedule for dense
-
-    Parameters
-    ----------
-    outs: Array of Tensor
-          The computation graph description of pool
-          in the format of an array of tensors.
-
-    Returns
-    -------
-    sch: Schedule
-        The computation schedule for the op.
-    """
-    #print('schedule dense generic')
-    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
-    s = tvm.create_schedule([x.op for x in outs])
-
-    def _callback(op):
-        if 'dense' in op.tag:
-            output = outs[0]
-            dense = op.output(0)
-
-            # Write cache for blocks
-            if dense.op in s.outputs:
-                CC = s.cache_write(dense, 'local')
-            else:
-                CC = dense
-
-            # Tile
-            bnx = 1
-            bny = 4
-            x, y = output.op.axis
-            xo, yo, xi, yi = s[output].tile(x, y, bnx, bny)
-
-            xc, yc = s[CC].op.axis
-            k, = s[CC].op.reduce_axis
-            ko, ki = s[CC].split(k, factor=4)
-            s[CC].reorder(ko, xc, ki, yc)
-
-            s[CC].unroll(ki)
-            s[CC].vectorize(yc)
-
-            s[output].unroll(xi)
-            s[output].vectorize(yi)
-
-            fused = s[output].fuse(xo, yo)
-            s[output].parallel(fused)
-            s[CC].compute_at(s[output], fused)
-
-    traverse_inline(s, outs[0].op, _callback)
-    return s
-
-
-@autotvm.register_topi_compute(nn.dense, 'cpu', 'direct')
+@autotvm.register_topi_compute(nn.dense, "cpu", "direct")
 def _declaration_dense(cfg, data, weight, bias=None):
     batch, in_dim = get_const_tuple(data.shape)
     out_dim, _ = get_const_tuple(weight.shape)
 
-    # create tuning space
-    cfg.define_split('tile_y', batch, num_outputs=3)
-    cfg.define_split('tile_x', out_dim, num_outputs=3)
-    cfg.define_split('tile_k', in_dim, num_outputs=2)
-    # cfg.define_knob("auto_unroll_max_step", [0, 32, 512, 1500])
-    # cfg.define_knob("unroll_explicit", [0, 1])
+    # For small batch sizes, don't pack weight into cache-friendly layout
+    # because of overhead in packing and limited reuse from batch dimension
+    # TODO(icemelon9): use a more systematic way to determine which schedule to use
+    if batch <= 16:
+        return _declaration_gemm_nopack(cfg, data, weight, bias)
+    return _declaration_gemm_pack(cfg, data, weight, bias)
 
-    packw_bn = cfg['tile_x'].size[-1]
+
+# Declare GEMM compute with packing weight into cache-friendly layout
+def _declaration_gemm_pack(cfg, data, weight, bias=None):
+    batch, in_dim = get_const_tuple(data.shape)
+    out_dim, _ = get_const_tuple(weight.shape)
+    # create tuning space
+    cfg.define_split("tile_y", batch, num_outputs=3)
+    cfg.define_split("tile_x", out_dim, num_outputs=3)
+    cfg.define_split("tile_k", in_dim, num_outputs=2)
+    if cfg.is_fallback:
+        _default_gemm_pack_config(cfg, batch, out_dim, in_dim)
+
+    packw_bn = cfg["tile_x"].size[-1]
     packw_shape = (out_dim // packw_bn, in_dim, packw_bn)
     packw = tvm.compute(packw_shape,
-                        lambda z, y, x: weight[z * packw_bn + x, y], name='packed_weight')
+                        lambda z, y, x: weight[z * packw_bn + x, y], name="packed_weight")
 
-    k = tvm.reduce_axis((0, in_dim), name='k')
-    matmul = tvm.compute((batch, out_dim),
-                         lambda y, x: tvm.sum(data[y, k] * packw[x // packw_bn, k, x % packw_bn], axis=k),
-                         tag='dense')
+    k = tvm.reduce_axis((0, in_dim), name="k")
+    C = tvm.compute((batch, out_dim),
+                    lambda y, x: tvm.sum(data[y, k] * packw[x // packw_bn, k, x % packw_bn], axis=k),
+                    tag="gemm_pack")
     if bias is not None:
-        matmul = tvm.compute((batch, out_dim),
-                             lambda i, j: matmul[i, j] + bias[j],
-                             tag=tag.BROADCAST)
+        C = tvm.compute((batch, out_dim), lambda i, j: C[i, j] + bias[j],
+                        tag=tag.BROADCAST)
+    return C
 
+
+# Declare GEMM compute without packing weight
+def _declaration_gemm_nopack(cfg, data, weight, bias=None):
+    batch, in_dim = get_const_tuple(data.shape)
+    out_dim, _ = get_const_tuple(weight.shape)
+    # create tuning space
+    cfg.define_split("tile_x", out_dim, num_outputs=2)
+    cfg.define_split("tile_y", batch, num_outputs=2)
+    cfg.define_split("tile_k", in_dim, num_outputs=2)
     if cfg.is_fallback:
-        _fallback_schedule(cfg, batch, out_dim, in_dim)
+        _default_gemm_nopack_config(cfg, batch, out_dim, in_dim)
 
-    return matmul
+    vec = cfg["tile_k"].size[-1]
+    k = tvm.reduce_axis((0, in_dim // vec), "k")
+    CC = tvm.compute((batch, out_dim, vec),
+                     lambda z, y, x: tvm.sum(data[z, k * vec + x] * weight[y, k * vec + x], axis=k))
+
+    kk = tvm.reduce_axis((0, vec), "kk")
+    C = tvm.compute((batch, out_dim),
+                    lambda y, x: tvm.sum(CC[y, x, kk], axis=kk),
+                    tag="gemm_nopack")
+    if bias is not None:
+        C = tvm.compute((batch, out_dim), lambda i, j: C[i, j] + bias[j],
+                        tag=tag.BROADCAST)
+
+    return C
 
 
-@autotvm.register_topi_schedule(generic.schedule_dense, 'cpu', 'direct')
+@autotvm.register_topi_schedule(generic.schedule_dense, "cpu", "direct")
 def _schedule_dense(cfg, outs):
     s = tvm.create_schedule([x.op for x in outs])
     scheduled_ops = []
 
     def _callback(op):
-        if 'dense' in op.tag:
-            _schedule_dense_template(cfg, s, op.output(0))
-
+        if "gemm_pack" in op.tag:
+            _schedule_gemm_pack_template(cfg, s, op.output(0))
+        else:
+            _schedule_gemm_nopack_template(cfg, s, op.output(0))
     traverse_inline(s, outs[0].op, _callback)
     return s
 
 
-def _fallback_schedule(cfg, M, N, K):
+def _schedule_gemm_pack_template(cfg, s, C):
+    A, packedB = s[C].op.input_tensors
+
+    CC = s.cache_write(C, "global")
+    y, x = s[C].op.axis
+    k, = s[CC].op.reduce_axis
+
+    yt, yo, yi = cfg["tile_y"].apply(s, C, y)
+    xt, xo, xi = cfg["tile_x"].apply(s, C, x)
+    s[C].reorder(yt, xt, yo, xo, yi, xi)
+    xyt = s[C].fuse(yt, xt)
+    s[C].parallel(xyt)
+    xyo = s[C].fuse(yo, xo)
+    s[C].unroll(yi)
+    s[C].vectorize(xi)
+
+    s[CC].compute_at(s[C], xyo)
+    y, x = s[CC].op.axis
+    ko, ki = cfg["tile_k"].apply(s, CC, k)
+    s[CC].reorder(ko, ki, y, x)
+    s[CC].vectorize(x)
+    s[CC].unroll(y)
+    s[CC].unroll(ki)
+
+    z, y, x = s[packedB].op.axis
+    s[packedB].reorder(z, x, y)
+    s[packedB].parallel(z)
+    s[packedB].vectorize(y)
+
+    return s
+
+
+def _schedule_gemm_nopack_template(cfg, s, C):
+    y, x = s[C].op.axis
+    kk, = s[C].op.reduce_axis
+    yo, yi = cfg["tile_y"].apply(s, C, y)
+    xo, xi = cfg["tile_x"].apply(s, C, x)
+    s[C].reorder(yo, xo, yi, xi)
+    xyo = s[C].fuse(yo, xo)
+    s[C].parallel(xyo)
+    s[C].unroll(kk)
+
+    CC, = s[C].op.input_tensors
+    s[CC].compute_at(s[C], xyo)
+    z, y, x = s[CC].op.axis
+    k, = s[CC].op.reduce_axis
+    yz = s[CC].fuse(z, y)
+    s[CC].reorder(k, yz, x)
+    s[CC].unroll(yz)
+    s[CC].vectorize(x)
+
+    return s
+
+
+def _default_gemm_pack_config(cfg, M, N, K):
     vec_width = get_fp32_len()
 
     tilex_ii = 1
@@ -167,41 +172,15 @@ def _fallback_schedule(cfg, M, N, K):
     cfg["tile_y"] = SplitEntity([MM // tiley_oi, tiley_oi, tiley_ii])
     cfg["tile_x"] = SplitEntity([NN // tilex_oi, tilex_oi, tilex_ii])
     cfg["tile_k"] = SplitEntity([K // 4, 4])
-    # cfg["auto_unroll_max_step"] = OtherOptionEntity(512)
-    # cfg["unroll_explicit"] = OtherOptionEntity(False)
 
 
-def _schedule_dense_template(cfg, s, C):
-    A, packedB = s[C].op.input_tensors
-
-    CC = s.cache_write(C, 'global')
-    y, x = s[C].op.axis
-    k, = s[CC].op.reduce_axis
-
-    yt, yo, yi = cfg['tile_y'].apply(s, C, y)
-    xt, xo, xi = cfg['tile_x'].apply(s, C, x)
-    s[C].reorder(yt, xt, yo, xo, yi, xi)
-
-    xyt = s[C].fuse(yt, xt)
-    s[C].parallel(xyt)
-    xyo = s[C].fuse(yo, xo)
-    s[C].vectorize(xi)
-
-    s[CC].compute_at(s[C], xyo)
-    y, x = s[CC].op.axis
-
-    ko, ki = cfg['tile_k'].apply(s, CC, k)
-    s[CC].reorder(ko, ki, y, x)
-    s[CC].vectorize(x)
-    s[CC].unroll(y)
-    s[CC].unroll(ki)
-
-    z, y, x = s[packedB].op.axis
-    s[packedB].reorder(z, x, y)
-    s[packedB].parallel(z)
-    s[packedB].vectorize(y)
-
-    # s[C].pragma(xyo, 'auto_unroll_max_step', cfg['auto_unroll_max_step'].val)
-    # s[C].pragma(xyo, 'unroll_explicit', cfg['unroll_explicit'].val)
-
-    return s
+def _default_gemm_nopack_config(cfg, M, N, K):
+    vec_width = get_fp32_len()
+    tilek_bn = 1
+    for bn in range(vec_width*2, 0, -1):
+        if K % bn == 0:
+            tilek_bn = bn
+            break
+    cfg["tile_k"] = SplitEntity([K // tilek_bn, tilek_bn])
+    cfg["tile_x"] = SplitEntity([N, 1])
+    cfg["tile_y"] = SplitEntity([1, M])

--- a/topi/tests/python/test_topi_dense.py
+++ b/topi/tests/python/test_topi_dense.py
@@ -37,7 +37,7 @@ def verify_dense(batch, in_dim, out_dim, use_bias=True):
         with tvm.target.create(device):
             D = topi.nn.dense(A, B, C if use_bias else None)
             D = topi.nn.relu(D)
-            s = topi.generic.schedule_dense(D)
+            s = topi.generic.schedule_dense([D])
         a = tvm.nd.array(a_np, ctx)
         b = tvm.nd.array(b_np, ctx)
         c = tvm.nd.array(c_np, ctx)


### PR DESCRIPTION
Improve the dense performance by using autoTVM to search for a better schedule on x86. Other minor changes:
- Fix the tophub link
- Remove the log messages of deleting files in RPC server (it prints out too many messages during AutoTVM search)
- Add dense in the topi doc

Benchmark:
- Compare the performance of AutoTVM vs numpy(MKL) of a few square matrix multiplication and dense with small batch sizes on ec2 c5.9xlarge (18 physical-core Intel Skylake cpu). Units: GFLOPS.

| Workload (M x K x N) | AutoTVM | numpy (MKL) |
|:---------------------:|:---------:|:-------------:|
| 128 x 128 x 128           |  424.19   | 320.21             |
| 256 x 256 x 256         | 1525.30   | 677.64            |
| 512 x 512 x 512           | 1727.35   | 1314.29           |
| 1 x 128 x 128               | 16.49       | 12.01               |
| 2 x 128 x 128               | 26.20      | 35.63              |
| 4 x 128 x 128               | 49.87      | 64.67              |
| 1 x 256 x 256              | 50.68      | 28.45              |
| 2 x 256 x 256              | 90.73      | 62.99              |
| 4 x 256 x 256              | 192.10     | 96.97             |
| 1 x 512 x 512               | 159.20     | 88.82             |
| 2 x 512 x 512               | 230.52     | 161.41            |
| 4 x 512 x 512               | 508.00    | 299.19           |