### PR TITLE
add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+# Run the following command to reformat a file:
+# clang-format -i -style=Google <file>
+# Or use clang-format-diff to only reformat the changed lines:
+# https://clang.llvm.org/docs/ClangFormat.html
+BasedOnStyle: Google
+DerivePointerAlignment: false
+ColumnLimit:     100
+PointerAlignment: Left


### PR DESCRIPTION
This PR adds .clang-format to help follow Google C++ code style when using clang-format to reformat the C++ files. This issue was discussed in #1732 

CC @tqchen @jroesch @junrushao1994 