### PR TITLE
Fix LLVM initialization again

### DIFF
--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -5,15 +5,17 @@
 #ifdef TVM_LLVM_VERSION
 
 #include <tvm/base.h>
+#include <atomic>
 #include <mutex>
 #include "llvm_common.h"
 
 namespace tvm {
 namespace codegen {
 
+
 struct LLVMEnv {
   std::mutex mu;
-  volatile bool all_initialized{false};
+  std::atomic<bool> all_initialized{false};
 
   static LLVMEnv* Global() {
     static LLVMEnv inst;
@@ -23,15 +25,15 @@ struct LLVMEnv {
 
 void InitializeLLVM() {
   LLVMEnv* e = LLVMEnv::Global();
-  if (!e->all_initialized) {
+  if (!e->all_initialized.load(std::memory_order::memory_order_acquire)) {
     std::lock_guard<std::mutex> lock(e->mu);
-    if (!e->all_initialized) {
+    if (!e->all_initialized.load(std::memory_order::memory_order_acquire)) {
       llvm::InitializeAllTargetInfos();
       llvm::InitializeAllTargets();
       llvm::InitializeAllTargetMCs();
       llvm::InitializeAllAsmParsers();
       llvm::InitializeAllAsmPrinters();
-      e->all_initialized = true;
+      e->all_initialized.store(true, std::memory_order::memory_order_release);
     }
   }
 }

--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -12,7 +12,6 @@
 namespace tvm {
 namespace codegen {
 
-
 struct LLVMEnv {
   std::mutex mu;
   std::atomic<bool> all_initialized{false};


### PR DESCRIPTION
Change volatile to atomic.
Add release and acquire to maintain memory order.