### PR TITLE
[PASS]Treat Halide call_type as pure expression

### DIFF
--- a/tests/cpp/simple_passes_test.cc
+++ b/tests/cpp/simple_passes_test.cc
@@ -1,0 +1,22 @@
+#include <dmlc/logging.h>
+#include <gtest/gtest.h>
+#include <tvm/tvm.h>
+#include <tvm/ir_pass.h>
+
+TEST(SimplePasses, HasSideEffect) {
+  using namespace tvm;
+  auto n = var("n");
+  Array<Expr> shape;
+  shape.push_back(n);
+
+  auto A = placeholder(shape, Float(32), "A");
+
+  CHECK(!tvm::ir::HasSideEffect(A[0]));
+}
+
+
+int main(int argc, char ** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Submodule changes:
````
Submodule changes to be committed:

* 3rdparty/HalideIR a08e26e...6e7c1f0 (3):
  > Treat Halide call_type as pure expression (#41)
  > Added rules for Div simplification (#30)
  > [typo] depenency => dependency (#29)
````