### PR TITLE
[RELAY] Fix function call parsing for binary op

### DIFF
--- a/python/tvm/relay/grammar/Relay.g4
+++ b/python/tvm/relay/grammar/Relay.g4
@@ -53,14 +53,15 @@ prog: (defn* | expr) EOF ;
 expr
   // operators
   : '(' expr ')'                              # parens
+  // function application
+  | expr '(' (expr (',' expr)*)? ')'          # call
   | '-' expr                                  # neg
   | expr op=('*'|'/') expr                    # binOp
   | expr op=('+'|'-') expr                    # binOp
   | expr op=('<'|'>'|'<='|'>=') expr          # binOp
   | expr op=('=='|'!=') expr                  # binOp
 
-  // function definition and application
-  | expr '(' (expr (',' expr)*)? ')'          # call
+  // function definition
   | func                                      # funcExpr
 
   // tuples and tensors

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -316,6 +316,23 @@ def test_ifelse_scope():
 
 @if_parser_enabled
 def test_call():
+    # select right function to call: simple ident case
+    x = relay.Var("x")
+    id_func = relay.Var("id")
+    assert alpha_equal(
+        relay.fromtext(
+        """
+        let %id = fn (%x) { %x };
+        10 * %id(10)
+        """
+        ),
+        relay.Let(
+            id_func,
+            relay.Function([x], x, None, []),
+            relay.multiply(relay.const(10), relay.Call(id_func, [relay.const(10)]))
+        )
+    )
+
     # 0 args
     constant = relay.Var("constant")
     assert alpha_equal(

--- a/tests/python/relay/test_ir_parser.py
+++ b/tests/python/relay/test_ir_parser.py
@@ -317,7 +317,6 @@ def test_ifelse_scope():
 @if_parser_enabled
 def test_call():
     # select right function to call: simple ident case
-    x = relay.Var("x")
     id_func = relay.Var("id")
     assert alpha_equal(
         relay.fromtext(
@@ -328,7 +327,7 @@ def test_call():
         ),
         relay.Let(
             id_func,
-            relay.Function([x], x, None, []),
+            relay.Function([X], X, None, []),
             relay.multiply(relay.const(10), relay.Call(id_func, [relay.const(10)]))
         )
     )


### PR DESCRIPTION
The bug I'm fixing is for function call expression like `10 * f(1)`, current parser will treat `10 * f` as function and use it to create a `Call` expression. Then type check failed.

cc @joshpoll @jroesch 