### PR TITLE
[Relay] Fix handling a tuple node in op fusion

### DIFF
--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -740,8 +740,9 @@ class FuseMutator : private ExprMutator {
     Array<Expr> new_fields = GetNewArguments(tuple->fields, ret_group);
     Tuple new_tuple = TupleNode::make(new_fields);
     if (ret_group == gmap_.at(tuple)) {
-      bool isolated = true;
-      for (size_t i = 0; i < new_fields.size(); ++i) {
+      // This tuple is the root of its group. Check if all fields come from other groups.
+      bool isolated = new_fields.size() == ginfo_[ret_group].params.size();
+      for (size_t i = 0; i < new_fields.size() && isolated; ++i) {
         isolated &= (new_fields[i].same_as(ginfo_[ret_group].params[i]));
       }
       if (isolated) {


### PR DESCRIPTION
Fixes #2431. In #2187, I was making a false assumption that the number of fields of a tuple nodes is the same as the number of parameters to a function containing the tuple. But this is not always the case, since the field value can be generated inside the function (or group). 

For example, the [gluon SSD](https://github.com/dmlc/gluon-cv/blob/master/gluoncv/model_zoo/ssd/ssd.py#L239-L242) model returns class ids, bounding box scores, and locations, shown below. After converting to Relay, the three outputs are put into a tuple. Three `slice_axis` and the last tuple are put into the same group. This group has one parameter, `result`, but the tuple has three fields. This caused out of bounds access in #2431. 

```
  result = ...
  ids = F.slice_axis(result, axis=2, begin=0, end=1)
  scores = F.slice_axis(result, axis=2, begin=1, end=2)
  bboxes = F.slice_axis(result, axis=2, begin=2, end=6)
  return ids, scores, bboxes
```   

@tqchen @kevinthesun @jroesch please review.