### PR TITLE
[Relay] Fixes to sum

### DIFF
--- a/python/tvm/relay/op/reduce.py
+++ b/python/tvm/relay/op/reduce.py
@@ -12,8 +12,8 @@ def argmax(data, axis=None, keepdims=False, exclude=False):
         The input data
 
     axis : None or int or tuple of int
-        Axis or axes along which a argmin operation is performed.
-        The default, axis=None, will find the indices of maximum element all of the elements of
+        Axis or axes along which a argmax operation is performed.
+        The default, axis=None, will find the indices of the maximum element of the elements of
         the input array. If axis is negative it counts from the last to the first axis.
 
     keepdims : bool
@@ -104,9 +104,9 @@ def max(data, axis=None, keepdims=False, exclude=False):
         The input data
 
     axis : None or int or tuple of int
-        Axis or axes along which a argmin operation is performed.
-        The default, axis=None, will find the indices of minimum element all of the elements of
-        the input array. If axis is negative it counts from the last to the first axis.
+        Axis or axes along which the max operation is performed.
+        The default, axis=None, will find the max element from all of the elements of the input
+        array. If axis is negative it counts from the last to the first axis.
 
     keepdims : bool
         If this is set to True, the axes which are reduced are left in the result as dimensions
@@ -135,9 +135,10 @@ def min(data, axis=None, keepdims=False, exclude=False):
         The input data
 
     axis : None or int or tuple of int
-        Axis or axes along which a argmin operation is performed.
-        The default, axis=None, will find the indices of minimum element all of the elements of
-        the input array. If axis is negative it counts from the last to the first axis.
+        Axis or axes along which a minimum operation is performed.
+        The default, axis=None, will find the minimum element from all
+        of the elements of the input array. If axis is negative it counts from
+        the last to the first axis.
 
     keepdims : bool
         If this is set to True, the axes which are reduced are left in the result as dimensions
@@ -166,7 +167,7 @@ def mean(data, axis=None, keepdims=False, exclude=False):
         The input data
 
     axis : None or int or tuple of int
-        Axis or axes along which a argmin operation is performed.
+        Axis or axes along which a mean operation is performed.
         The default, axis=None, will find the indices of minimum element all of the elements of
         the input array. If axis is negative it counts from the last to the first axis.
 
@@ -197,7 +198,7 @@ def prod(data, axis=None, keepdims=False, exclude=False):
         The input data
 
     axis : None or int or tuple of int
-        Axis or axes along which a argmin operation is performed.
+        Axis or axes along which a product is performed.
         The default, axis=None, will find the indices of minimum element all of the elements of
         the input array. If axis is negative it counts from the last to the first axis.
 

--- a/python/tvm/relay/op/reduce.py
+++ b/python/tvm/relay/op/reduce.py
@@ -73,14 +73,14 @@ def sum(data, axis=None, keepdims=False, exclude=False):
         The input data
 
     axis : None or int or tuple of int
-        Axis or axes along which a argmin operation is performed.
-        The default, axis=None, will find the indices of minimum element all of the elements of
-        the input array. If axis is negative it counts from the last to the first axis.
+        Axis or axes along which a sum is performed. The default, axis=None,
+        will sum all of the elements of the input array. If axis is
+        negative it counts from the last to the first axis.
 
     keepdims : bool
-        If this is set to True, the axes which are reduced are left in the result as dimensions
-        with size one.
-        With this option, the result will broadcast correctly against the input array.
+        If this is set to True, the axes which are reduced are left in the result as
+        dimensions with size one. With this option, the result will broadcast
+        correctly against the input array.
 
     exclude : bool
         If `exclude` is true, reduction will be performed on the axes that are
@@ -91,7 +91,7 @@ def sum(data, axis=None, keepdims=False, exclude=False):
     result : relay.Expr
         The computed result.
     """
-    axis = [axis] if isinstance(axis, int) else axis
+    axis = [axis] if axis and isinstance(axis, int) else axis
     return _make.sum(data, axis, keepdims, exclude)
 
 

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -94,6 +94,7 @@ inline std::vector<int64_t> GetReduceAxes(const uint32_t indim,
     }
     r_axes[k++] = i;
   }
+
   return r_axes;
 }
 
@@ -136,12 +137,14 @@ Array<Tensor> ReduceCompute(const Attrs& attrs,
   const ReduceAttrs* param = attrs.as<ReduceAttrs>();
   CHECK(param != nullptr);
   auto axes = param->axis;
+
   if (param->exclude) {
     axes = GetExcludeAxes(inputs[0]->shape.size(), param->axis);
     if (axes.size() == 0) {
       return { topi::identity(inputs[0]) };
     }
   }
+
   return { f(inputs[0], axes, param->keepdims, false) };
 }
 

--- a/src/relay/op/tensor/reduce.cc
+++ b/src/relay/op/tensor/reduce.cc
@@ -94,7 +94,6 @@ inline std::vector<int64_t> GetReduceAxes(const uint32_t indim,
     }
     r_axes[k++] = i;
   }
-
   return r_axes;
 }
 
@@ -137,14 +136,12 @@ Array<Tensor> ReduceCompute(const Attrs& attrs,
   const ReduceAttrs* param = attrs.as<ReduceAttrs>();
   CHECK(param != nullptr);
   auto axes = param->axis;
-
   if (param->exclude) {
     axes = GetExcludeAxes(inputs[0]->shape.size(), param->axis);
     if (axes.size() == 0) {
       return { topi::identity(inputs[0]) };
     }
   }
-
   return { f(inputs[0], axes, param->keepdims, false) };
 }
 

--- a/tests/python/relay/test_op_level4.py
+++ b/tests/python/relay/test_op_level4.py
@@ -121,9 +121,6 @@ def test_where():
 
 def verify_reduce(funcs, data, axis, keepdims, exclude, output, dtype="float32"):
     test_func = funcs[0]
-
-
-
     ref_func = funcs[1]
 
     x = relay.var("x", relay.TensorType(data, dtype))

--- a/tests/python/relay/test_op_level4.py
+++ b/tests/python/relay/test_op_level4.py
@@ -121,6 +121,9 @@ def test_where():
 
 def verify_reduce(funcs, data, axis, keepdims, exclude, output, dtype="float32"):
     test_func = funcs[0]
+
+
+
     ref_func = funcs[1]
 
     x = relay.var("x", relay.TensorType(data, dtype))
@@ -180,6 +183,7 @@ def test_reduce_functions():
                  [relay.prod, np.prod],
                  [relay.argmin, _with_keepdims(np.argmin)],
                  [relay.argmax, _with_keepdims(np.argmax)]]:
+        verify_reduce(func, (d1, d2, d3, d4), None, False, False, ())
         verify_reduce(func, (d1, d2, d3, d4), 2, True, False, (d1, d2, 1, d4))
         verify_reduce(func, (d1, d2, d3), 1, True, False, (d1, 1, d3))
         verify_reduce(func, (d1, d2, d3), None, True, False, (1, 1, 1))


### PR DESCRIPTION
~Currently when you try to compile `op.sum(x, axis=None)` the type checker computes that the return type should be a scalar. When you actually code generate it calls `topi::identity` causing the output buffer to be the same size as the input buffer.~

@tqchen beat me to fixing this by an hour or so, just upstreamed the changes that are still good.

