### PR TITLE
Avoid runtime exception when file doesn't exist

### DIFF
--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -266,8 +266,11 @@ class ApplyHistoryBest(DispatchContext):
             Otherwise, it is an iterator.
         """
         from ..record import load_from_file
+        import os
 
         if isinstance(records, str):
+            if not os.path.isfile(records):
+                return
             records = load_from_file(records)
         if not records:
             return

--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -266,11 +266,8 @@ class ApplyHistoryBest(DispatchContext):
             Otherwise, it is an iterator.
         """
         from ..record import load_from_file
-        import os
 
         if isinstance(records, str):
-            if not os.path.isfile(records):
-                return
             records = load_from_file(records)
         if not records:
             return

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -77,7 +77,8 @@ def context(target, extra_files=None):
         for name in possible_names:
             name = _alias(name)
             if name in all_packages:
-                check_backend(name)
+                if not check_backend(name):
+                    continue
 
                 filename = "%s_%s.log" % (name, PACKAGE_VERSION[name])
                 best_context.load(os.path.join(AUTOTVM_TOPHUB_ROOT_PATH, filename))
@@ -98,6 +99,11 @@ def check_backend(backend):
     ----------
     backend: str
         The name of backend.
+
+    Returns
+    ----------
+    success: bool
+        Whether the check is successful.
     """
     backend = _alias(backend)
     assert backend in PACKAGE_VERSION, 'Cannot find backend "%s" in TopHub' % backend
@@ -105,7 +111,7 @@ def check_backend(backend):
     version = PACKAGE_VERSION[backend]
     package_name = "%s_%s.log" % (backend, version)
     if os.path.isfile(os.path.join(AUTOTVM_TOPHUB_ROOT_PATH, package_name)):
-        return
+        return True
 
     if sys.version_info >= (3,):
         import urllib.request as urllib2
@@ -113,8 +119,10 @@ def check_backend(backend):
         import urllib2
     try:
         download_package(package_name)
+        return True
     except urllib2.URLError as e:
         logging.warning("Failed to download tophub package for %s: %s", backend, e)
+        return False
 
 
 def download_package(package_name):


### PR DESCRIPTION
When running auto-tuning, autoTVM tries to read from history run logs. However, if the log file doesn't exist, and cannot download from the web, the run would fail. That is because `load_from_file(records)`
returns a generator, which is guaranteed to be not None. So it would fail in line 279 when iterating the `records`. 

I believe we need to return in case the `records` does not exist. 
