### PR TITLE
[RELAY][API] not show meta_data by default

### DIFF
--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -480,11 +480,12 @@ inline const TTypeNode* ExprNode::type_as() const {
  * \param show_meta_data Whether to print meta data section.
  * \param annotate An optional callback function for attaching
  *        additional comment block to an expr.
+ * \note show_meta_data field is necessary to fully parse the text format.
  * \return The text representation.
  */
 std::string RelayPrint(
     const NodeRef& node,
-    bool show_meta_data = true,
+    bool show_meta_data = false,
     runtime::TypedPackedFunc<std::string(Expr)> annotate = nullptr);
 }  // namespace relay
 }  // namespace tvm

--- a/python/tvm/relay/base.py
+++ b/python/tvm/relay/base.py
@@ -38,14 +38,14 @@ def register_relay_attr_node(type_key=None):
 
 class RelayNode(NodeBase):
     """Base class of all Relay nodes."""
-    def astext(self, show_meta_data=True, annotate=None):
+    def astext(self, show_meta_data=False, annotate=None):
         """Get the text format of the expression.
 
         Parameters
         ----------
         show_meta_data : bool
-            Whether to include meta data section in the text
-            if there is meta data.
+            Whether to include meta data section in the
+            text if there is meta data.
 
         annotate: Optional[relay.Expr->str]
             Optional annotate function to provide additional
@@ -54,7 +54,7 @@ class RelayNode(NodeBase):
         Note
         ----
         The metadata section is necessary to fully parse the text format.
-        However, it can contain dumps that are big (e.g constant weights)a,
+        However, it can contain dumps that are big (e.g constant weights),
         so it can be helpful to skip printing the meta data section.
 
         Returns


### PR DESCRIPTION
Background, relay_node.astext() is a quick way to print out the text format in the relay IR. previously, we include meta_data by default, this can leads to an explosive text being printed out when there is a constant weight node(which are encoded into base64).

This PR proposes to switch off this option by default because the astext API is usually used for debugging.  Note that we might want to introduce another API that allows us to get the full IR, something around save_xxx.

Since this API has not been released, I will propose this directly. 

cc @zhiics @jroesch @yzhliu @ZihengJiang 