### PR TITLE
[TEST] Remove script that references previously removed content.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,7 +220,6 @@ stage('Integration Test') {
         unpack_lib('gpu', tvm_multilib)
         timeout(time: max_time, unit: 'MINUTES') {
           sh "${docker_run} tvmai/ci-gpu ./tests/scripts/task_python_topi.sh"
-          sh "${docker_run} tvmai/ci-gpu ./tests/scripts/task_cpp_topi.sh"
         }
       }
     }

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -32,7 +32,6 @@ fi
 if [ ${TASK} == "cpp_test" ] || [ ${TASK} == "all_test" ]; then
     make -f dmlc-core/scripts/packages.mk gtest
     ./tests/scripts/task_cpp_unittest.sh || exit -1
-    ./tests/scripts/task_cpp_topi.sh || exit -1
 fi
 
 if [ ${TASK} == "python_test" ] || [ ${TASK} == "all_test" ]; then


### PR DESCRIPTION
Commit 6d1f4c0b5ced2ca890db4fdd436278a9d70280c7 removed the contents
of topi/tests/python_cpp but did not remove the task_cpp_topi.sh
script that references that content.  That script no longer serves any
purpose so remove it.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
