### PR TITLE
 [TVM][BUGFIX] Fix missing reduction init predicates

### DIFF
--- a/src/op/compute_op.cc
+++ b/src/op/compute_op.cc
@@ -457,11 +457,11 @@ ComputeLoopNest ComputeLoopNest::make(
       ret.init_vmap[iv] = ret.main_vmap.at(iv);
     }
     ret.num_common_loop = begin_loop;
-    // skip loops that does not relates to axis.
+    // skip loops that are related to reduction axes.
     std::unordered_set<IterVar> skip_iter;
     for (auto kv : update_state) {
       int flag = kv.second;
-      if ((flag & 1) == 0) skip_iter.insert(kv.first);
+      if ((flag & 2) != 0) skip_iter.insert(kv.first);
     }
     ret.init_nest = op::MakeLoopNest(
         stage, dom_map, begin_loop, true,

--- a/src/op/compute_op.cc
+++ b/src/op/compute_op.cc
@@ -457,11 +457,11 @@ ComputeLoopNest ComputeLoopNest::make(
       ret.init_vmap[iv] = ret.main_vmap.at(iv);
     }
     ret.num_common_loop = begin_loop;
-    // skip loops that are related to reduction axes.
+    // skip loops that are related to reduction and are unrelated to axis.
     std::unordered_set<IterVar> skip_iter;
     for (auto kv : update_state) {
       int flag = kv.second;
-      if ((flag & 2) != 0) skip_iter.insert(kv.first);
+      if (flag == 2) skip_iter.insert(kv.first);
     }
     ret.init_nest = op::MakeLoopNest(
         stage, dom_map, begin_loop, true,

--- a/src/op/tensor_compute_op.cc
+++ b/src/op/tensor_compute_op.cc
@@ -215,11 +215,11 @@ ComputeLoopNest MakeLoopNest(
       ret.init_vmap[iv] = ret.main_vmap.at(iv);
     }
     ret.num_common_loop = begin_loop;
-    // skip loops that does not relates to axis.
+    // skip loops that are related to reduction axes.
     std::unordered_set<IterVar> skip_iter;
     for (auto kv : update_state) {
       int flag = kv.second;
-      if ((flag & 1) == 0) skip_iter.insert(kv.first);
+      if ((flag & 2) != 0) skip_iter.insert(kv.first);
     }
     ret.init_nest = op::MakeLoopNest(
         stage, dom_map, begin_loop, true,

--- a/src/op/tensor_compute_op.cc
+++ b/src/op/tensor_compute_op.cc
@@ -215,11 +215,11 @@ ComputeLoopNest MakeLoopNest(
       ret.init_vmap[iv] = ret.main_vmap.at(iv);
     }
     ret.num_common_loop = begin_loop;
-    // skip loops that are related to reduction axes.
+    // skip loops that are related to reduction and are unrelated to axis.
     std::unordered_set<IterVar> skip_iter;
     for (auto kv : update_state) {
       int flag = kv.second;
-      if ((flag & 2) != 0) skip_iter.insert(kv.first);
+      if (flag == 2) skip_iter.insert(kv.first);
     }
     ret.init_nest = op::MakeLoopNest(
         stage, dom_map, begin_loop, true,

--- a/tests/python/unittest/test_schedule_schedule_ops.py
+++ b/tests/python/unittest/test_schedule_schedule_ops.py
@@ -1,5 +1,5 @@
 import tvm
-
+import numpy as np
 
 def test_schedule0():
     m = tvm.var('m')
@@ -432,6 +432,19 @@ def test_loop_dep_reduce_cache_write():
     s.cache_write(Y, 'local')
     f = tvm.build(s, [X, Y])
 
+def test_reduction_and_dummy_fuse_split():
+    n = 10
+    X = tvm.placeholder(shape=(10,), dtype='int32', name="X")
+    k = tvm.reduce_axis((0, n))
+    Y = tvm.compute((), lambda: tvm.sum(X[k], k), name="Y")
+    s = tvm.create_schedule([Y.op])
+    ax = s[Y.op].fuse(*Y.op.axis)
+    axo, axi = s[Y.op].split(ax, nparts=20)
+    f = tvm.build(s, [Y, X])
+
+    args = [tvm.nd.empty((), 'int32')] + [tvm.ndarray.array(np.ones((n,), dtype='int32'))]
+    f(*args)
+    assert args[0].asnumpy() == n
 
 if __name__ == "__main__":
     test_loop_dep_reduce()
@@ -456,3 +469,4 @@ if __name__ == "__main__":
     test_schedule_tensor_compute1()
     test_schedule_tensor_compute2()
     test_schedule_tensor_compute3()
+    test_reduction_and_dummy_fuse_split()


### PR DESCRIPTION
The commit 6fdc3e0 triggered the following bug. Consider this code:
```python
    n = 10
    X = tvm.placeholder(shape=(10,), dtype='int32', name="X")
    k = tvm.reduce_axis((0, n))
    Y = tvm.compute((), lambda: tvm.sum(X[k], k), name="Y")

    s = tvm.create_schedule([Y.op])
    ax = s[Y.op].fuse(*Y.op.axis)
    axo, axi = s[Y.op].split(ax, nparts=20)

    print(tvm.lower(s, [Y, X], simple_mode=True))
```

Before 6fdc3e0 the generated code looked like this:
```
produce Y {
  for (singleton.outer, 0, 20) {
    Y[0] = 0
    for (rv, 0, 10) {
      Y[0] = (Y[0] + X[rv])
    }
  }
}
```

After 6fdc3e0 the code looks like this:
```
produce Y {
  for (singleton.outer, 0, 20) {
    Y[0] = 0
    for (rv, 0, 10) {
      if (likely((singleton.outer < 1))) {
        Y[0] = (Y[0] + X[rv])
      }
    }
  }
}
```
which is wrong, the result gets reset to zero. The reason is that the initialization is not guarded by the condition `singleton.outer < 1`.

The fix I propose is to skip loops related to the reduction axes instead of skipping loops unrelated to the compute op axes when generating predicates for the initialization code. The result now looks like this:
```
produce Y {
  for (singleton.outer, 0, 20) {
    if (likely((singleton.outer < 1))) {
      Y[0] = 0
    }
    for (rv, 0, 10) {
      if (likely((singleton.outer < 1))) {
        Y[0] = (Y[0] + X[rv])
      }
    }
  }
}
```

@tqchen @derisavi Please take a look.