### PR TITLE
[RUST] Update Cargo crate authors

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/dmlc/tvm"
 readme = "README.md"
 keywords = ["tvm", "nnvm"]
 categories = ["api-bindings", "science"]
-authors = ["Nick Hynes <nhynes@berkeley.edu>"]
+authors = ["TVM Contributors"]
 
 [features]
 default = ["nom/std"]


### PR DESCRIPTION
This PR updates the `Cargo.toml` `authors` in preparation for #2292 and #2466. This, and the rest of the field, will be visible on [crates.io](https://crates.io/crates/tvm)).

