### PR TITLE
[Rust] Update rustc

### DIFF
--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -3,12 +3,12 @@ apt-get update && apt-get install -y --no-install-recommends --force-yes curl
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 # this rustc is one supported by the installed version of rust-sgx-sdk
-curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2018-10-01
+curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2019-01-28
 . $CARGO_HOME/env
 rustup toolchain add nightly
 rustup component add rust-src
 cargo +nightly install sccache
-cargo +nightly install rustfmt-nightly --version 0.99.5 --force
+cargo +nightly install rustfmt-nightly --version 1.0.1 --force
 cargo +nightly install xargo
 
 # make rust usable by all users

--- a/docker/install/ubuntu_install_sgx.sh
+++ b/docker/install/ubuntu_install_sgx.sh
@@ -16,6 +16,6 @@ cd -
 
 git clone https://github.com/baidu/rust-sgx-sdk.git /opt/rust-sgx-sdk
 cd /opt/rust-sgx-sdk
-git checkout v1.0.4
-curl 'https://gist.githubusercontent.com/nhynes/37164039c5d3f33aa4f123e4ba720036/raw/5b7fc24d4faa0bd6efce19f8324f79d5562991e0/rust-sgx-sdk.diff' | git apply
+git checkout 6098af # v1.0.5
+curl 'https://gist.githubusercontent.com/nhynes/37164039c5d3f33aa4f123e4ba720036/raw/b0de575fe937231799930764e76c664b92975163/rust-sgx-sdk.diff' | git apply
 cd -


### PR DESCRIPTION
This bumps rustc to a 2018-compatible toolchain version and also updates to stable rustfmt-nightly (not an oxymoron, I promise). This PR is in preparation for #2292 