### PR TITLE
add `min_repeat_ms` to other CUDA tutorials

### DIFF
--- a/tutorials/autotvm/tune_nnvm_cuda.py
+++ b/tutorials/autotvm/tune_nnvm_cuda.py
@@ -118,7 +118,7 @@ tuning_option = {
 
     'measure_option': autotvm.measure_option(
         builder=autotvm.LocalBuilder(timeout=10),
-        runner=autotvm.LocalRunner(number=20, repeat=3, timeout=4),
+        runner=autotvm.LocalRunner(number=20, repeat=3, timeout=4, min_repeat_ms=150),
     ),
 }
 
@@ -369,6 +369,6 @@ tuning_option = {
         runner=autotvm.RPCRunner(
             '1080ti',  # change the device key to your key
             'localhost', 9190,
-            number=20, repeat=3, timeout=4),
+            number=20, repeat=3, timeout=4, min_repeat_ms=150),
     ),
 }


### PR DESCRIPTION
Just noticed that we added this default value to the other tutorial but not this one.