### PR TITLE
[TFLite][Python 2] Solve TFLite frontend python 2 compatibility

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -546,7 +546,7 @@ def get_pad_value(data, kernel, stride):
         pad tuple of value
     """
 
-    out = math.ceil(float(data) / float(stride))
+    out = int(math.ceil(float(data) / float(stride)))
     pad = max(0, (out - 1) * stride + kernel - data)
     pad_before = pad // 2
     pad_after = pad - pad_before

--- a/tutorials/frontend/from_tflite.py
+++ b/tutorials/frontend/from_tflite.py
@@ -18,11 +18,11 @@ To install TFlite packages, you could use our prebuilt wheel:
 .. code-block:: bash
 
     # For python3:
-    wget https://github.com/dmlc/web-data/tree/master/tensorflow/tflite/whl/tflite-0.0.1-py3-none-any.whl
+    wget https://raw.githubusercontent.com/dmlc/web-data/master/tensorflow/tflite/whl/tflite-0.0.1-py3-none-any.whl
     pip install tflite-0.0.1-py3-none-any.whl --user
 
     # For python2:
-    wget https://github.com/dmlc/web-data/tree/master/tensorflow/tflite/whl/tflite-0.0.1-py2-none-any.whl
+    wget https://raw.githubusercontent.com/dmlc/web-data/master/tensorflow/tflite/whl/tflite-0.0.1-py2-none-any.whl
     pip install tflite-0.0.1-py2-none-any.whl --user
 
 


### PR DESCRIPTION
When use Python 2 to compile TFLite model will raise `Check failed: width1 != nullptr` error. The root cause is Python 2's`math.ceil` return `float`, but Python 3 return `int`.

Python 2: https://docs.python.org/2.7/library/math.html#math.ceil
Python 3: https://docs.python.org/3.6/library/math.html#math.ceil

This changeset also modify the doc's TFLite whl file download path. Previous path is not raw and will get HTML file.

@yzhliu Please review and could this changeset be into 0.5 release? Thanks.