### PR TITLE
[RELAY] Copy subfunction arguments to output tuple field

### DIFF
--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -318,6 +318,13 @@ inline Expr ReshapeLike(Expr lhs, Expr rhs) {
   return CallNode::make(op, {lhs, rhs}, Attrs(), {});
 }
 
+
+inline Expr Copy(Expr data) {
+  static const Op& op = Op::Get("copy");
+  return CallNode::make(op, {data}, Attrs(), {});
+}
+
+
 Expr MakeConcatenate(Expr data, int axis);
 
 Expr MakeStridedSlice(Expr data, Array<Integer> begin, Array<Integer> end, Array<Integer> strides);

--- a/tests/python/relay/test_backend_compile_engine.py
+++ b/tests/python/relay/test_backend_compile_engine.py
@@ -43,6 +43,18 @@ def test_compile_placeholder_bypass():
     with relay.build_config(opt_level=0):
        graph, lib, params = relay.build(func, 'llvm')
 
+
+def test_compile_injective_with_tuple():
+    x = relay.var("x", shape=(2, 3))
+    y = relay.var("y", shape=(2, 3))
+    x_transpose = relay.transpose(x)
+    output = relay.Tuple([x_transpose, y])
+    func = relay.Function([x, y], output)
+    relay.build(func, 'llvm')
+
+
 if __name__ == "__main__":
     test_compile_engine()
     test_compile_placeholder_bypass()
+    test_compile_injective_with_tuple()
+

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -161,8 +161,9 @@ def test_tuple_root():
 
         p0 = relay.var("p0", shape=(dshape[0], dshape[1], dshape[2]//2, dshape[3]//2))
         p1 = relay.var("p1", shape=(dshape[0], dshape[1], dshape[2], dshape[3]))
+        p1_copy = relay.copy(p1)
         upsampled = relay.nn.upsampling(p0, scale=2, layout="NCHW")
-        out = relay.Tuple((upsampled, p1))
+        out = relay.Tuple((upsampled, p1_copy))
         f1 = relay.Function([p0, p1], out)
 
         x = relay.var("x", shape=dshape)


### PR DESCRIPTION
As discussed in https://discuss.tvm.ai/t/relay-injective-ops-do-not-work-with-tuple/1526, the tuple output of subfunction may be incorrect because currently storage allocator doesn't support inplace operations.

First, we have issue in codegen for the assert added by `ArgBinder` if the input and output buffer are the same (the testcase doesn't compile before this patch).

Second,  in the below example,
```
  %0 = fn(%p0: Tensor[(100, 5), float32],
          %p1: Tensor[(100, 7), float32])
          -> Tuple[Tensor[(100, 5), float32], Tensor[(7, 100), float32]] {
    %1 = transpose(%p1, axes=None)
    %2 = (%p0, %1)
    %2
  }
  %3 = %0(%data_0, %data_1)
```
The function param `%p0` is returned as one of the output tuple fields. However, new storage tokens are allocated for each output field (it should have the same storage token as the first argument).

In `OpFusion`, we copy the function argument to the output field. Since tuple output is only used in a few cases, memory copy won't cause great performance regression.

Please review @tqchen @masahi 