### PR TITLE
[VERSION] Move version script to the project root

### DIFF
--- a/version.py
+++ b/version.py
@@ -46,8 +46,7 @@ def update(file_name, pattern, repl):
 
 
 def main():
-    curr_dir = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    proj_root = os.path.abspath(os.path.join(curr_dir, ".."))
+    proj_root = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
     # python path
     update(os.path.join(proj_root, "python", "tvm", "_ffi", "libinfo.py"),
            r"(?<=__version__ = \")[.0-9a-z]+", __version__)


### PR DESCRIPTION
The version.py script is used to synchronize the version info among all the packages. We need to do some updates to enable version sync for

- golang @srkreddy1238 
- rust @nhynes 
- jvm @yzhliu 