### PR TITLE
More Strongly-Typed Rust Bindings

### DIFF
--- a/rust/common/src/value.rs
+++ b/rust/common/src/value.rs
@@ -329,6 +329,7 @@ impl TVMRetValue {
             | TVMTypeCode::kArrayHandle
             | TVMTypeCode::kNodeHandle
             | TVMTypeCode::kModuleHandle
+            | TVMTypeCode::kNDArrayContainer
             | TVMTypeCode::kFuncHandle => {
                 Self::new(value.v_handle as usize, box value.v_handle, type_code)
             }

--- a/rust/frontend/src/errors.rs
+++ b/rust/frontend/src/errors.rs
@@ -46,6 +46,7 @@ error_chain! {
         NulError(ffi::NulError);
         IntoStringError(ffi::IntoStringError);
         CommonError(common_errors::Error);
+        IoError(std::io::Error);
     }
 }
 

--- a/rust/frontend/src/errors.rs
+++ b/rust/frontend/src/errors.rs
@@ -15,9 +15,14 @@ error_chain! {
             display("requested `{}` handle is null", name)
         }
 
-        FunctionNotFound {
-            description("function not found")
-            display("function was not set in `function::Builder`")
+        FunctionNotSet {
+            description("packed function not set")
+            display("packed function was not set in `function::Builder` or does not exist in the global registry")
+        }
+
+        FunctionNotFound(name: String) {
+            description("packed function not found")
+            display("packed function `{}` does not exist in the global registry", name)
         }
 
         TypeMismatch(expected: String, found: String) {

--- a/rust/frontend/src/graph_runtime.rs
+++ b/rust/frontend/src/graph_runtime.rs
@@ -1,0 +1,24 @@
+use crate::{ Module, TVMContext, TVMDeviceType, NDArray, Result, ErrorKind };
+use std::fs;
+use std::path::Path;
+
+pub struct RuntimeModule {
+    module: Module
+}
+
+impl RuntimeModule {
+    pub fn from_paths<P: AsRef<Path>, Q: AsRef<Path>>(graph_json_path: P, lib_path: Q, ctx: TVMContext) -> Result<Self> {
+        let graph = fs::read_to_string(&graph_json_path)?;
+        let lib = Module::load(&lib_path)?;
+        RuntimeModule::new(&graph[..], &lib, ctx)
+    }
+
+    pub fn new(graph: &str, lib: &Module, ctx: TVMContext) -> Result<Self> {
+        let module = packed::create(graph, lib, &ctx.device_type, &ctx.device_id)?;
+        Ok(RuntimeModule { module })
+    }
+}
+
+wrap_packed_globals! {
+    fn tvm.graph_runtime::create(graph: &str, lib: &Module, ty: &TVMDeviceType, id: &usize) -> Result<Module>;
+}

--- a/rust/frontend/src/graph_runtime.rs
+++ b/rust/frontend/src/graph_runtime.rs
@@ -1,24 +1,101 @@
-use crate::{ Module, TVMContext, TVMDeviceType, NDArray, Result, ErrorKind };
-use std::fs;
-use std::path::Path;
+use crate::{
+    Module, TVMContext, TVMDeviceType,
+    TVMByteArray, NDArray, Result, Function
+};
+use std::{
+    fs,
+    path::Path,
+    convert::TryInto
+};
 
-pub struct RuntimeModule {
-    module: Module
+#[allow(unused)]
+pub struct GraphModule {
+    module: Module,
+    set_input_: Function,
+    get_input_: Function,
+    get_output_: Function,
+    get_num_outputs_: Function,
+    run_: Function,
+    load_params_: Function
 }
 
-impl RuntimeModule {
-    pub fn from_paths<P: AsRef<Path>, Q: AsRef<Path>>(graph_json_path: P, lib_path: Q, ctx: TVMContext) -> Result<Self> {
+impl GraphModule {
+    pub fn from_paths<P: AsRef<Path>, Q: AsRef<Path>, R: AsRef<Path>>(
+        graph_json_path: P,
+        lib_path: Q,
+        params_path: R,
+        ctx: TVMContext
+    ) -> Result<Self> {
         let graph = fs::read_to_string(&graph_json_path)?;
         let lib = Module::load(&lib_path)?;
-        RuntimeModule::new(&graph[..], &lib, ctx)
+        let params: Vec<u8> = fs::read(&params_path)?;
+        let mut result = GraphModule::new(&graph[..], &lib, ctx)?;
+        result.load_params(TVMByteArray::from(&params));
+        Ok(result)
     }
 
     pub fn new(graph: &str, lib: &Module, ctx: TVMContext) -> Result<Self> {
         let module = packed::create(graph, lib, &ctx.device_type, &ctx.device_id)?;
-        Ok(RuntimeModule { module })
+
+        let set_input_ = module.get_function("set_input", false).expect("no set_input, invalid GraphModule");
+        let get_input_ = module.get_function("get_input", false).expect("no get_input, invalid GraphModule");
+        let get_output_ = module.get_function("get_output", false).expect("no get_output, invalid GraphModule");
+        let get_num_outputs_ = module.get_function("get_num_outputs", false).expect("no get_num_outputs, invalid GraphModule");
+        let run_ = module.get_function("run", false).expect("no run_, invalid GraphModule");
+        let load_params_ = module.get_function("load_params", false).expect("no load_params_, invalid GraphModule");
+
+        Ok(GraphModule { module, set_input_, get_input_, get_output_, get_num_outputs_, run_, load_params_ })
+    }
+
+    // TODO: should these functions return Result?
+
+    pub fn load_params<B: Into<TVMByteArray>>(&mut self, params: B) {
+        let params: TVMByteArray = params.into();
+        call_packed!(&self.load_params_, &params).expect("load params failed");
+    }
+
+    pub fn set_input(&mut self, name: &str, input: &NDArray) {
+        call_packed!(&self.set_input_, name, input).expect("set input failed");
+    }
+
+    pub fn get_num_outputs(&mut self) -> usize {
+        let num_outputs: i32 = call_packed!(&self.get_num_outputs_,).expect("get num outputs failed")
+            .try_into().expect("incorrect num_outputs type");
+        num_outputs as usize
+    }
+
+    pub fn set_input_by_index(&mut self, index: usize, input: &NDArray) {
+        call_packed!(&self.set_input_, &index, input).expect("set input failed");
+    }
+
+    pub fn copy_output_to(&mut self, index: usize, output: &NDArray) {
+        call_packed!(&self.get_output_, &index, output).expect("get output failed");
+    }
+
+    pub fn get_output(&mut self, index: usize) -> NDArray {
+        call_packed!(&self.get_output_, &index).expect("get output failed")
+            .try_into().expect("incorrect get_output type")
+    }
+
+    pub fn run(&mut self) {
+        call_packed!(&self.run_,).expect("run failed");
+    }
+
+    pub fn apply(&mut self, inputs: &[&NDArray]) -> Vec<NDArray> {
+        for (i, input) in inputs.iter().enumerate() {
+            self.set_input_by_index(i, input);
+        }
+        self.run();
+        let outputs = self.get_num_outputs();
+        (0..outputs).map(|i| self.get_output(i)).collect()
     }
 }
 
 wrap_packed_globals! {
-    fn tvm.graph_runtime::create(graph: &str, lib: &Module, ty: &TVMDeviceType, id: &usize) -> Result<Module>;
+    fn tvm.graph_runtime::create(
+        graph: &str,
+        lib: &Module,
+        ty: &TVMDeviceType,
+        id: &usize
+    ) -> Result<Module>;
 }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -19,8 +19,7 @@
     try_trait,
     fn_traits,
     unboxed_closures,
-    box_syntax,
-    option_replace
+    box_syntax
 )]
 
 #[macro_use]
@@ -68,11 +67,14 @@ pub(crate) fn set_last_error(err: &Error) {
 pub mod function;
 pub mod bytearray;
 pub mod context;
+#[allow(deprecated)]
 pub mod errors;
 pub mod module;
 pub mod ndarray;
 pub mod ty;
 pub mod value;
+
+pub mod graph_runtime;
 
 pub use crate::{
     bytearray::TVMByteArray,


### PR DESCRIPTION
After reading #2523 I was messing with the newly-merged Rust API and noticed some some changes that might be helpful.
The main change this PR makes is to start adding some "typed" rust APIs, which look like normal rust functions / structs, and call tvm PackedFuncs under the hood. The rust graph runtime example is now much simpler:

```rust
    let image: ndarray::Array = /* ... load image in Rust ... */;

    let input = tvm_frontend::NDArray::from_rust_ndarray(
        &image,
        TVMContext::cpu(0),
        TVMType::from("float32")
    )?;

    let mut module = GraphModule::from_paths(
        concat!(env!("CARGO_MANIFEST_DIR"), "/deploy_graph.json"),
        concat!(env!("CARGO_MANIFEST_DIR"), "/deploy_lib.so"),
        concat!(env!("CARGO_MANIFEST_DIR"), "/deploy_param.params"),
        ctx
    )?;

    let mut result: Vec<tvm_frontend::NDArray> = module.apply(&[&input]);
```

Of course, all the old PackedFunc functionality is still there. This just makes well-defined APIs a little easier to use.

This approach could be used for binding the non-runtime APIs as well, I think. (Which I want, because I kinda wanna make a tvm-backed rust deep learning framework at some point... that's the far future though ;))

I've also fixed up a few other random things I've noticed:
- I think the old `Function::get` implementation would break for freshly registered globals, so I made it more dynamic
- I allowed `kNDArrayContainer`s to be returned from PackedFuncs without blowing up... probably. The example works, anyway. I don't entirely understand what's going on with the stuff in `common::value` though.

TODO:
- [ ] more docs
- [ ] more tests
- [ ] run rustfmt

Open questions:
- What other APIs would be good to wrap with types?

CC @ehsanmok , hope it's okay that i'm poking around in your code :)