### PR TITLE
Tighten buffer bound for TensorComputeOp by improving EvalSet on ranges

### DIFF
--- a/tests/python/unittest/test_schedule_bound_inference.py
+++ b/tests/python/unittest/test_schedule_bound_inference.py
@@ -259,6 +259,7 @@ def test_gemm_bound():
     assert(bounds[CC.op.axis[0]].extent.value == 8)
     assert(bounds[CC.op.axis[1]].extent.value == 8)
 
+
 def test_bound_tensor_compute_op():
     def intrin_test():
       m1 = tvm.var("m1")
@@ -283,11 +284,11 @@ def test_bound_tensor_compute_op():
     test_func = intrin_test()
     A = tvm.placeholder((20,20), name='A')
     B = tvm.compute(A.shape, lambda i,j : A[i,j], name='B')
-    C = tvm.compute((10, 20), lambda i : test_func(B[i:(i+3), 0:20]), name='C')
+    C = tvm.compute((10, 20), lambda i : test_func(B[i:10, 0:20]), name='C')
     s = tvm.create_schedule(C.op)
     bounds = tvm.schedule.InferBound(s)
     assert isinstance(bounds, tvm.container.Map)
-    assert(bounds[B.op.axis[0]].extent.value == 12)
+    assert(bounds[B.op.axis[0]].extent.value == 10)
 
 if __name__ == "__main__":
     test_bound_nest_thread()

--- a/tests/python/unittest/test_schedule_bound_inference.py
+++ b/tests/python/unittest/test_schedule_bound_inference.py
@@ -259,6 +259,35 @@ def test_gemm_bound():
     assert(bounds[CC.op.axis[0]].extent.value == 8)
     assert(bounds[CC.op.axis[1]].extent.value == 8)
 
+def test_bound_tensor_compute_op():
+    def intrin_test():
+      m1 = tvm.var("m1")
+      n1 = tvm.var("n1")
+      a = tvm.placeholder((m1, n1), name='a')
+      c = tvm.compute((1, n1), lambda i, j : a[0, j] + a[1, j] + a[2, j], name='c')
+
+      Ab = tvm.decl_buffer(a.shape, name="Abuf", offset_factor=1)
+      Cb = tvm.decl_buffer(c.shape, name="Cbuf", offset_factor=1)
+
+      def intrin_func(ins, outs):
+        aa = ins[0]
+        cc = outs[0]
+        def _body():
+          ib = tvm.ir_builder.create()
+          ib.emit(tvm.call_extern("int32", "test", cc.access_ptr("w"), aa.access_ptr("r")))
+          return ib.get()
+        return _body()
+      with tvm.build_config(offset_factor=1):
+        return tvm.decl_tensor_intrin(c.op, intrin_func, binds={a : Ab, c : Cb})
+
+    test_func = intrin_test()
+    A = tvm.placeholder((20,20), name='A')
+    B = tvm.compute(A.shape, lambda i,j : A[i,j], name='B')
+    C = tvm.compute((10, 20), lambda i : test_func(B[i:(i+3), 0:20]), name='C')
+    s = tvm.create_schedule(C.op)
+    bounds = tvm.schedule.InferBound(s)
+    assert isinstance(bounds, tvm.container.Map)
+    assert(bounds[B.op.axis[0]].extent.value == 12)
 
 if __name__ == "__main__":
     test_bound_nest_thread()
@@ -273,3 +302,4 @@ if __name__ == "__main__":
     test_bound2()
     test_gemm_bound()
     test_bound_warp()
+    test_bound_tensor_compute_op()


### PR DESCRIPTION
Tighten buffer bounds for TensorComputeOp by improving EvalSet on ranges. (#2564)

Buffers used by TensorComputeOp can be unnecessarily large, as described in #2564  
Tighten these buffer bounds, by modifying EvalSet to use the following formula to calculate the maximum value of the range:

max(range) = max(min + extent - 1)

This formula can provide a tighter bound when min and extent share variables. 

For example, if min=i and extent=(10 - i), with i in the domain [0, 9], then EvalSet currently returns [0, 18].  
Using the new formula, max(range) = max( i + (10 - i) - 1) = max(10 - 1)=max(9). 
Therefore EvalSet now returns [0, 9], which is much tighter than [0, 18].