### PR TITLE
[Graph Runtime] Add get_output_name

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -343,6 +343,13 @@ PackedFunc GraphRuntime::GetFunction(
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
         *rv = this->NumOutputs();
       });
+  } else if (name == "get_output_name") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      int index = args[0];
+      CHECK_LT(static_cast<size_t>(index), outputs_.size());
+      uint32_t eid = this->entry_id(outputs_[index]);
+      *rv = this->GetNodeName(eid);
+    });
   } else if (name == "run") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
         this->Run();


### PR DESCRIPTION
We have a use case where we would like to ship the pre winograd transform weights (for the sake of smaller model size) and then run them through the pregraph to get the transformed weights at runtime. The `get_output_name` function is needed to allow us to execute the extracted pregraph at runtime. The client code looks like this:
```
// load pregraph_module
// load run_module

// set input for pregraph_module

// run pregraph
pregraph_module_->run();

// set weights for run module
for (int i = 0; i < static_cast<int>(pregraph_module_->get_num_outputs()); i++) {
  run_module_->set_input(
      pregraph_module_->get_output_name(i), pregraph_module_->get_output(i));
}

// set input for the run module

// run graph
run_module_->run();   
```

@tqchen, @siju-samuel, @ajtulloch, please review