### PR TITLE
[Python dep] Add missing dep pkg for relay

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -129,6 +129,7 @@ setup(name='tvm',
       install_requires=[
         'numpy',
         'decorator',
+        'attrs',
         ],
       packages=find_packages(),
       distclass=BinaryDistribution,


### PR DESCRIPTION
Relay is using pkg ```attrs``` but is missing in dependancy. 