### PR TITLE
Fix the FInplaceIdentity

### DIFF
--- a/nnvm/src/pass/plan_memory.cc
+++ b/nnvm/src/pass/plan_memory.cc
@@ -9,6 +9,7 @@
 #include <nnvm/op_attr_types.h>
 #include <nnvm/top/tensor.h>
 #include <memory>
+#include <set>
 #include "graph_algorithm.h"
 
 namespace nnvm {
@@ -37,6 +38,22 @@ static int GetDTypeSize(int type_flag) {
       LOG(FATAL) << "unknown type_flag=" << type_flag;
       return -1;
   }
+}
+
+static bool BitwiseCompatibleTypes(int type1, int type2) {
+  static std::set<std::pair<int, int>> compatible_pairs { {kUint8, kInt8},
+                                                          {kUint16, kInt16},
+                                                          {kUint32, kInt32},
+                                                          {kUint64, kInt64} };
+  if (type1 == type2) {
+    return true;
+  }
+  if (compatible_pairs.find(std::make_pair(type1, type2)) != compatible_pairs.end() ||
+      compatible_pairs.find(std::make_pair(type2, type1)) != compatible_pairs.end()) {
+    return true;
+  }
+
+  return false;
 }
 
 // simple graph based allocator.
@@ -218,10 +235,15 @@ size_t AllocMemory(const Graph& ret, const IndexedGraph& idx,
         bool ignore_all_inputs = (fignore_inputs.count(inode.source->op()) != 0 &&
                                   fignore_inputs[inode.source->op()](
                                       inode.source->attrs).size() == inode.source->num_inputs());
+        // Identity should only be true if shape.Size() match and type
+        // is bitwise compatible
+        bool real_identity = identity[ipair] &&
+                             shape_vec[eid_out].Size() == shape_vec[eid_in].Size() &&
+                             BitwiseCompatibleTypes(dtype_vec[eid_out], dtype_vec[eid_in]);
         if (taken[kv.first] == false &&
             sid_out == GraphAllocator::kBadStorageID &&
             sid_in >= 0 &&
-            ((storage_ref_count[sid_in] == 1 && !ignore_all_inputs) || identity[ipair]) &&
+            ((storage_ref_count[sid_in] == 1 && !ignore_all_inputs) || real_identity) &&
             entry_ref_count[eid_out] > 0 &&
             shape_vec[eid_out].Size() == shape_vec[eid_in].Size() &&
              (dtype_vec[eid_out] == dtype_vec[eid_in] ||


### PR DESCRIPTION
Currently NNVM operators that **could** be identity under certain conditions (e.g. Cast from type A to type A) cannot be marked with FInplaceIdentity option. It is because PR #1696 changed the requirements of inplace optimization (including identity) to not check for the exact type match, and the operator itself does not have sufficient information inside FInplaceIdentity function to be able to set the option only if it is actually identity.

This PR restricts identity in the memory plan pass to honor FInplaceIdentity option from operator only if shape sizes match and if types of input and output are bitwise compatible (by which I mean cast from dtype1 to dtype2 does not change anything in memory, like going from int32_t to uint32_t).

@eric-haibin-lin FYI
Adding author of PR #1696 @ZhennanQin for comment if this approach still satisfies their needs.