### PR TITLE
[Relay][Docs] Documentation for Algebraic Data Types

### DIFF
--- a/docs/langref/index.rst
+++ b/docs/langref/index.rst
@@ -10,7 +10,7 @@ Relay is a functional, differentiable programming language
 designed to be an expressive intermediate representation for machine
 learning systems. Relay supports algebraic data types, closures,
 control flow, and recursion, allowing it to directly represent more
-complex models than can computation graph-based IRs.
+complex models than computation graph-based IRs can.
 Relay also includes a form of dependent typing using *type relations*
 in order to handle shape analysis for operators with complex
 requirements on argument shapes.

--- a/docs/langref/index.rst
+++ b/docs/langref/index.rst
@@ -8,9 +8,9 @@ Introduction to Relay
 
 Relay is a functional, differentiable programming language
 designed to be an expressive intermediate representation for machine
-learning systems. Relay supports closures, control flow, and
-recursion, allowing it to directly represent more complex models
-than can computation graph-based IRs.
+learning systems. Relay supports algebraic data types, closures,
+control flow, and recursion, allowing it to directly represent more
+complex models than can computation graph-based IRs.
 Relay also includes a form of dependent typing using *type relations*
 in order to handle shape analysis for operators with complex
 requirements on argument shapes.
@@ -19,13 +19,15 @@ Relay is extensible by design and makes it easy for machine learning
 researchers and practitioners to develop new large-scale program
 transformations and optimizations.
 
-The below pages describe the grammar, type system, and operators in Relay, respectively.
+The below pages describe the grammar, type system,
+algebraic data types, and operators in Relay, respectively.
 
 .. toctree::
    :maxdepth: 2
 
    relay_expr
    relay_type
+   relay_adt
    relay_op
 
 Hybrid Script

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -1,3 +1,5 @@
+.. _adt-overview:
+
 =============================
 Algebraic Data Types in Relay
 =============================
@@ -192,6 +194,8 @@ As it happens, many recursive functions on lists like the one just given
 share structures that can be factored out into generic, easily
 usable functions that will be discussed under `Common ADT Uses`_.
 
+.. _adt-pattern:
+
 Pattern Matching in Match Expressions
 =====================================
 
@@ -264,7 +268,8 @@ The option type defined under `Type-Checking ADTs and Polymorphism`_ is one such
 whenever it can make sense for a function to only return a value under certain circumstances. Having
 the option type allows for the type system to keep track of which functions always return a value
 of a certain type versus returning an option of that type, ensuring that any options are always
-explicitly checked (contrast with :code:`None` in Python).
+explicitly checked (contrast with returning null pointers or throwing
+exceptions as other ways to addressing that problem).
 
 Lists (defined in `Recursion with ADTs`_) can be manipulated by generic functions in a manner similar to
 list comprehensions and certain library functions in Python. Below are very common functions for iterating

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -430,6 +430,7 @@ a generator network (which takes a single input and produces a sequence of outpu
 
 .. code_block:: python
 
+   # included in Relay's Prelude
    def @unfoldr<a, b>(%f : fn(b) -> Optional[(a, b)], %z : b) -> List[a] {
      match(%f(%z)) {
        case Some(%pair) { Cons(%pair.0, @unfoldr(%f, %pair.1)) }
@@ -469,7 +470,8 @@ of outputs) can be used to write a general RNN (with an output for every input):
      }
    }
 
-   # can also be implemented as a right fold:
+   # can also be implemented as a right fold
+   # (this version is included in Relay's Prelude)
    def @map_accumr_fold(%f, %acc, %l) {
      @foldr(fn(%b, %p) {
        let %f_out = %f(%p.0, %b);
@@ -490,6 +492,7 @@ single set of outputs. The following is a Relay implementation of that example:
 .. code_block:: python
 
    # creates a list of tuples from two lists
+   # included in Relay's Prelude
    def @zip<a, b>(%l : List[a], %m : List[b]) -> List[(a, b)] {
      match(%l) {
        case Nil() { Nil() }
@@ -503,6 +506,7 @@ single set of outputs. The following is a Relay implementation of that example:
    }
 
    # analogous to map_accumr
+   # included in Relay's Prelude
    def @map_accmul(%f, %acc, %l) {
      @foldl(fn(%p, %b){
        let %f_out = %f(%p.0, %b);

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -17,11 +17,11 @@ Defining and Matching on an ADT
 *Note: ADTs are not presently supported in the text format.
  The syntax here is speculative, based on ADTs in other languages.*
 
-In essence, ADTs are a more powerful version of enums from C-like languages.
-Like a C :code:`struct:`, an ADT instance is a container for fields of specified types,
-but the type system allows for the same type to encode different possible groupings
-of fields in a systematic manner, similar to C :code:`enum` types, each of which have
-a finite set of possible values named by the user.
+ADTs can be understood as a generalized version of :code:`enum` and :code:`struct` types
+from C-like languages. Like a C :code:`struct:`, an ADT instance is a container for fields
+of specified types, but the type system allows for the same type to encode different possible
+groupings of fields in a systematic manner, similar to C :code:`enum` types, which are
+defined using a finite set of possible values named by the user.
 
 Specifically, an ADT is defined as a named group of constructors, each of which is
 a function that takes values of specified types as arguments and returns an instance
@@ -35,6 +35,12 @@ it is usually necessary to branch on the different possible constructors,
 resulting in the *match* syntax for ADTs. Hence, ADTs are sometimes called
 "tagged unions" because an ADT instance is tagged by the name of the constructor
 used to produce it and can later be inspected based on the tag.
+
+Because each ADT has a finite set of constructors, it is straightforward to determine
+whether a function processing an ADT instance is handling all possible cases.
+In particular, the type system can ensure that types are properly assigned in all cases when
+deconstructing an ADT instance, in contrast to :code:`union` types in C.
+Hence, it is often easy to reason about ADTs.
 
 *Implementation detail: Relay ADT definitions are global and are stored in the module,
  similarly to global function definitions. An ADT name is, in fact, a global type variable
@@ -262,8 +268,8 @@ A top-level wildcard pattern is also used to handle all cases that do not match 
    # @second_opt(None()) evaluates to None()
 
 Note that a match expression checks its patterns in the order the cases are listed: the first clause whose pattern
-that matches the queried value is the one that is evaluated. Here, a top-level variable pattern binds the whole
-queried value:
+that matches the input value is the one that is evaluated. Here, a top-level variable pattern binds the whole
+input value:
 
 .. code_block:: python
 

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -1,0 +1,207 @@
+=============================
+Algebraic Data Types in Relay
+=============================
+
+Algebraic data types (ADTs, also known as sum types) are
+a staple feature of functional programming languages, particularly
+those derived from ML, because they express data structures in a
+manner that is easy to reason about when writing recursive computations.
+Because recursion is intended to be one of the primary mechanisms of control
+flow in Relay, it is important that Relay include ADTs in order to handle
+loops and other control flow structures.
+
+Defining and Matching on an ADT
+===============================
+
+*Note: ADTs are not presently supported in the text format.
+ The syntax here is speculative, based on ADTs in other languages.*
+
+An ADT is defined with a name and a list of constructors, each of
+which takes certain types as arguments and returns an instance of the
+named ADT. A call to one of the constructors in the program where the
+ADT is defined produces an instance of the ADT.
+
+An ADT "value" simply contains the values of the arguments passed
+to the constructor used to produce it. An ADT value is opaque until
+it is *deconstructed*, allowing the arguments to the
+constructor to be accessed again and used to compute new values. Because
+a particular ADT can have multiple constructors with different signatures,
+it is usually necessary to branch on the different possible constructors,
+resulting in the *match* syntax for ADTs.
+
+Note that ADTs are identified by name,
+meaning that two ADTs with structurally identical constructors
+will nevertheless be distinct data types from the point of view of
+the typechecker.
+
+Below is a simple example of defining an ADT and using it in a function
+via a match construction.
+
+.. code-block:: python
+
+   # Defines an ADT named "Numbers"
+   data Numbers {
+     Empty : () -> Numbers
+     Single : (Tensor[(), int32]) -> Numbers
+     Pair : (Tensor[(), int32], Tensor[(), int32]) -> Numbers
+   }
+   # A Numbers value can be produced using an Empty, Single, or Pair
+   # constructor, each with a signature given above
+
+   def @sum(%n : Numbers[]) -> Tensor[(), int32] {
+      # The match expression branches on the constructor that was
+      # used to produce %n. The variables in each case are bound
+      # if the constructor matches that used for %n
+      match(%n) {
+        case Empty() { 0 }
+        case Single(x) { x }
+        case Pair(x, y) { x + y }
+      }
+   }
+
+   def @main() {
+     let %s1 = @sum(Empty());    # evaluates to 0
+     let %s2 = @sum(Single(3));  # evaluates to 3
+     let %s3 = @sum(Pair(5, 6)); # evaluates to 11
+     ()
+   }
+
+Type-Checking ADTs and Polymorphism
+===================================
+
+This section will go into more specific detail about the typing of ADTs.
+Most of the complexity involved here results from the fact that ADTs
+can be polymorphic and take type parameters, like functions.
+
+For example, one of the standard ADTs commonly used in functional
+programming languages is the option type, defined here:
+
+.. code-block:: python
+
+   data Option<a> {
+     None : () -> Option
+     Some : (a) -> Option
+   }
+
+Option types are commonly used as the return type for any operation
+involving querying into a data structure (returning :code:`Some(v)`
+if a value is found and :code:`None` if it isn't).
+Taking a type parameter in the definition allows the same option type
+to be used in a wide variety of situations, rather than having to
+define a unique ADT for each different type that could be contained in
+the option.
+
+However, it is important to ensure that option types whose contents
+are of different types can still be distinguished by the type system,
+since it would violate type safety if a function expecting an option
+containing a :code:`Tensor[(), int32]` instead receives an option
+containing a :code:`Tensor[(3, 4), float32]`. As this example may
+imply, an ADT instance is thus given a type that contains the
+concrete type arguments for that instance, ensuring the information is
+kept around. Let the below example illustrate:
+
+.. code-block:: python
+
+   # the signature for option indicates the type argument
+   def @inc_scalar(%opt : Option[Tensor[(), int32]]) -> Tensor[(), int32] {
+     match(%opt) {
+       case None() { 1 }
+       case Some(%s) { %s + 1 }
+     }
+   }
+
+   def @main() {
+     let %one : Option[Tensor[(), int32]] = Some(1);
+     let %big : Option[Tensor[(10, 10), float32]]
+       = Some(Constant(1, (10, 10), float32));
+     let %two = inc_scalar(%one);
+     # let %bigger = inc_scalar(%big); # type system rejects
+     # None does not take an argument so it can always implicitly
+     # be given the correct type arguments
+     let %z = inc_scalar(None());
+     ()
+   }
+
+The syntax for the annotated type arguments in the above examples is
+called a "type call," treating the polymorphic ADT definition as a
+type-level function (taking type params and returning a type, namely
+the ADT). Any ADT appearing in a type annotation or function signature
+must be annotated with type arguments (a non-polymorphic ADT must be
+in a type call with no arguments).
+
+Thus, we can say in general that if constructor :code:`C` that
+takes arguments of types :code:`T1, ..., Tn` is a constructor
+for an ADT :code:`D` that takes type arguments :code:`v1, ..., vn`,
+then :code:`C` has
+the type :code:`fun<v1, ..., vn>(T1, ..., Tn) -> D[v1, ..., vn]`.
+This means that constructors behave like ordinary functions and
+thus appear inside call nodes and can be passed to or returned by
+other functions. In particular, the :code:`Some` example above has
+the signature :code:`fun<a>(a) -> Option[a]`, while :code:`None`
+has the signature :code:`fun<a>() -> Option[a]`.
+
+Recursion with ADTs
+===================
+
+ADT definitions are allowed to be recursive, that is, a definition for
+an ADT named :code:`D` can assume the existence of type :code:`D` and
+use it as an argument to constructors. Recursion allows ADTs to
+represent complex structures such as lists or trees; it is the source
+of much of ADTs' power in functional programming, since an appropriately
+designed data structure could make it easy to concisely express a
+computation with a recursive function.
+
+Many commonly used ADTs involve recursion; some of these are given
+in `Stanard ADTs and Their Uses`_. As an example here, we will
+examine the list ADT, ubiquitous in functional languages:
+
+.. code-block:: python
+
+   data List<a> {
+      Nil : () -> List
+      Cons : (a, List[a]) -> List
+   }
+
+(Notice that the recursive reference to :code:`List` is wrapped
+in a type call even in the constructor.)
+
+The above definition means that a list of values of a particular type
+can be represented by nesting :code:`Cons` constructors until the
+end of the list is reached, which can be indicated with a :code:`Nil`
+(representing an empty list).
+
+Lists represented in this manner can easily be recursively processed.
+For example, the following function sums a list of integers:
+
+.. code_block:: python
+
+   def @list_sum(%l : List[Tensor[(), int32]]) -> Tensor[(), int32] {
+     match(%l) {
+       case Nil() { 0 } # base case
+       # induction: add the head of the list to the sum of the tail
+       case Cons(%h, %t) { %h + @list_sum(%t) }
+     }
+   }
+
+As it happens, many recursive functions on lists like the one just given
+share structures that can be factored out into generic, easily
+usable functions that will be discussed under `Standard ADTs and Their Uses`_.
+
+The above example refers to the :code:`Nil` match case as a "base case";
+this is because the :code:`Nil` constructor does not require an instance
+of a list to be called. It is possible to give an ADT definition where
+every constructor case has an argument that is a recursive reference
+to the ADT, but it will never be possible to create an instance of
+such an ADT, since there is no way to start building up the nesting.
+
+Pattern Matching in Match Expressions
+=====================================
+
+Standard ADTs and Their Uses
+============================
+
+Implementation Details: Module Type Data
+========================================
+
+Optimizations for ADTs
+======================

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -77,8 +77,8 @@ Type-Checking ADTs and Polymorphism
 ===================================
 
 This section will go into more specific detail about the typing of ADTs.
-Most of the complexity involved results from the fact that ADTs
-can be polymorphic and take type parameters, like functions.
+Most of the complexity involved results from the fact that, as with functions, ADTs
+can be polymorphic and take type parameters.
 
 For example, one of the standard ADTs commonly used in functional
 programming languages is the option type, defined here:
@@ -142,7 +142,7 @@ for an ADT :code:`D` that takes type arguments :code:`v1, ..., vn`,
 then :code:`C` has
 the type :code:`fun<v1, ..., vn>(T1, ..., Tn) -> D[v1, ..., vn]`.
 This means that constructors behave like ordinary functions and
-thus appear inside call nodes and can be passed to or returned by
+thus can appear inside call nodes and be passed to or returned by
 other functions. In particular, the :code:`Some` example above has
 the signature :code:`fun<a>(a) -> Option[a]`, while :code:`None`
 has the signature :code:`fun<a>() -> Option[a]`.
@@ -209,8 +209,8 @@ In particular, the patterns in match cases can be built up recursively:
 - Wildcard patterns will match any value and will not bind to a variable.
 - Variable patterns will match any value and bind it to a local variable, scoped to the match clause.
 
-In the simple case of :code:`@list_sum` above, the first match case has a :code:`Nil` pattern constructor (with no nested arguments)
-and the second has a :code:`Cons` pattern constructor that uses variable patterns for each of the arguments to :code:`Cons`.
+In the simple case of :code:`@list_sum` above, the first match case has a :code:`Nil` constructor pattern (with no nested arguments)
+and the second has a :code:`Cons` constructor pattern that uses variable patterns for each of the arguments to :code:`Cons`.
 
 The below example uses a wildcard pattern to ignore one of the arguments to :code:`Cons`:
 
@@ -273,13 +273,13 @@ exceptions as other ways to addressing that problem).
 
 Lists (defined in `Recursion with ADTs`_) can be manipulated by generic functions in a manner similar to
 list comprehensions and certain library functions in Python. Below are very common functions for iterating
-through lists, which are included in Relay's Prelude. (Naturally, these have all been extensively characterized
-in the functional programming literature, so this document will not attempt to recapitulate that work.)
+through lists, which are included in Relay's Prelude. (These have all been extensively characterized
+in the functional programming literature, and we do not attempt to reproduce that work in this document.)
 
 .. code_block:: python
 
    # Map: for [h1, h2, ..., hn] returns [f(h1), f(h2), ..., f(hn)]
-   def @map<a, b>(%f : fun(a) -> b, %l : List[a]) -> List[b] {
+   def @map<a, b>(%f : fn(a) -> b, %l : List[a]) -> List[b] {
      match(%l) {
        case Nil() { Nil() }
        case Cons(%h, %t) { Cons(%f(%h), @map(%f, %t)) }
@@ -287,7 +287,7 @@ in the functional programming literature, so this document will not attempt to r
    }
 
    # Left fold: for [h1, h2, ..., hn] returns f(...(f(f(z, h1), h2)...), hn)
-   def @foldl<a, b>(%f : fun(b, a) -> b, %z : b, %l : List[a]) -> b {
+   def @foldl<a, b>(%f : fn(b, a) -> b, %z : b, %l : List[a]) -> b {
      match(%l) {
        case Nil() { %z }
        case Cons(%h, %t) { @foldl(%f, %f(%z, %h), %t) }
@@ -295,14 +295,14 @@ in the functional programming literature, so this document will not attempt to r
    }
 
    # Right fold: for [h1, h2, ..., hn] returns f(h1, f(h2, f(..., (f(hn, z)...)
-   def @foldr<a, b>(%f : fun(a, b) -> b, %z : b, %l : List[a] -> b {
+   def @foldr<a, b>(%f : fn(a, b) -> b, %z : b, %l : List[a] -> b {
      match(%l) {
        case Nil() { %z }
        case Cons(%h, %t) { %f(%h, @foldr(%f, %z, %t)) }
      }
    }
 
-Using these iteration constructs, many common operations over list can be expressed compactly.
+Using these iteration constructs, many common operations over lists can be expressed compactly.
 For example, the following map doubles all members of a list:
 
 .. code_block:: python
@@ -316,7 +316,7 @@ For example, the following map doubles all members of a list:
    }
 
    # no recursion needed
-   @map(fun(%i) { %i * 2 }, %l)
+   @map(fn(%i) { %i * 2 }, %l)
 
 The following right fold concatenates two lists:
 
@@ -331,7 +331,7 @@ The following right fold concatenates two lists:
    }
 
    # no recursion needed
-   @foldr(fun(%h, %z) { Cons(%h, %z) }, %l2, %l1)
+   @foldr(fn(%h, %z) { Cons(%h, %z) }, %l2, %l1)
 
 The following left fold flattens a list of lists (using concatenation):
 

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -489,6 +489,7 @@ single set of outputs. The following is a Relay implementation of that example:
 
 .. code_block:: python
 
+   # creates a list of tuples from two lists
    def @zip<a, b>(%l : List[a], %m : List[b]) -> List[(a, b)] {
      match(%l) {
        case Nil() { Nil() }
@@ -496,11 +497,18 @@ single set of outputs. The following is a Relay implementation of that example:
          match(%m) {
            case Nil() { Nil() }
            case Cons(%b, %t2) { Cons((%a, %b), @zip(%t1, %t2)) }
+         }
        }
      }
    }
 
-   # assume that map_accuml does the same as map_accumr as a left fold
+   # analogous to map_accumr
+   def @map_accmul(%f, %acc, %l) {
+     @foldl(fn(%p, %b){
+       let %f_out = %f(%p.0, %b);
+       (%f_out.0, Cons(%f_out.1, %p.1))
+     }, (%acc, Nil()), %l)
+   }
 
    def @bidirectional_rnn<state1_type, state2_type, in_type, out1_type, out2_type>
      (%cell1, %cell2, %state1 : state1_type, %state2 : state2_type, %input : List[in_type])

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -72,12 +72,9 @@ via a match expression:
       }
    }
 
-   def @main() {
-     let %s1 = @sum(Empty());    # evaluates to 0
-     let %s2 = @sum(Single(3));  # evaluates to 3
-     let %s3 = @sum(Pair(5, 6)); # evaluates to 11
-     ()
-   }
+   @sum(Empty())    # evaluates to 0
+   @sum(Single(3))  # evaluates to 3
+   @sum(Pair(5, 6)) # evaluates to 11
 
 Note that ADTs are identified by name,
 meaning that two ADTs with structurally identical constructors
@@ -153,7 +150,8 @@ kept around. Let the below example illustrate:
      ()
    }
 
-The syntax for the annotated type arguments in the above examples is
+The syntax for the annotated type arguments
+(e.g., :code:`Optional[Tensor[(), int32]]`) in the above examples is
 called a "type call," treating the polymorphic ADT definition as a
 type-level function (taking type params and returning a type, namely
 the ADT). Any ADT appearing in a type annotation or function signature

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -14,8 +14,7 @@ loops and other control flow structures that must be implemented using recursion
 Defining and Matching on an ADT
 ===============================
 
-*Note: ADTs are not presently supported in the text format.
- The syntax here is speculative, based on ADTs in other languages.*
+*Note: ADTs are not presently supported in the text format. The syntax here is speculative, based on ADTs in other languages.*
 
 ADTs can be understood as a generalized version of :code:`enum` and :code:`struct` types
 from C-like languages. Like a C :code:`struct:`, an ADT instance is a container for fields
@@ -42,10 +41,7 @@ In particular, the type system can ensure that types are properly assigned in al
 deconstructing an ADT instance, in contrast to :code:`union` types in C.
 Hence, it is often easy to reason about ADTs.
 
-*Implementation detail: Relay ADT definitions are global and are stored in the module,
- similarly to global function definitions. An ADT name is, in fact, a global type variable
- (just as a global function name is a global variable). The module keeps a mapping of ADT names
- (global type variables) to the list of constructors for that ADT.*
+*Implementation detail: Relay ADT definitions are global and are stored in the module, similarly to global function definitions. An ADT name is, in fact, a global type variable (just as a global function name is a global variable). The module keeps a mapping of ADT names (global type variables) to the list of constructors for that ADT.*
 
 Below is a simple example of defining an ADT and using it in a function
 via a match expression:
@@ -203,7 +199,7 @@ end of the list is reached, which can be indicated with a :code:`Nil`
 Lists represented in this manner can easily be recursively processed.
 For example, the following function sums a list of integers:
 
-.. code_block:: python
+.. code-block:: python
 
    def @list_sum(%l : List[Tensor[(), int32]]) -> Tensor[(), int32] {
      match(%l) {
@@ -237,7 +233,7 @@ and the second has a :code:`Cons` constructor pattern that uses variable pattern
 
 The below example uses a wildcard pattern to ignore one of the arguments to :code:`Cons`:
 
-.. code_block:: python
+.. code-block:: python
 
    def @first<a>(%l : List[a]) -> Optional[a] {
      match(%l) {
@@ -249,7 +245,7 @@ The below example uses a wildcard pattern to ignore one of the arguments to :cod
 Here, a constructor pattern is nested inside another constructor pattern to avoid nested match expressions for a list option.
 A top-level wildcard pattern is also used to handle all cases that do not match the first clause:
 
-.. code_block:: python
+.. code-block:: python
 
    def @second_opt<a>(%ll : Optional[List[a]]) -> Optional[a] {
      match(%ll) {
@@ -268,7 +264,7 @@ Note that a match expression checks its patterns in the order the cases are list
 that matches the input value is the one that is evaluated. Here, a top-level variable pattern binds the whole
 input value:
 
-.. code_block:: python
+.. code-block:: python
 
    def @match_order_beware<a>(%l : List[a]) -> List[a] {
      match(%l) {
@@ -299,7 +295,7 @@ list comprehensions and certain library functions in Python. Below are very comm
 through lists, which are included in Relay's Prelude. (These have all been extensively characterized
 in the functional programming literature, and we do not attempt to reproduce that work in this document.)
 
-.. code_block:: python
+.. code-block:: python
 
    # Map: for [h1, h2, ..., hn] returns [f(h1), f(h2), ..., f(hn)]
    def @map<a, b>(%f : fn(a) -> b, %l : List[a]) -> List[b] {
@@ -328,7 +324,7 @@ in the functional programming literature, and we do not attempt to reproduce tha
 Using these iteration constructs, many common operations over lists can be expressed compactly.
 For example, the following map doubles all members of a list:
 
-.. code_block:: python
+.. code-block:: python
 
    # directly written
    def @double(%l : List[Tensor[(), int32]]) -> List[Tensor[(), int32]] {
@@ -343,7 +339,7 @@ For example, the following map doubles all members of a list:
 
 The following right fold concatenates two lists:
 
-.. code_block:: python
+.. code-block:: python
 
    # directly written
    def @concat<a>(%l1 : List[a], %l2 : List[a]) -> List[a] {
@@ -358,7 +354,7 @@ The following right fold concatenates two lists:
 
 The following left fold flattens a list of lists (using concatenation):
 
-.. code_block:: python
+.. code-block:: python
 
   # directly written
   def @flatten<a>(%ll : List[List[a]]) -> List[a] {
@@ -388,13 +384,13 @@ First let us suppose that we have a function corresponding to a trained recurren
 cell, which takes in a past state and an input value and returns a new state and output value. In
 Relay, this would have the following signature:
 
-.. code_block:: python
+.. code-block:: python
 
    @cell : fn<state_type, in_type, out_type>(state_type, in_type) -> (state_type, out_type)
 
 We might consider a ReLU cell as a simple concrete example, with a trained version below:
 
-.. code_block:: python
+.. code-block:: python
 
   def @linear(%x, %w, %b) { %w*%x + %b }
 
@@ -416,7 +412,7 @@ We might consider a ReLU cell as a simple concrete example, with a trained versi
 
 Following Olah's example, we can encode a sequence (list) of inputs with the following left fold:
 
-.. code_block:: python
+.. code-block:: python
 
    def @encode<state_type, in_type, out_type>(%cell, %input : List[in_type], %init : state_type) -> state_type {
      # not using the output
@@ -426,7 +422,7 @@ Following Olah's example, we can encode a sequence (list) of inputs with the fol
 Using an *unfold* iterator (from Haskell's standard library), the same cell could be used to make
 a generator network (which takes a single input and produces a sequence of outputs):
 
-.. code_block:: python
+.. code-block:: python
 
    # included in Relay's Prelude
    def @unfoldr<a, b>(%f : fn(b) -> Optional[(a, b)], %z : b) -> List[a] {
@@ -455,7 +451,7 @@ a generator network (which takes a single input and produces a sequence of outpu
 An accumulating map (a fold that simultaneously updates an accumulator value and a list
 of outputs) can be used to write a general RNN (with an output for every input):
 
-.. code_block:: python
+.. code-block:: python
 
    def @map_accumr<a, b, c>(%f : fn(a, b) -> (a, c), %acc : a, %l : List[b]) -> (a, List[c]) {
      match(%l) {
@@ -487,7 +483,7 @@ Olah also gives an example of a bidirectional neural network, in which two sets 
 cells (which may have different weights) process the input in both directions and produce a
 single set of outputs. The following is a Relay implementation of that example:
 
-.. code_block:: python
+.. code-block:: python
 
    # creates a list of tuples from two lists
    # included in Relay's Prelude

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -40,7 +40,7 @@ will nevertheless be distinct data types from the point of view of
 the typechecker.
 
 Below is a simple example of defining an ADT and using it in a function
-via a match construction.
+via a match expression:
 
 .. code-block:: python
 
@@ -75,7 +75,7 @@ Type-Checking ADTs and Polymorphism
 ===================================
 
 This section will go into more specific detail about the typing of ADTs.
-Most of the complexity involved here results from the fact that ADTs
+Most of the complexity involved results from the fact that ADTs
 can be polymorphic and take type parameters, like functions.
 
 For example, one of the standard ADTs commonly used in functional

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -105,23 +105,22 @@ Most of the complexity involved results from the fact that, as with functions, A
 can be polymorphic and take type parameters.
 
 For example, one of the standard ADTs commonly used in functional
-programming languages is the option type, defined here:
+programming languages is the optional type, defined here:
 
 .. code-block:: python
 
    # a is a type parameter
-   data Option<a> {
-     None : () -> Option
-     Some : (a) -> Option
+   data Optional<a> {
+     None : () -> Optional
+     Some : (a) -> Optional
    }
 
-Option types are commonly used as the return type for any operation
+Optional types are commonly used as the return type for any operation
 involving querying into a data structure (returning :code:`Some(v)`
 if a value is found and :code:`None` if it isn't).
-Taking a type parameter in the definition allows the same option type
+Taking a type parameter in the definition allows the same optional type
 to be used in a wide variety of situations, rather than having to
-define a unique ADT for each different type that could be contained in
-the option.
+define a unique ADT for each different type that could be contained in it.
 
 However, it is important to ensure that option types whose contents
 are of different types can still be distinguished by the type system,
@@ -135,7 +134,7 @@ kept around. Let the below example illustrate:
 .. code-block:: python
 
    # the signature for option indicates the type argument
-   def @inc_scalar(%opt : Option[Tensor[(), int32]]) -> Tensor[(), int32] {
+   def @inc_scalar(%opt : Optional[Tensor[(), int32]]) -> Tensor[(), int32] {
      match(%opt) {
        case None() { 1 }
        case Some(%s) { %s + 1 }
@@ -143,8 +142,8 @@ kept around. Let the below example illustrate:
    }
 
    def @main() {
-     let %one : Option[Tensor[(), int32]] = Some(1);
-     let %big : Option[Tensor[(10, 10), float32]]
+     let %one : Optional[Tensor[(), int32]] = Some(1);
+     let %big : Optional[Tensor[(10, 10), float32]]
        = Some(Constant(1, (10, 10), float32));
      let %two = inc_scalar(%one);
      # let %bigger = inc_scalar(%big); # type system rejects
@@ -170,8 +169,8 @@ the type :code:`fun<v1, ..., vn>(T1, ..., Tn) -> D[v1, ..., vn]`.
 This means that constructors are typed like ordinary functions and
 thus appear inside call nodes and can be passed to or returned by
 other functions. In particular, the :code:`Some` example above has
-the signature :code:`fun<a>(a) -> Option[a]`, while :code:`None`
-has the signature :code:`fun<a>() -> Option[a]`.
+the signature :code:`fun<a>(a) -> Optional[a]`, while :code:`None`
+has the signature :code:`fun<a>() -> Optional[a]`.
 
 Recursion with ADTs
 ===================
@@ -242,7 +241,7 @@ The below example uses a wildcard pattern to ignore one of the arguments to :cod
 
 .. code_block:: python
 
-   def @first<a>(%l : List[a]) -> Option[a] {
+   def @first<a>(%l : List[a]) -> Optional[a] {
      match(%l) {
        case Nil() { None() }
        case Cons(%h, _) { Some(%h) } # list tail is unused and ignored
@@ -254,7 +253,7 @@ A top-level wildcard pattern is also used to handle all cases that do not match 
 
 .. code_block:: python
 
-   def @second_opt<a>(%ll : Option[List[a]]) -> Option[a] {
+   def @second_opt<a>(%ll : Optional[List[a]]) -> Optional[a] {
      match(%ll) {
        # we only need the second member of the list if there is one
        case Some(Cons(_, Cons(%s, _))) { Some(%s) }

--- a/docs/langref/relay_adt.rst
+++ b/docs/langref/relay_adt.rst
@@ -333,7 +333,7 @@ The following left fold flattens a list of lists (using concatenation):
   # directly written
   def @flatten<a>(%ll : List[List[a]]) -> List[a] {
     match(%ll) {
-      case Cons(%h, %t)) { @concat(%h, @flatten(%t) }
+      case Cons(%h, %t) { @concat(%h, @flatten(%t)) }
       case Nil() { Nil() }
     }
 

--- a/docs/langref/relay_expr.rst
+++ b/docs/langref/relay_expr.rst
@@ -287,8 +287,8 @@ ADT Constructors
 ================
 
 Algebraic data types (ADTs) in Relay are described in detail in a
-`separate overview <adt-overview_>`__ and their integration into
-the type system is described `here <adt-typing_>`__.
+:ref:`separate overview<adt-overview>` and their integration into
+the type system is described :ref:`here<adt-typing>`.
 
 In this section, we will simply note that ADT constructors are given
 a function type and should be used inside call nodes like a function
@@ -585,7 +585,7 @@ ADT Matching
 ============
 
 Instances of algebraic data types (ADTs), as discussed in the
-`ADT overview <adt-overview_>`__, are containers that store the
+:ref:`ADT overview<adt-overview>`, are containers that store the
 arguments passed to the constructor used to create them, tagged by
 the constructor name.
 
@@ -598,7 +598,7 @@ expressions are capable of more general pattern-matching than simply
 splitting by constructors: any ADT instance nested inside an instance
 (e.g., a list of lists) can be deconstructed at the same time as
 the outer instance, while the different fields of the instance can be
-bound to variables. (See `this section <adt_pattern_>`__ for a detailed
+bound to variables. (See :ref:`this section<adt-pattern>` for a detailed
 description of ADT pattern-matching.)
 
 A match expression is defined using the

--- a/docs/langref/relay_expr.rst
+++ b/docs/langref/relay_expr.rst
@@ -613,7 +613,7 @@ For example, suppose we have an ADT for Peano natural numbers:
 
    data Nat {
      Z : () -> Nat # zero
-     S : Nat -> Nat # successor (+1) to a nat
+     S : (Nat) -> Nat # successor (+1) to a nat
    }
 
 Then the following function subtracts one from a passed nat:

--- a/docs/langref/relay_expr.rst
+++ b/docs/langref/relay_expr.rst
@@ -21,13 +21,14 @@ constructs corresponds to a pure computation graph:
 - Tuple `Construction`_ and `Projection`_
 - `Let Bindings`_
 - `Graph Bindings`_
-- Calls to `Operators`_
+- Calls to `Operators`_ and `ADT Constructors`_
 
 Control flow expressions allow the graph topology to change
 based on the value of previously executed expressions. The control
 fragment in Relay includes the following constructs:
 
 - `If-Then-Else`_ Expressions
+- `ADT Matching`_ Expressions
 - Recursive Calls in Functions
 
 From the point of view of a computation graph, a function is a subgraph and a function call inlines the subgraph, substituting its arguments for the free variables in the subgraph with corresponding names.
@@ -282,6 +283,42 @@ handles for generating a call to various pre-registered operators.
 The :ref:`tutorial on adding operators to Relay <relay-add-op>` shows how to add further
 operators into the language.
 
+ADT Constructors
+================
+
+Algebraic data types (ADTs) in Relay are described in detail in a
+`separate overview <adt-overview_>`__ and their integration into
+the type system is described `here <adt-typing_>`__.
+
+In this section, we will simply note that ADT constructors are given
+a function type and should be used inside call nodes like a function
+or operator. An ADT constructor is defined by giving the name of
+the ADT it constructs (a global type variable) and the types of the
+expected arguments for the constructor.
+
+If the ADT definition includes type variables, those type variables
+may appear in the constructor. Constructors cannot include any other
+type variables.
+
+Let us suppose that :code:`D` is an ADT that takes type parameters
+:code:`a` and :code:`b`. If :code:`C1` is a constructor for :code:`D`
+expects an argument each of type :code:`a` and type :code:`b`, then
+:code:`C1` has the following type signature:
+:code:`fun<a, b>(a, b) -> D[a, b]`. (See either the ADT overview
+or the discussion of ADT typing for an explanation of the type call
+in the return type.)
+If another constructor for :code:`D`, :code:`C2`, takes no arguments,
+then it has the following type signature: :code:`fun<a, b>() -> D[a, b]`;
+the type parameters will always appear in the return type.
+
+Once called, a constructor produces an ADT instances, which is a
+container that stores the values of the arguments to the constructor
+as well as the name ("tag") of the constructor. The tag will be used
+for deconstructing the instances and retrieving the values when
+`ADT Matching`_.
+
+See :py:class:`~tvm.relay.adt.Constructor` for the definition and documentation.
+
 Call
 ====
 
@@ -342,6 +379,8 @@ the type annotation:
    %x
 
 See :py:class:`~tvm.relay.expr.Call` for its definition and documentation.
+
+.. _module-description:
 
 Module and Global Functions
 ===========================
@@ -541,6 +580,82 @@ evaluates to :code:`True` and evaluates to the value of the "else" branch if the
 condition value evaluates to :code:`False`.
 
 See :py:class:`~tvm.relay.expr.If` for its definition and documentation.
+
+ADT Matching
+============
+
+Instances of algebraic data types (ADTs), as discussed in the
+`ADT overview <adt-overview_>`__, are containers that store the
+arguments passed to the constructor used to create them, tagged by
+the constructor name.
+
+Match expressions in Relay allow for retrieving the values stored in
+an ADT instance ("deconstructing" it) based on their constructor tag.
+A match expression behaves similarly to a C-style :code:`switch` statement,
+branching on the different possible constructors for the type of the
+value being deconstructed. As the ADT overview details, match
+expressions are capable of more general pattern-matching than simply
+splitting by constructors: any ADT instances nested inside an instance
+(e.g., a list of lists) can be deconstructed at the same time as
+the outer instance, while the different fields of the instance can be
+bound to varialbes. (See `this section <adt_pattern_>`__ for a detailed
+description of ADT pattern-matching.)
+
+A match expression is defined using the
+queried value (an expression) and a list of clauses, each of which
+consists of a pattern and an expression. When executed, the *first*
+clause whose pattern matches the structure of the queried value is
+executed; the clause expression is evaluated and returned.
+
+For example, suppose we have an ADT for Peano natural numbers:
+
+.. code-block:: python
+
+   data Nat {
+     Z : () -> Nat # zero
+     S : Nat -> Nat # successor (+1) to a nat
+   }
+
+Then the following function subtracts one from a passed nat:
+
+.. code-block:: python
+
+   fun(%v: Nat[]) -> Nat[] {
+     match(%v) {
+       case Z() { Z() }
+       case S(%n) { %n } # the variable %n is bound in the scope of this clause
+     }
+   }
+
+The following function subtracts two from its argument if it is at least
+two and returns the argument otherwise, using a nested constructor pattern:
+
+.. code-block:: python
+
+   fun(%v : Nat[]) -> Nat[] {
+     match(%v) {
+        case S(S(%n)) { %n }
+        # wildcard pattern: matches all cases not matched already
+        case _ { %v }
+     }
+   }
+
+As aforementioned, the ordering of match clauses is relevant.
+In the below example, the first clause will always match so
+those below it can never run:
+
+.. code-block:: python
+
+   fun(%v : Nat[]) -> Nat[] {
+     match(%v) {
+       case _ { %v }
+       case S(S(%n)) { S(%n) }
+       case S(%n) { %n }
+       case Z() { S(Z()) }
+     }
+   }
+
+See :py:class:`~tvm.relay.adt.Match` for its definition and documentation.
 
 TempExprs
 =========

--- a/docs/langref/relay_expr.rst
+++ b/docs/langref/relay_expr.rst
@@ -302,7 +302,7 @@ type variables.
 
 Let us suppose that :code:`D` is an ADT that takes type parameters
 :code:`a` and :code:`b`. If :code:`C1` is a constructor for :code:`D`
-expects an argument each of type :code:`a` and type :code:`b`, then
+and expects two arguments, one of type :code:`a` and one of type :code:`b`, then
 :code:`C1` has the following type signature:
 :code:`fun<a, b>(a, b) -> D[a, b]`. (See either the ADT overview
 or the discussion of ADT typing for an explanation of the type call
@@ -311,7 +311,7 @@ If another constructor for :code:`D`, :code:`C2`, takes no arguments,
 then it has the following type signature: :code:`fun<a, b>() -> D[a, b]`;
 the type parameters will always appear in the return type.
 
-Once called, a constructor produces an ADT instances, which is a
+Once called, a constructor produces an ADT instance, which is a
 container that stores the values of the arguments to the constructor
 as well as the name ("tag") of the constructor. The tag will be used
 for deconstructing the instances and retrieving the values when
@@ -595,10 +595,10 @@ A match expression behaves similarly to a C-style :code:`switch` statement,
 branching on the different possible constructors for the type of the
 value being deconstructed. As the ADT overview details, match
 expressions are capable of more general pattern-matching than simply
-splitting by constructors: any ADT instances nested inside an instance
+splitting by constructors: any ADT instance nested inside an instance
 (e.g., a list of lists) can be deconstructed at the same time as
 the outer instance, while the different fields of the instance can be
-bound to varialbes. (See `this section <adt_pattern_>`__ for a detailed
+bound to variables. (See `this section <adt_pattern_>`__ for a detailed
 description of ADT pattern-matching.)
 
 A match expression is defined using the
@@ -620,7 +620,7 @@ Then the following function subtracts one from a passed nat:
 
 .. code-block:: python
 
-   fun(%v: Nat[]) -> Nat[] {
+   fn(%v: Nat[]) -> Nat[] {
      match(%v) {
        case Z() { Z() }
        case S(%n) { %n } # the variable %n is bound in the scope of this clause
@@ -632,7 +632,7 @@ two and returns the argument otherwise, using a nested constructor pattern:
 
 .. code-block:: python
 
-   fun(%v : Nat[]) -> Nat[] {
+   fn(%v : Nat[]) -> Nat[] {
      match(%v) {
         case S(S(%n)) { %n }
         # wildcard pattern: matches all cases not matched already
@@ -646,7 +646,7 @@ those below it can never run:
 
 .. code-block:: python
 
-   fun(%v : Nat[]) -> Nat[] {
+   fn(%v : Nat[]) -> Nat[] {
      match(%v) {
        case _ { %v }
        case S(S(%n)) { S(%n) }

--- a/docs/langref/relay_expr.rst
+++ b/docs/langref/relay_expr.rst
@@ -602,12 +602,12 @@ bound to variables. (See `this section <adt_pattern_>`__ for a detailed
 description of ADT pattern-matching.)
 
 A match expression is defined using the
-queried value (an expression) and a list of clauses, each of which
+input value (an expression) and a list of clauses, each of which
 consists of a pattern and an expression. When executed, the *first*
 clause whose pattern matches the structure of the queried value is
 executed; the clause expression is evaluated and returned.
 
-For example, suppose we have an ADT for Peano natural numbers:
+For example, suppose we have an ADT for natural numbers:
 
 .. code-block:: python
 

--- a/docs/langref/relay_type.rst
+++ b/docs/langref/relay_type.rst
@@ -11,7 +11,7 @@ Static types are useful when performing compiler optimizations because they
 communicate properties about the data a program manipulates, such as runtime
 shape, data layout, and storage, without needing to run the program.
 Relay's `Algebraic Data Types`_ allow for easily and flexibly composing
-together types in order to build data structures that can easily be
+types in order to build data structures that can be
 reasoned about inductively and used to write recursive functions.
 
 Relay's type system features a form of *dependent typing* for shapes. That is, its type system keeps track of the shapes of tensors in a Relay program. Treating tensor
@@ -293,7 +293,7 @@ Definitions (Type Data)
 
 Besides a name, an ADT needs to store the constructors that are used
 to define it and any type paramters used within them. These are
-stored in the module, `analogously to global function definitions <module-description_>`__.
+stored in the module, `analogous to global function definitions <module-description_>`__.
 
 While type-checking uses of ADTs, the type system sometimes must
 index into the module using the ADT name to look up information
@@ -316,7 +316,7 @@ as two ADT instances built using different constructors but the
 same type parameters are of the *same type* while two ADT instances
 with different type parameters should not be considered the same
 type (e.g., a list of integers should not have the same type as
-a list of tuples of floating point tensors).
+a list of pairs of floating point tensors).
 
 The "function" in the type call is the ADT handle and there must
 be one argument for each type parameter in the ADT definition. (An
@@ -342,10 +342,10 @@ sections. Its definition is as follows:
 Thus, the global type variable :code:`List` is the handle for the ADT.
 The type data for the list ADT in the module notes that
 :code:`List` takes one type parameter and has two constructors,
-:code:`Nil` (with signature :code:`fun<a>() -> List[a]`)
-and :code:`Cons` (with signature :code:`fun<a>(a, List[a]) -> List[a]`).
+:code:`Nil` (with signature :code:`fn<a>() -> List[a]`)
+and :code:`Cons` (with signature :code:`fn<a>(a, List[a]) -> List[a]`).
 The recursive reference to :code:`List` in the :code:`Cons`
-constructor is accomplished by using to the global type
+constructor is accomplished by using the global type
 variable :code:`List` in the constructor definition.
 
 Below two instances of lists with their types given, using type calls:

--- a/docs/langref/relay_type.rst
+++ b/docs/langref/relay_type.rst
@@ -256,8 +256,11 @@ each of which takes arguments of certain types.
 An instance of an ADT is a container that stores the values
 of the constructor arguments used to produce it as well as the
 name of the constructor; the values can be retrieved by
-deconstructing the instance by matching based on its constructor
-(hence, ADTs are sometimes called "tagged unions").
+deconstructing the instance by matching based on its constructor.
+Hence, ADTs are sometimes called "tagged unions": like a C-style
+union, the contents of an instance for a given ADT may have
+different types in certain cases, but the constructor serves as a
+tag to indicate how to interpret the contents.
 
 From the type system's perspective, it is most pertinent that
 ADTs can take type parameters (constructor arguments can be

--- a/docs/langref/relay_type.rst
+++ b/docs/langref/relay_type.rst
@@ -297,7 +297,10 @@ stored in the module, `analogous to global function definitions <module-descript
 
 While type-checking uses of ADTs, the type system sometimes must
 index into the module using the ADT name to look up information
-about constructors.
+about constructors. For example, if a constructor is being pattern-matched
+in a match expression clause, the type-checker must check the constructor's
+signature to ensure that any bound variables are being assigned the
+correct types.
 
 See :py:class:`~tvm.relay.adt.TypeData` for its definition and documentation.
 

--- a/docs/langref/relay_type.rst
+++ b/docs/langref/relay_type.rst
@@ -10,6 +10,9 @@ be fully typed while requiring just a few explicit type annotations.
 Static types are useful when performing compiler optimizations because they
 communicate properties about the data a program manipulates, such as runtime
 shape, data layout, and storage, without needing to run the program.
+Relay's `Algebraic Data Types`_ allow for easily and flexibly composing
+together types in order to build data structures that can easily be
+reasoned about inductively and used to write recursive functions.
 
 Relay's type system features a form of *dependent typing* for shapes. That is, its type system keeps track of the shapes of tensors in a Relay program. Treating tensor
 shapes as types allows Relay to perform more powerful reasoning at compile time;
@@ -33,20 +36,17 @@ type relations are satisfied at call sites). Type relations offer a flexible and
 relatively simple way of making the power of dependent typing available in Relay
 without greatly increasing the complexity of its type system.
 
-Types
-=====
-
 Below we detail the language of types in Relay and how they are assigned to Relay expressions.
 
 Type
-~~~~
+====
 
 The base type for all Relay types. All Relay types are sub-classes of this base type.
 
 See :py:class:`~tvm.relay.ty.Type` for its definition and documentation.
 
 Tensor Type
-~~~~~~~~~~~
+===========
 
 A concrete tensor type in Relay.
 
@@ -70,7 +70,7 @@ For example, here is a simple concrete tensor type corresponding to a 10-by-10 t
 See :py:class:`~tvm.relay.ty.TensorType` for its definition and documentation.
 
 Tuple Type
-~~~~~~~~~~
+==========
 
 A type of a tuple in Relay.
 
@@ -94,7 +94,7 @@ See :py:class:`~tvm.relay.ty.TupleType` for its definition and documentation.
 .. _type-parameter:
 
 Type Parameter
-~~~~~~~~~~~~~~
+==============
 
 Type parameters represent placeholder types used for polymorphism in functions.
 Type parameters are specified according to *kind*, corresponding to the types
@@ -127,7 +127,7 @@ be substituted with :code:`(10, 10)` at the call site below:
 See :py:class:`~tvm.relay.ty.TypeVar` for its definition and documentation.
 
 Type Constraint
-~~~~~~~~~~~~~~~
+===============
 
 This is an abstract class representing a type constraint, to be elaborated
 upon in further releases. Currently, type relations are the only
@@ -136,7 +136,7 @@ type constraints provided; they are discussed below.
 See :py:class:`~tvm.relay.ty.TypeConstraint` for its definition and documentation.
 
 Function Type
-~~~~~~~~~~~~~
+=============
 
 A function type in Relay, see `tvm/relay/type.h` for more details.
 
@@ -158,7 +158,7 @@ See :py:class:`~tvm.relay.ty.FuncType` for its definition and documentation.
 .. _type-relation:
 
 Type Relation
-~~~~~~~~~~~~~
+=============
 
 A type relation is the most complex type system feature in Relay.
 It allows users to extend type inference with new rules.
@@ -226,7 +226,7 @@ in C++.
 See :py:class:`~tvm.relay.ty.TypeRelation` for its definition and documentation.
 
 Incomplete Type
-~~~~~~~~~~~~~~~
+===============
 
 An incomplete type is a type or portion of a type that is not yet known.
 This is only used during type inference. Any omitted type annotation is
@@ -239,3 +239,133 @@ parameters: Type parameters must be bound to a function and are replaced with co
 at call sites, whereas incomplete types may appear anywhere in the program and are filled in during type inference.
 
 See :py:class:`~tvm.relay.ty.IncompleteType` for its definition and documentation.
+
+.. _adt-typing:
+
+Algebraic Data Types
+====================
+
+*Note: ADTs are not currently supported in the text format.*
+
+Algebraic data types (ADTs) are described in more detail in
+`their overview <adt-overview_>`__; this section describes
+their implementation in the type system.
+
+An ADT is defined by a collection of named constructors,
+each of which takes arguments of certain types.
+An instance of an ADT is a container that stores the values
+of the constructor arguments used to produce it as well as the
+name of the constructor; the values can be retrieved by
+deconstructing the instance by matching based on its constructor
+(hence, ADTs are sometimes called "tagged unions").
+
+From the type system's perspective, it is most pertinent that
+ADTs can take type parameters (constructor arguments can be
+type parameters, though ADT instances with different type
+parameters must be treated as different types) and be
+recursive (a constructor for an ADT can take an instance of
+that ADT, thus an ADT like a tree or list can be inductively
+built up). The representation of ADTs in the type system must
+be able to accomodate these facts, as the below sections will detail.
+
+Global Type Variable
+~~~~~~~~~~~~~~~~~~~~
+
+To represent ADTs compactly and easily allow for recursive ADT definitions,
+an ADT definition is given a handle in the form of a global type variable
+that uniquely identifies it. Each ADT definition is given a fresh global
+type variable as a handle, so pointer equality can be used to distinguish
+different ADT names.
+
+For the purposes of Relay's type system, ADTs are differentiated by name;
+that means that if two ADTs have different handles, they will be
+considered different types even if all their constructors are
+structurally identical.
+
+Recursion in an ADT definition thus follows just like recursion for a
+global function: the constructor can simply reference the ADT handle
+(global type variable) in its definition.
+
+See :py:class:`~tvm.relay.ty.GlobalTypeVar` for its definition and documentation.
+
+Definitions (Type Data)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Besides a name, an ADT needs to store the constructors that are used
+to define it and any type paramters used within them. These are
+stored in the module, `analogously to global function definitions <module-description_>`__.
+
+While type-checking uses of ADTs, the type system sometimes must
+index into the module using the ADT name to look up information
+about constructors.
+
+See :py:class:`~tvm.relay.adt.TypeData` for its definition and documentation.
+
+Type Call
+~~~~~~~~~
+
+Because an ADT definition can take type parameters, Relay's type
+system considers an ADT definition to be a *type-level function*
+(in that the definition takes type parameters and returns the
+type of an ADT instance with those type parameters). Thus, any
+instance of an ADT is typed using a type call, which explicitly
+lists the type parameters given to the ADT definition.
+
+It is important to list the type parameters for an ADT instance,
+as two ADT instances built using different constructors but the
+same type parameters are of the *same type* while two ADT instances
+with different type parameters should not be considered the same
+type (e.g., a list of integers should not have the same type as
+a list of tuples of floating point tensors).
+
+The "function" in the type call is the ADT handle and there must
+be one argument for each type parameter in the ADT definition. (An
+ADT definition with no arguments means that any instance will have
+no type arguments passed to the type call).
+
+See :py:class:`~tvm.relay.ty.TypeCall` for its definition and documentation.
+
+Example: List ADT
+~~~~~~~~~~~~~~~~~
+
+This subsection uses the simple list ADT (included as a default
+ADT in Relay) to illustrate the constructs described in the previous
+sections. Its definition is as follows:
+
+.. code-block:: python
+
+   data List<a> {
+     Nil : () -> List
+     Cons : (a, List[a]) -> List
+   }
+
+Thus, the global type variable :code:`List` is the handle for the ADT.
+The type data for the list ADT in the module notes that
+:code:`List` takes one type parameter and has two constructors,
+:code:`Nil` (with signature :code:`fun<a>() -> List[a]`)
+and :code:`Cons` (with signature :code:`fun<a>(a, List[a]) -> List[a]`).
+The recursive reference to :code:`List` in the :code:`Cons`
+constructor is accomplished by using to the global type
+variable :code:`List` in the constructor definition.
+
+Below two instances of lists with their types given, using type calls:
+
+.. code_block:: python
+
+   Cons(1, Cons(2, Nil())) # List[Tensor[(), int32]]
+   Cons((1, 1), Cons((2, 2), Nil())) # List[(Tensor[(), int32], Tensor[(), int32])]
+
+Note that :code:`Nil()` can be an instance of any list because it
+does not take any arguments that use a type parameter. (Nevertheless,
+for any *particular* instance of :code:`Nil()`, the type parameter must
+be specified.)
+
+Here are two lists that are rejected by the type system because
+the type parameters do not match:
+
+.. code_block:: python
+
+   # attempting to put an integer on a list of int * int tuples
+   Cons(1, Cons((1, 1), Nil()))
+   # attempting to put a list of ints on a list of lists of int * int tuples
+   Cons(Cons(1, Cons(2, Nil())), Cons(Cons((1, 1), Cons((2, 2), Nil())), Nil()))

--- a/docs/langref/relay_type.rst
+++ b/docs/langref/relay_type.rst
@@ -248,7 +248,7 @@ Algebraic Data Types
 *Note: ADTs are not currently supported in the text format.*
 
 Algebraic data types (ADTs) are described in more detail in
-`their overview <adt-overview_>`__; this section describes
+:ref:`their overview <adt-overview>`; this section describes
 their implementation in the type system.
 
 An ADT is defined by a collection of named constructors,
@@ -296,7 +296,7 @@ Definitions (Type Data)
 
 Besides a name, an ADT needs to store the constructors that are used
 to define it and any type paramters used within them. These are
-stored in the module, `analogous to global function definitions <module-description_>`__.
+stored in the module, :ref:`analogous to global function definitions<module-description>`.
 
 While type-checking uses of ADTs, the type system sometimes must
 index into the module using the ADT name to look up information
@@ -356,7 +356,7 @@ variable :code:`List` in the constructor definition.
 
 Below two instances of lists with their types given, using type calls:
 
-.. code_block:: python
+.. code-block:: python
 
    Cons(1, Cons(2, Nil())) # List[Tensor[(), int32]]
    Cons((1, 1), Cons((2, 2), Nil())) # List[(Tensor[(), int32], Tensor[(), int32])]
@@ -369,7 +369,7 @@ be specified.)
 Here are two lists that are rejected by the type system because
 the type parameters do not match:
 
-.. code_block:: python
+.. code-block:: python
 
    # attempting to put an integer on a list of int * int tuples
    Cons(1, Cons((1, 1), Nil()))


### PR DESCRIPTION
This PR adds documentation to the Relay language reference for ADTs, which are in the still-under-review PR #2442 and were described in the RFC #2175.

ADTs have a lot of complexity to them, so I made them a separate page, but I wonder whether that's the best choice or whether it should be a tutorial page. A lot of the material is similar to introductory functional programming examples, so I am interested on feedback on whether it's the best way to present this material. I am not sure about how much familiarity to expect with these constructs.