### PR TITLE
Conda packages with cuda support

### DIFF
--- a/conda/Dockerfile.cuda100
+++ b/conda/Dockerfile.cuda100
@@ -4,7 +4,7 @@ RUN curl -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-lat
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install conda-build && \
+     /opt/conda/bin/conda install conda-build conda-verify && \
      /opt/conda/bin/conda clean -ya
 
 ENV PATH /opt/conda/bin:$PATH

--- a/conda/Dockerfile.cuda100
+++ b/conda/Dockerfile.cuda100
@@ -12,3 +12,5 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 WORKDIR /workspace
 RUN chmod -R a+w /workspace
+
+CMD conda build --output-folder /workspace/conda/pkg --variants '{cuda: True, cuda_version: 10.0}' /workspace/conda/tvm-libs

--- a/conda/Dockerfile.cuda100
+++ b/conda/Dockerfile.cuda100
@@ -1,0 +1,14 @@
+FROM nvidia/cuda:10.0-devel-centos6
+
+RUN curl -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+     chmod +x ~/miniconda.sh && \
+     ~/miniconda.sh -b -p /opt/conda && \
+     rm ~/miniconda.sh && \
+     /opt/conda/bin/conda install conda-build && \
+     /opt/conda/bin/conda clean -ya
+
+ENV PATH /opt/conda/bin:$PATH
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+WORKDIR /workspace
+RUN chmod -R a+w /workspace

--- a/conda/Dockerfile.cuda92
+++ b/conda/Dockerfile.cuda92
@@ -1,0 +1,14 @@
+FROM nvidia/cuda:9.2-devel-centos6
+
+RUN curl -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+     chmod +x ~/miniconda.sh && \
+     ~/miniconda.sh -b -p /opt/conda && \
+     rm ~/miniconda.sh && \
+     /opt/conda/bin/conda install conda-build && \
+     /opt/conda/bin/conda clean -ya
+
+ENV PATH /opt/conda/bin:$PATH
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+WORKDIR /workspace
+RUN chmod -R a+w /workspace

--- a/conda/Dockerfile.cuda92
+++ b/conda/Dockerfile.cuda92
@@ -12,3 +12,5 @@ ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
 
 WORKDIR /workspace
 RUN chmod -R a+w /workspace
+
+CMD conda build --output-folder /workspace/conda/pkg --variants '{cuda: True, cuda_version: 9.2}' /workspace/conda/tvm-libs

--- a/conda/Dockerfile.cuda92
+++ b/conda/Dockerfile.cuda92
@@ -4,7 +4,7 @@ RUN curl -o ~/miniconda.sh -O https://repo.continuum.io/miniconda/Miniconda3-lat
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \
-     /opt/conda/bin/conda install conda-build && \
+     /opt/conda/bin/conda install conda-build conda-verify && \
      /opt/conda/bin/conda clean -ya
 
 ENV PATH /opt/conda/bin:$PATH

--- a/conda/build_cuda.sh
+++ b/conda/build_cuda.sh
@@ -1,0 +1,6 @@
+#/bin/sh
+docker build -t tvm-cuda101-forge . -f Dockerfile.cuda100
+docker run -v `pwd`/..:/workspace tvm-cuda100-forge
+docker build -t tvm-cuda92-forge . -f Dockerfile.cuda92
+docker run -v `pwd`/..:/workspace tvm-cuda92-forge
+sudo chown -R `whoami` pkg

--- a/conda/build_cuda.sh
+++ b/conda/build_cuda.sh
@@ -1,6 +1,10 @@
 #/bin/sh
-docker build -t tvm-cuda101-forge . -f Dockerfile.cuda100
-docker run -v `pwd`/..:/workspace tvm-cuda100-forge
-docker build -t tvm-cuda92-forge . -f Dockerfile.cuda92
-docker run -v `pwd`/..:/workspace tvm-cuda92-forge
-sudo chown -R `whoami` pkg
+condadir=`dirname $0`
+condadir=`readlink -f $condadir`
+srcdir=`dirname $condadir`
+
+docker build -t tvm-cuda100-forge $condadir -f $condadir/Dockerfile.cuda100
+docker run --rm -v $srcdir:/workspace tvm-cuda100-forge
+docker build -t tvm-cuda92-forge $condadir -f $condadir/Dockerfile.cuda92
+docker run --rm -v $srcdir:/workspace tvm-cuda92-forge
+sudo chown -R `whoami` $condadir/pkg

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -2,3 +2,6 @@ python:
   - 3.5
   - 3.6
   - 3.7
+
+cuda:
+  - False

--- a/conda/nnvm/meta.yaml
+++ b/conda/nnvm/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:

--- a/conda/topi/meta.yaml
+++ b/conda/topi/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/conda/tvm-libs/build.sh
+++ b/conda/tvm-libs/build.sh
@@ -6,10 +6,16 @@ if [ -z "$PREFIX" ]; then
   PREFIX="$CONDA_PREFIX"
 fi
 
+if [ -z "$cuda" ] || [ "$cuda" == "False" ]; then
+    CUDA_OPT=""
+else
+    CUDA_OPT="-DUSE_CUDA=ON"
+fi
+
 rm -rf build || true
 mkdir -p build
 cd build
-cmake -DUSE_LLVM=ON -DINSTALL_DEV=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" ..
-make -j2 VERBOSE=1
+cmake $CUDA_OPT -DUSE_LLVM=ON -DINSTALL_DEV=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" ..
+make -j4 VERBOSE=1
 make install
 cd ..

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   number: 1
-  string: cuda{{ cuda_version }}  # [cuda]
+  string: cuda{{ cuda_version }}_{{ PKG_BUILDNUM }}  # [cuda]
 
 requirements:
   build:
@@ -24,6 +24,7 @@ requirements:
     - cmake
     - llvmdev ==6.0.0  # [linux]
     - zlib  # [linux]
+  run:
     - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
 
 about:

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - cmake
     - llvmdev ==6.0.0  # [linux]
     - zlib  # [linux]
+  run:
+    - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
 
 about:
   home: https://github.com/dmlc/tvm

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 0
+  number: 1
   string: cuda{{ cuda_version }}  # [cuda]
 
 requirements:

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  string: cuda{{ cuda_version }}  # [cuda]
 
 requirements:
   build:

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - cmake
     - llvmdev ==6.0.0  # [linux]
     - zlib  # [linux]
-  run:
     - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]
 
 about:

--- a/conda/tvm/meta.yaml
+++ b/conda/tvm/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
I've added scripts and dockerfiles to build packages for conda with cuda support.  It would be possible to use a similar approach to build for other backends, but I haven't done the work.

These scripts are not hooked up to any build at the moment and must be launched manually.

If there is interest I can try to make it work with the current testing pipeline so that it will build the packages after a pass of the tests.  It would be a good idea to setup an anaconda channel and upload packages for the releases there too.