### PR TITLE
[TVM][Bugfix] fix storage_rewrite bug when input is big

### DIFF
--- a/src/pass/storage_rewrite.cc
+++ b/src/pass/storage_rewrite.cc
@@ -564,6 +564,9 @@ class StoragePlanRewriter : public IRMutator {
           Expr combo_size;
           for (const Allocate* op : e->allocs) {
             Expr sz = arith::ComputeReduce<Mul>(op->extents, make_const(Int(32), 1));
+            if (const auto* imm = sz.as<IntImm>()) {
+              sz =  make_const(Int(64), imm->value);
+            }
             // transform to bits
             auto sz_nbits = sz * (op->type.bits() * op->type.lanes());
             if (combo_size.defined()) {
@@ -578,7 +581,7 @@ class StoragePlanRewriter : public IRMutator {
           combo_size = combo_size / type_bits;
           // round up for can not divided
           if (!divided) {
-             combo_size = combo_size + make_const(Int(32), 1);
+             combo_size = combo_size + make_const(Int(64), 1);
           }
           combo_size = ir::Simplify(combo_size);
           e->new_alloc = Allocate::make(

--- a/src/pass/storage_rewrite.cc
+++ b/src/pass/storage_rewrite.cc
@@ -572,9 +572,9 @@ class StoragePlanRewriter : public IRMutator {
                 LOG(WARNING) << "The allocation requires : " << imm->value
                              << " * " << nbits
                              << " bits, which is greater than the maximum of "
-                                "int32. The size is cast to int64."
+                                "int32. The size is cast to uint32."
                              << "\n";
-                sz = make_const(Int(64), imm->value);
+                sz = make_const(UInt(32), imm->value);
               }
             }
             // transform to bits

--- a/src/pass/storage_rewrite.cc
+++ b/src/pass/storage_rewrite.cc
@@ -571,10 +571,10 @@ class StoragePlanRewriter : public IRMutator {
               if (imm->value > std::numeric_limits<int>::max() / nbits) {
                 LOG(WARNING) << "The allocation requires : " << imm->value
                              << " * " << nbits
-                             << " bits, which is greater than the maximum of "
-                                "int32. The size is cast to uint32."
+                             << " bits, which is greater than the maximum of"
+                                " int32. The size is cast to int64."
                              << "\n";
-                sz = make_const(UInt(32), imm->value);
+                sz = make_const(Int(64), imm->value);
               }
             }
             // transform to bits

--- a/src/pass/storage_rewrite.cc
+++ b/src/pass/storage_rewrite.cc
@@ -564,11 +564,14 @@ class StoragePlanRewriter : public IRMutator {
           Expr combo_size;
           for (const Allocate* op : e->allocs) {
             Expr sz = arith::ComputeReduce<Mul>(op->extents, make_const(Int(32), 1));
+            auto nbits = op->type.bits() * op->type.lanes();
             if (const auto* imm = sz.as<IntImm>()) {
-              sz =  make_const(Int(64), imm->value);
+              if (imm->value > std::numeric_limits<int>::max() / nbits) {
+                sz = make_const(Int(64), imm->value);
+              }
             }
             // transform to bits
-            auto sz_nbits = sz * (op->type.bits() * op->type.lanes());
+            auto sz_nbits = sz * nbits;
             if (combo_size.defined()) {
               combo_size = max(combo_size, sz_nbits);
             } else {
@@ -581,7 +584,7 @@ class StoragePlanRewriter : public IRMutator {
           combo_size = combo_size / type_bits;
           // round up for can not divided
           if (!divided) {
-             combo_size = combo_size + make_const(Int(64), 1);
+            combo_size = combo_size + make_const(Int(32), 1);
           }
           combo_size = ir::Simplify(combo_size);
           e->new_alloc = Allocate::make(

--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -480,14 +480,14 @@ def test_replace_dataflow():
 def test_large_input():
     @tvm.hybrid.script
     def compute(a, b):
-        n = 8192
+        n = 16384
         c = output_tensor((n, n), 'int32')
         for i in range(n):
             for j in range(n):
                 c[i, j] = a[i, j] - b[i, j]
         return c
 
-    n = 8192
+    n = 16384
     shape = (n, n)
     a = tvm.placeholder(shape, name='a', dtype='int32')
     b = tvm.placeholder(shape, name='b', dtype='int32')
@@ -497,7 +497,7 @@ def test_large_input():
     stmt = tvm.lower(s, [a, b, c], simple_mode=True)
     def verify(n):
         if isinstance(n, tvm.stmt.Allocate):
-            assert n.extents[0].value == 67108864
+            assert n.extents[0].value == 268435456
     tvm.ir_pass.PostOrderVisit(stmt, verify)
 
 

--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -477,6 +477,33 @@ def test_replace_dataflow():
     assert isinstance(bounds, tvm.container.Map)
 
 
+def test_large_input():
+    @tvm.hybrid.script
+    def compute(a, b):
+        n = 16384
+        c = output_tensor((n, n), 'int32')
+        for i in range(n):
+            for j in range(n):
+                c[i, j] = a[i, j] - b[i, j]
+        return c
+
+    n = 16384
+    shape = (n, n)
+    a = tvm.placeholder(shape, name='a', dtype='int32')
+    b = tvm.placeholder(shape, name='b', dtype='int32')
+    c = tvm.compute(shape, lambda i, j: compute(a, b)[i, j])
+    c = tvm.compute(shape, lambda i, j: 1 + c[i, j])
+    s = tvm.create_schedule(c.op)
+    stmt = tvm.lower(s, [a, b, c], simple_mode=True)
+    num_alloc = [0]
+    def verify(n):
+        if isinstance(n, tvm.stmt.Allocate):
+            num_alloc[0] += 1
+            assert n.extents[0].value == 268435456
+    tvm.ir_pass.PostOrderVisit(stmt, verify)
+    assert num_alloc[0] == 1
+
+
 if __name__ == "__main__":
     test_alloc_seq()
     test_alloc_different_dtypes()
@@ -492,3 +519,4 @@ if __name__ == "__main__":
     test_alloc_seq_type2()
     test_reuse_small_buffer()
     test_replace_dataflow()
+    test_large_input()

--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -480,14 +480,14 @@ def test_replace_dataflow():
 def test_large_input():
     @tvm.hybrid.script
     def compute(a, b):
-        n = 16384
+        n = 8192
         c = output_tensor((n, n), 'int32')
         for i in range(n):
             for j in range(n):
                 c[i, j] = a[i, j] - b[i, j]
         return c
 
-    n = 16384
+    n = 8192
     shape = (n, n)
     a = tvm.placeholder(shape, name='a', dtype='int32')
     b = tvm.placeholder(shape, name='b', dtype='int32')
@@ -497,7 +497,7 @@ def test_large_input():
     stmt = tvm.lower(s, [a, b, c], simple_mode=True)
     def verify(n):
         if isinstance(n, tvm.stmt.Allocate):
-            assert n.extents[0].value == 268435456
+            assert n.extents[0].value == 67108864
     tvm.ir_pass.PostOrderVisit(stmt, verify)
 
 

--- a/tests/python/unittest/test_pass_storage_rewrite.py
+++ b/tests/python/unittest/test_pass_storage_rewrite.py
@@ -495,13 +495,10 @@ def test_large_input():
     c = tvm.compute(shape, lambda i, j: 1 + c[i, j])
     s = tvm.create_schedule(c.op)
     stmt = tvm.lower(s, [a, b, c], simple_mode=True)
-    num_alloc = [0]
     def verify(n):
         if isinstance(n, tvm.stmt.Allocate):
-            num_alloc[0] += 1
             assert n.extents[0].value == 268435456
     tvm.ir_pass.PostOrderVisit(stmt, verify)
-    assert num_alloc[0] == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a bug when input size is large. For example, the size of a tensor in terms of bits may exceed the maximum of int32. It causes core dump at runtime. This bug is identified with the help from @yzhliu 

@yzhliu @tqchen @wweic please review
