### PR TITLE
[TUTORIAL] Fix downloaded file path

### DIFF
--- a/vta/tutorials/resnet.py
+++ b/vta/tutorials/resnet.py
@@ -147,8 +147,7 @@ if not os.path.exists(data_dir):
 
 # Download files
 for file in [categ_fn, graph_fn, params_fn]:
-    if not os.path.isfile(file):
-        download(os.path.join(url, file), os.path.join(data_dir, file))
+    download(os.path.join(url, file), os.path.join(data_dir, file))
 
 # Read in ImageNet Categories
 synset = eval(open(os.path.join(data_dir, categ_fn)).read())


### PR DESCRIPTION
The downloaded file path is not `file` but `os.path.join(data_dir, file)`.  Let's remove the file existence check since we do it in download() either way.