### PR TITLE
[TEST] Remove script that references previously removed content.

### DIFF
--- a/tests/scripts/task_cpp_topi.sh
+++ b/tests/scripts/task_cpp_topi.sh
@@ -1,4 +1,0 @@
-export PYTHONPATH=python:topi/python
-
-python -m nose -v topi/tests/python_cpp || exit -1
-python3 -m nose -v topi/tests/python_cpp || exit -1


### PR DESCRIPTION
Commit 6d1f4c0b5ced2ca890db4fdd436278a9d70280c7 removed the contents
of topi/tests/python_cpp but did not remove the task_cpp_topi.sh
script that references that content.  Hence task_cpp_topi.sh servers
no longer serves any purpose.

Commit 911c3a36eddacfaad2218c811168c12bccf01a49 removed the
Jenkinsfile and travis references to task_cpp_topi.sh, this patch
removes the file itself.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
