### PR TITLE
[Relay] Port param dict save/load from NNVM

### DIFF
--- a/python/tvm/api.py
+++ b/python/tvm/api.py
@@ -136,7 +136,7 @@ def load_json(json_str):
 
 
 def save_json(node):
-    """Load tvm object as json string.
+    """Save tvm object as json string.
 
     Parameters
     ----------

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -13,6 +13,7 @@ from .build_module import build, build_config, create_executor, optimize
 from . import prelude
 from . import parser
 from . import debug
+from . import param_dict
 
 # Root operators
 from .op import Op
@@ -85,3 +86,7 @@ ExprMutator = expr_functor.ExprMutator
 
 # Parser
 fromtext = parser.fromtext
+
+# Param Serialization
+save_param_dict = param_dict.save_param_dict
+load_param_dict = param_dict.load_param_dict

--- a/python/tvm/relay/param_dict.py
+++ b/python/tvm/relay/param_dict.py
@@ -26,8 +26,7 @@ def save_param_dict(params):
     .. code-block:: python
 
        # compile and save the modules to file.
-       graph, lib, params = nnvm.compiler.build(
-          graph, target, shape={"data", data_shape}, params=params)
+       graph, lib, params = tvm.relay.build(func, target=target, params=params)
        module = graph_runtime.create(graph, lib, tvm.gpu(0))
        # save the parameters as byte array
        param_bytes = tvm.relay.save_param_dict(params)

--- a/python/tvm/relay/param_dict.py
+++ b/python/tvm/relay/param_dict.py
@@ -1,0 +1,59 @@
+# pylint: disable=invalid-name
+"""Helper utility to save parameter dicts."""
+import tvm
+from tvm.relay.backend.interpreter import TensorValue
+
+
+def save_param_dict(params):
+    """Save parameter dictionary to binary bytes.
+
+    The result binary bytes can be loaded by the
+    GraphModule with API "load_params".
+
+    Parameters
+    ----------
+    params : dict of str to NDArray
+        The parameter dictionary.
+
+    Returns
+    -------
+    param_bytes: bytearray
+        Serialized parameters.
+
+    Examples
+    --------
+    .. code-block:: python
+
+       # compile and save the modules to file.
+       graph, lib, params = nnvm.compiler.build(
+          graph, target, shape={"data", data_shape}, params=params)
+       module = graph_runtime.create(graph, lib, tvm.gpu(0))
+       # save the parameters as byte array
+       param_bytes = nnvm.compiler.save_param_dict(params)
+       # We can serialize the param_bytes and load it back later.
+       # Pass in byte array to module to directly set parameters
+       module["load_params"](param_bytes)
+    """
+    # Wrap the `NDArray`s in a `TensorValue`, because raw `NDArray`s are not
+    # serializable, and `TensorValue`s are.
+    json_str = tvm.save_json({key: TensorValue(val)
+                              for (key, val) in params.items()})
+    return bytearray(json_str.encode('utf-8'))
+
+
+def load_param_dict(param_bytes):
+    """Load parameter dictionary to binary bytes.
+
+    Parameters
+    ----------
+    param_bytes: bytearray
+        Serialized parameters.
+
+    Returns
+    -------
+    params : dict of str to NDArray
+        The parameter dictionary.
+    """
+    param_json = tvm.load_json(param_bytes.decode('utf-8'))
+    # Pull the `data` field from each of the `TensorValue`s to get `NDArray`s.
+    return {key: val.data for (key, val) in param_json.items()}

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -578,5 +578,10 @@ TVM_REGISTER_API("relay.backend.CreateInterpreter")
 .set_body([](TVMArgs args, TVMRetValue* ret) {
     *ret = CreateInterpreter(args[0], args[1], args[2]);
   });
+
+TVM_REGISTER_NODE_TYPE(ClosureNode);
+TVM_REGISTER_NODE_TYPE(TupleValueNode);
+TVM_REGISTER_NODE_TYPE(TensorValueNode);
+
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/backend/param_dict.cc
+++ b/src/relay/backend/param_dict.cc
@@ -4,6 +4,9 @@
  * \brief Implementation and registration of parameter dictionary
  * serializing/deserializing functions.
  */
+#include <string>
+#include <vector>
+
 #include <dmlc/memory_io.h>
 
 #include "param_dict.h"

--- a/src/relay/backend/param_dict.cc
+++ b/src/relay/backend/param_dict.cc
@@ -69,19 +69,19 @@ TVM_REGISTER_GLOBAL("tvm.relay._load_param_dict")
     size_t size = static_cast<size_t>(sz);
     CHECK(size == names.size())
         << "Invalid parameters file format";
-    tvm::Array<NDArrayWrapper> ret;
+    tvm::Array<NamedNDArray> ret;
     for (size_t i = 0; i < size; ++i) {
       tvm::runtime::NDArray temp;
       temp.Load(strm);
-      auto n = tvm::make_node<NDArrayWrapperNode>();
+      auto n = tvm::make_node<NamedNDArrayNode>();
       n->name = std::move(names[i]);
       n->array = temp;
-      ret.push_back(NDArrayWrapper(n));
+      ret.push_back(NamedNDArray(n));
     }
     *rv = ret;
   });
 
-TVM_REGISTER_NODE_TYPE(NDArrayWrapperNode);
+TVM_REGISTER_NODE_TYPE(NamedNDArrayNode);
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/backend/param_dict.cc
+++ b/src/relay/backend/param_dict.cc
@@ -1,0 +1,84 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file param_dict.cc
+ * \brief Implementation and registration of parameter dictionary
+ * serializing/deserializing functions.
+ */
+#include <dmlc/memory_io.h>
+
+#include "param_dict.h"
+
+namespace tvm {
+namespace relay {
+
+using namespace runtime;
+
+TVM_REGISTER_GLOBAL("tvm.relay._save_param_dict")
+.set_body([](TVMArgs args, TVMRetValue *rv) {
+    CHECK_EQ(args.size() % 2, 0u);
+    // `args` is in the form "key, value, key, value, ..."
+    size_t num_params = args.size() / 2;
+    std::vector<std::string> names;
+    names.reserve(num_params);
+    std::vector<DLTensor*> arrays;
+    arrays.reserve(num_params);
+    for (size_t i = 0; i < num_params * 2; i += 2) {
+      names.emplace_back(args[i].operator std::string());
+      arrays.emplace_back(args[i + 1].operator DLTensor*());
+    }
+    std::string bytes;
+    dmlc::MemoryStringStream strm(&bytes);
+    dmlc::Stream* fo = &strm;
+    uint64_t header = kTVMNDArrayListMagic, reserved = 0;
+    fo->Write(header);
+    fo->Write(reserved);
+    fo->Write(names);
+    {
+      uint64_t sz = static_cast<uint64_t>(arrays.size());
+      fo->Write(sz);
+      for (size_t i = 0; i < sz; ++i) {
+        tvm::runtime::SaveDLTensor(fo, arrays[i]);
+      }
+    }
+    TVMByteArray arr;
+    arr.data = bytes.c_str();
+    arr.size = bytes.length();
+    *rv = arr;
+  });
+
+TVM_REGISTER_GLOBAL("tvm.relay._load_param_dict")
+.set_body([](TVMArgs args, TVMRetValue *rv) {
+    std::string bytes = args[0];
+    std::vector<std::string> names;
+    dmlc::MemoryStringStream memstrm(&bytes);
+    dmlc::Stream* strm = &memstrm;
+    uint64_t header, reserved;
+    CHECK(strm->Read(&header))
+        << "Invalid parameters file format";
+    CHECK(header == kTVMNDArrayListMagic)
+        << "Invalid parameters file format";
+    CHECK(strm->Read(&reserved))
+        << "Invalid parameters file format";
+    CHECK(strm->Read(&names))
+        << "Invalid parameters file format";
+    uint64_t sz;
+    strm->Read(&sz, sizeof(sz));
+    size_t size = static_cast<size_t>(sz);
+    CHECK(size == names.size())
+        << "Invalid parameters file format";
+    tvm::Array<NDArrayWrapper> ret;
+    for (size_t i = 0; i < size; ++i) {
+      tvm::runtime::NDArray temp;
+      temp.Load(strm);
+      auto n = tvm::make_node<NDArrayWrapperNode>();
+      n->name = std::move(names[i]);
+      n->array = temp;
+      ret.push_back(NDArrayWrapper(n));
+    }
+    *rv = ret;
+  });
+
+TVM_REGISTER_NODE_TYPE(NDArrayWrapperNode);
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/backend/param_dict.cc
+++ b/src/relay/backend/param_dict.cc
@@ -4,12 +4,12 @@
  * \brief Implementation and registration of parameter dictionary
  * serializing/deserializing functions.
  */
-#include <string>
-#include <vector>
+#include "param_dict.h"
 
 #include <dmlc/memory_io.h>
 
-#include "param_dict.h"
+#include <string>
+#include <vector>
 
 namespace tvm {
 namespace relay {

--- a/src/relay/backend/param_dict.h
+++ b/src/relay/backend/param_dict.h
@@ -6,6 +6,8 @@
 #ifndef TVM_RELAY_BACKEND_PARAM_DICT_H_
 #define TVM_RELAY_BACKEND_PARAM_DICT_H_
 
+#include <string>
+
 #include <tvm/node/node.h>
 #include <tvm/packed_func_ext.h>
 #include <tvm/runtime/ndarray.h>

--- a/src/relay/backend/param_dict.h
+++ b/src/relay/backend/param_dict.h
@@ -1,0 +1,41 @@
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file param_dict.h
+ * \brief Definitions for serializing and deserializing parameter dictionaries.
+ */
+#ifndef TVM_RELAY_BACKEND_PARAM_DICT_H_
+#define TVM_RELAY_BACKEND_PARAM_DICT_H_
+
+#include <tvm/node/node.h>
+#include <tvm/packed_func_ext.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/packed_func.h>
+
+namespace tvm {
+namespace relay {
+
+/*! \brief Magic number for NDArray list file  */
+constexpr uint64_t kTVMNDArrayListMagic = 0xF7E58D4F05049CB7;
+
+/*!
+ * \brief wrapper node container for exchange.
+ */
+struct NDArrayWrapperNode : public ::tvm::Node {
+  std::string name;
+  tvm::runtime::NDArray array;
+
+  void VisitAttrs(tvm::AttrVisitor* v) final {
+    v->Visit("name", &name);
+    v->Visit("array", &array);
+  }
+
+  static constexpr const char* _type_key = "NDArrayWrapper";
+  TVM_DECLARE_NODE_TYPE_INFO(NDArrayWrapperNode, Node);
+};
+
+TVM_DEFINE_NODE_REF(NDArrayWrapper, NDArrayWrapperNode);
+
+}  // namespace relay
+}  // namespace tvm
+
+#endif  // TVM_RELAY_BACKEND_PARAM_DICT_H_

--- a/src/relay/backend/param_dict.h
+++ b/src/relay/backend/param_dict.h
@@ -20,9 +20,9 @@ namespace relay {
 constexpr uint64_t kTVMNDArrayListMagic = 0xF7E58D4F05049CB7;
 
 /*!
- * \brief wrapper node container for exchange.
+ * \brief Wrapper node for naming `NDArray`s.
  */
-struct NDArrayWrapperNode : public ::tvm::Node {
+struct NamedNDArrayNode : public ::tvm::Node {
   std::string name;
   tvm::runtime::NDArray array;
 
@@ -31,11 +31,11 @@ struct NDArrayWrapperNode : public ::tvm::Node {
     v->Visit("array", &array);
   }
 
-  static constexpr const char* _type_key = "NDArrayWrapper";
-  TVM_DECLARE_NODE_TYPE_INFO(NDArrayWrapperNode, Node);
+  static constexpr const char* _type_key = "NamedNDArray";
+  TVM_DECLARE_NODE_TYPE_INFO(NamedNDArrayNode, Node);
 };
 
-TVM_DEFINE_NODE_REF(NDArrayWrapper, NDArrayWrapperNode);
+TVM_DEFINE_NODE_REF(NamedNDArray, NamedNDArrayNode);
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/backend/param_dict.h
+++ b/src/relay/backend/param_dict.h
@@ -6,12 +6,12 @@
 #ifndef TVM_RELAY_BACKEND_PARAM_DICT_H_
 #define TVM_RELAY_BACKEND_PARAM_DICT_H_
 
-#include <string>
-
 #include <tvm/node/node.h>
 #include <tvm/packed_func_ext.h>
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/packed_func.h>
+
+#include <string>
 
 namespace tvm {
 namespace relay {

--- a/tests/python/relay/test_param_dict.py
+++ b/tests/python/relay/test_param_dict.py
@@ -31,7 +31,7 @@ def test_ndarray_reflection():
     param_dict_bytes = relay.save_param_dict(param_dict)
     # Deserialize (using `json.loads`), then verify the base64 `NDArray`
     # encoding wasn't corrupted.
-    deser_param_dict = json.loads(param_dict_bytes)
+    deser_param_dict = json.loads(param_dict_bytes.decode('utf-8'))
     b64_str = deser_param_dict["b64ndarrays"][0]
     decoded = py_str(base64.b64encode(base64.b64decode(b64_str)))
     assert b64_str == decoded

--- a/tests/python/relay/test_param_dict.py
+++ b/tests/python/relay/test_param_dict.py
@@ -4,6 +4,7 @@ import tvm
 import json
 import base64
 from tvm._ffi.base import py_str
+from tvm.relay.op import add
 from tvm import relay
 from tvm import rpc
 from tvm.contrib import util, graph_runtime
@@ -13,32 +14,26 @@ def test_save_load():
     x = np.ones((10, 2)).astype("float32")
     y = np.ones((1, 2, 3)).astype("float32")
     params = {"x": x, "y": y}
-    param_bytes = tvm.relay.save_param_dict(params)
+    param_bytes = relay.save_param_dict(params)
     assert isinstance(param_bytes, bytearray)
-    param2 = tvm.relay.load_param_dict(param_bytes)
+    param2 = relay.load_param_dict(param_bytes)
     assert len(param2) == 2
     np.testing.assert_equal(param2["x"].asnumpy(), x)
     np.testing.assert_equal(param2["y"].asnumpy(), y)
 
 
 def test_ndarray_reflection():
-    # Make a param dict where both keys point to the same array.
-    x = np.random.uniform(size=(10, 2)).astype("float32")
-    xx = tvm.nd.array(x)
-    param_dict = {'xx': xx, 'x2': xx}
-    assert param_dict['xx'].same_as(param_dict['x2'])
-    # Serialize the param dict.
-    param_dict_bytes = relay.save_param_dict(param_dict)
-    # Deserialize (using `json.loads`), then verify the base64 `NDArray`
-    # encoding wasn't corrupted.
-    deser_param_dict = json.loads(param_dict_bytes.decode('utf-8'))
-    b64_str = deser_param_dict["b64ndarrays"][0]
-    decoded = py_str(base64.b64encode(base64.b64decode(b64_str)))
-    assert b64_str == decoded
-    # Deserialize (using `load_param_dict`), and verify the data wasn't corrupted.
-    deser_param_dict = relay.load_param_dict(param_dict_bytes)
-    np.testing.assert_equal(deser_param_dict['xx'].asnumpy(), xx.asnumpy())
-    assert deser_param_dict['xx'] == deser_param_dict['x2']
+    # Make two `NDArrayWrapper`s that point to the same underlying array.
+    np_array = np.random.uniform(size=(10, 2)).astype("float32")
+    tvm_array = tvm.nd.array(np_array)
+    param_dict = {'x': tvm_array, 'y': tvm_array}
+    assert param_dict['x'].same_as(param_dict['y'])
+    # Serialize then deserialize `param_dict`.
+    deser_param_dict = relay.load_param_dict(relay.save_param_dict(param_dict))
+    # Make sure the data matches the original data and `x` and `y` contain the same data.
+    np.testing.assert_equal(deser_param_dict['x'].asnumpy(), tvm_array.asnumpy())
+    # Make sure `x` and `y` contain the same data.
+    np.testing.assert_equal(deser_param_dict['x'].asnumpy(), deser_param_dict['y'].asnumpy())
 
 
 def test_bigendian_rpc_param():
@@ -48,34 +43,33 @@ def test_bigendian_rpc_param():
     if host is None:
         return
 
-    def verify_nnvm(remote, target, shape, dtype):
-        x = nnvm.sym.Variable("x")
-        y = x + 1
-        graph, lib, _ = relay.build(
-            y, target,
-            shape={"x": shape},
-        dtype={"x": dtype})
+    def verify_graph_runtime(remote, target, shape, dtype):
+        x = relay.var('x')
+        y = relay.const(1)
+        z = relay.add(x, y)
+        func = relay.Function([x], z)
+
+        x_in = np.ones(shape).astype(dtype)
+        params = {'x': x_in}
+        graph, lib, params = relay.build(func, target=target, params=params)
 
         temp = util.tempdir()
         path_dso = temp.relpath("dev_lib.o")
         lib.save(path_dso)
         remote.upload(path_dso)
         lib = remote.load_module("dev_lib.o")
-        a = np.random.randint(0, 256, size=shape).astype(dtype)
-        a[:] = 1
-        params = {"x" : a}
         ctx = remote.cpu(0)
-        m = graph_runtime.create(graph, lib, ctx)
-        m.load_params(relay.save_param_dict(params))
-        m.run()
-        out = m.get_output(0, tvm.nd.empty(shape, dtype=dtype, ctx=ctx))
-        tvm.testing.assert_allclose(a + 1, out.asnumpy())
+        mod = graph_runtime.create(graph, lib, ctx)
+        mod.load_params(relay.save_param_dict(params))
+        mod.run()
+        out = mod.get_output(0, tvm.nd.empty(shape, dtype=dtype, ctx=ctx))
+        tvm.testing.assert_allclose(x_in + 1, out.asnumpy())
 
     print("Test RPC connection to PowerPC...")
     remote = rpc.connect(host, port)
     target = "llvm -mtriple=powerpc-linux-gnu"
     for dtype in ["float32", "float64", "int32", "int8"]:
-        verify_nnvm(remote, target, (10,), dtype)
+        verify_graph_runtime(remote, target, (10,), dtype)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_param_dict.py
+++ b/tests/python/relay/test_param_dict.py
@@ -1,0 +1,84 @@
+import os
+import numpy as np
+import tvm
+import json
+import base64
+from tvm._ffi.base import py_str
+from tvm import relay
+from tvm import rpc
+from tvm.contrib import util, graph_runtime
+
+
+def test_save_load():
+    x = np.ones((10, 2)).astype("float32")
+    y = np.ones((1, 2, 3)).astype("float32")
+    params = {"x": x, "y": y}
+    param_bytes = tvm.relay.save_param_dict(params)
+    assert isinstance(param_bytes, bytearray)
+    param2 = tvm.relay.load_param_dict(param_bytes)
+    assert len(param2) == 2
+    np.testing.assert_equal(param2["x"].asnumpy(), x)
+    np.testing.assert_equal(param2["y"].asnumpy(), y)
+
+
+def test_ndarray_reflection():
+    # Make a param dict where both keys point to the same array.
+    x = np.random.uniform(size=(10, 2)).astype("float32")
+    xx = tvm.nd.array(x)
+    param_dict = {'xx': xx, 'x2': xx}
+    assert param_dict['xx'].same_as(param_dict['x2'])
+    # Serialize the param dict.
+    param_dict_bytes = relay.save_param_dict(param_dict)
+    # Deserialize (using `json.loads`), then verify the base64 `NDArray`
+    # encoding wasn't corrupted.
+    deser_param_dict = json.loads(param_dict_bytes)
+    b64_str = deser_param_dict["b64ndarrays"][0]
+    decoded = py_str(base64.b64encode(base64.b64decode(b64_str)))
+    assert b64_str == decoded
+    # Deserialize (using `load_param_dict`), and verify the data wasn't corrupted.
+    deser_param_dict = relay.load_param_dict(param_dict_bytes)
+    np.testing.assert_equal(deser_param_dict['xx'].asnumpy(), xx.asnumpy())
+    assert deser_param_dict['xx'] == deser_param_dict['x2']
+
+
+def test_bigendian_rpc_param():
+    """Test big endian rpc when there is a PowerPC RPC server available"""
+    host = os.environ.get("TVM_POWERPC_TEST_HOST", None)
+    port = os.environ.get("TVM_POWERPC_TEST_PORT", 9090)
+    if host is None:
+        return
+
+    def verify_nnvm(remote, target, shape, dtype):
+        x = nnvm.sym.Variable("x")
+        y = x + 1
+        graph, lib, _ = relay.build(
+            y, target,
+            shape={"x": shape},
+        dtype={"x": dtype})
+
+        temp = util.tempdir()
+        path_dso = temp.relpath("dev_lib.o")
+        lib.save(path_dso)
+        remote.upload(path_dso)
+        lib = remote.load_module("dev_lib.o")
+        a = np.random.randint(0, 256, size=shape).astype(dtype)
+        a[:] = 1
+        params = {"x" : a}
+        ctx = remote.cpu(0)
+        m = graph_runtime.create(graph, lib, ctx)
+        m.load_params(relay.save_param_dict(params))
+        m.run()
+        out = m.get_output(0, tvm.nd.empty(shape, dtype=dtype, ctx=ctx))
+        tvm.testing.assert_allclose(a + 1, out.asnumpy())
+
+    print("Test RPC connection to PowerPC...")
+    remote = rpc.connect(host, port)
+    target = "llvm -mtriple=powerpc-linux-gnu"
+    for dtype in ["float32", "float64", "int32", "int8"]:
+        verify_nnvm(remote, target, (10,), dtype)
+
+
+if __name__ == "__main__":
+    test_save_load()
+    test_ndarray_reflection()
+    test_bigendian_rpc_param()


### PR DESCRIPTION
This PR addresses #2413 by porting the `nnvm.compiler.save_param_dict` and `nnvm.compiler.load_param_dict` functions to Relay as `tvm.relay.save_param_dict` and `tvm.relay.load_param_dict`, respectively.

To serialize `NDArray`s, we wrap them in `TensorValue`s, which have serialization functions defined on them.  Let me know of any concerns about this approach.

While porting, I found that `ClosureNode`, `TupleValueNode`, and `TensorValueNode` were not registered with `TVM_REGISTER_NODE_TYPE`.  This PR also addresses this issue.

The `test_bigendian_rpc_param` test has not yet been confirmed to pass, so I still need to wait for the results from CI.

@jroesch @tqchen @srkreddy1238

Apologies for being late on this one.  Let me know of anyone else I should @.
