### PR TITLE
[Bugfix] Missing #include <sstream>

### DIFF
--- a/include/tvm/runtime/packed_func.h
+++ b/include/tvm/runtime/packed_func.h
@@ -6,6 +6,9 @@
 #ifndef TVM_RUNTIME_PACKED_FUNC_H_
 #define TVM_RUNTIME_PACKED_FUNC_H_
 
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
+#include <sstream>
+#endif
 #include <dmlc/logging.h>
 #include <functional>
 #include <tuple>

--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #if defined(__linux__) || defined(__ANDROID__)
 #include <fstream>
+#include <sstream>
 #else
 #endif
 #if defined(__linux__)


### PR DESCRIPTION
`std::ostringstream` is only defined in `<sstream>` on some platforms.
@tqchen, please review