### PR TITLE
Fix fusion bug when call symbol that is not an operator.

### DIFF
--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -208,11 +208,22 @@ class IndexedForwardGraph::Creator : private ExprVisitor {
     Node* node = graph_.node_map.at(call);
     static auto fpattern =
         Op::GetAttr<TOpPattern>("TOpPattern");
-    // setup pattern.
+    // Now we set the pattern of this call.
+    //
+    // If we see a call mentioning an operator we should mark it with its
+    // annotated pattern.
+    //
+    // If the pattern is not annotated we will default to opaque.
+    //
+    // Finally if the operator position is not a call node we will
+    // need to call Update, as it may be an arbitrary expression.
     OpPatternKind op_pattern = kOpaque;
     if (const OpNode* opnode = call->op.as<OpNode>()) {
       op_pattern = static_cast<OpPatternKind>(fpattern[GetRef<Op>(opnode)]);
+    } else {
+      this->Update(call->op, node, kOpaque);
     }
+
     node->pattern = op_pattern;
     const auto* rtype = call->checked_type().as<TensorTypeNode>();
     // pass the message back to all the children it references.

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -252,20 +252,39 @@ def test_stop_fusion():
 
 
 def test_fuse_myia_regression():
-    x = relay.var('x', shape=(), dtype='int64')
-    y = relay.var('y', shape=(), dtype='int64')
-    sb = relay.ScopeBuilder()
-    with sb.if_scope(relay.op.greater(x, y)):
-        sb.ret(relay.Function([], x))
-    with sb.else_scope():
-        sb.ret(relay.Function([], y))
-    f = relay.Function([x, y],
-        relay.Call(sb.get(), []))
+    def before(dshape, dtype):
+        x = relay.var('x', shape=dshape, dtype=dtype)
+        y = relay.var('y', shape=dshape, dtype=dtype)
+        sb = relay.ScopeBuilder()
+        with sb.if_scope(relay.op.greater(x, y)):
+            sb.ret(relay.Function([], x))
+        with sb.else_scope():
+            sb.ret(relay.Function([], y))
+        return relay.Function([x, y],
+            relay.Call(sb.get(), []))
+
+    def expected(dshape, dtype):
+        x = relay.var('x', shape=dshape, dtype=dtype)
+        y = relay.var('y', shape=dshape, dtype=dtype)
+        sb = relay.ScopeBuilder()
+        p1 = relay.var('p1', shape=dshape, dtype=dtype)
+        p2 = relay.var('p2', shape=dshape, dtype=dtype)
+        fused_gt = relay.Function([p1, p2],
+            relay.op.greater(p1, p2))
+        with sb.if_scope(fused_gt(x, y)):
+            sb.ret(relay.Function([], x))
+        with sb.else_scope():
+            sb.ret(relay.Function([], y))
+        return relay.Function([x, y],
+            relay.Call(sb.get(), []))
+
+    dshape = ()
+    dtype = 'int64'
+    f = before(dshape, dtype)
     f = relay.ir_pass.infer_type(f)
-    print(f)
     f = relay.ir_pass.fuse_ops(f)
-    print(f)
-    import pdb; pdb.set_trace()
+    after = relay.ir_pass.infer_type(expected(dshape, dtype))
+    assert relay.ir_pass.alpha_equal(f, after)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -251,6 +251,23 @@ def test_stop_fusion():
     assert relay.ir_pass.alpha_equal(z, after)
 
 
+def test_fuse_myia_regression():
+    x = relay.var('x', shape=(), dtype='int64')
+    y = relay.var('y', shape=(), dtype='int64')
+    sb = relay.ScopeBuilder()
+    with sb.if_scope(relay.op.greater(x, y)):
+        sb.ret(relay.Function([], x))
+    with sb.else_scope():
+        sb.ret(relay.Function([], y))
+    f = relay.Function([x, y],
+        relay.Call(sb.get(), []))
+    f = relay.ir_pass.infer_type(f)
+    print(f)
+    f = relay.ir_pass.fuse_ops(f)
+    print(f)
+    import pdb; pdb.set_trace()
+
+
 if __name__ == "__main__":
     test_fuse_simple()
     test_conv2d_fuse()
@@ -258,3 +275,4 @@ if __name__ == "__main__":
     test_tuple_root()
     test_tuple_strided_slice()
     test_stop_fusion()
+    test_fuse_myia_regression()


### PR DESCRIPTION
Arnaud ran into this issue while trying to use Relay. 

Previously fusion did not properly update non-operator expressions in the call position. 

This is one potential fix to this case in fusion. I think we should discuss data-flow/ssa style vs. functional in this pass. 

cc @tqchen @abergeron