### PR TITLE
[Quantization][RELAY] Add check against NCHWc ops in the quantization pass

### DIFF
--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -118,6 +118,11 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
         data, dom_scale, clip_min, clip_max, kind, sign, rounding)
 
 
+@register_annotate_function("nn.conv2d_nchwc")
+def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
+    raise TypeError, "NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass..."
+
+
 @register_annotate_function("nn.conv2d")
 def conv2d_rewrite(ref_call, new_args, ctx):
     """Rewrite function for conv2d. Lhs of conv will be quantized to

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -121,8 +121,7 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
 
 @register_annotate_function("nn.contrib_conv2d_NCHWc")
 def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
-    warnings.warn("NCHWc layout Conv2D detected, please use a lower\
-                   optimization level before applying the quantization pass...")
+    warnings.warn("NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass as quantization will have no effect here...")
     return None
 
 

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -121,7 +121,7 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
 
 @register_annotate_function("nn.contrib_conv2d_NCHWc")
 def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
-    warnings.warn("NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass as quantization here...")
+    warnings.warn("NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass as quantization will have no effect here...")
     return None
 
 

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -121,7 +121,7 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
 
 @register_annotate_function("nn.contrib_conv2d_NCHWc")
 def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
-    warnings.warn("NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass as quantization will have no effect here...")
+    warnings.warn("NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass as quantization here...")
     return None
 
 

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -1,6 +1,7 @@
 #pylint: disable=unused-argument
 """Internal module for registering attribute for annotation."""
 from __future__ import absolute_import
+import warnings
 
 import topi
 from . import _quantize
@@ -120,8 +121,9 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
 
 @register_annotate_function("nn.contrib_conv2d_NCHWc")
 def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
-    raise TypeError("NCHWc layout Conv2D detected, please use a lower\
-                     optimization level before applying the quantization pass...")
+    warnings.warn("NCHWc layout Conv2D detected, please use a lower\
+                   optimization level before applying the quantization pass...")
+    return None
 
 
 @register_annotate_function("nn.conv2d")

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -121,7 +121,9 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
 
 @register_annotate_function("nn.contrib_conv2d_NCHWc")
 def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
-    warnings.warn("NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass as quantization will have no effect here...")
+    warnings.warn("NCHWc layout Conv2D detected, please use a lower "
+                  "optimization level before applying the quantization "
+                  "pass as quantization will have no effect here...")
     return None
 
 

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -118,9 +118,10 @@ def attach_simulated_quantize(data, kind, sign=True, rounding="round"):
         data, dom_scale, clip_min, clip_max, kind, sign, rounding)
 
 
-@register_annotate_function("nn.conv2d_nchwc")
+@register_annotate_function("nn.contrib_conv2d_NCHWc")
 def conv2d_nchwc_rewrite(ref_call, new_args, ctx):
-    raise TypeError, "NCHWc layout Conv2D detected, please use a lower optimization level before applying the quantization pass..."
+    raise TypeError("NCHWc layout Conv2D detected, please use a lower\
+                     optimization level before applying the quantization pass...")
 
 
 @register_annotate_function("nn.conv2d")


### PR DESCRIPTION
Currently we must be careful about how the quantization pass is mixed with other optimizations, especially ones that alter both the computational graph and underlying operator implementations, such as the x86 `alter_op_layout` pass. An example pitfall is when a default `fp32` graph is constructed and optimized for x86 CPU with the intent of being quantized. If the layout transformation pass is applied in this case, the `conv2d_nchwc` ops will be replaced with `conv2d_nchwc`, and the pass will silently fail because the `conv2d_nchwc` ops will not match against the quantization pass's target ops. Everything will run "correctly," but the user may not be aware that an `fp32` graph is being run.

This PR adds a check that the quantization pass is not being applied to a graph with `NCHWc` ops.
In general, it is a good idea to defer data layout transformation passes to be _after_ quantization, as quantization can change the sizes of the data types.