### PR TITLE
[Bugfix] Fix autotvm history loader for heterogeneous execution

### DIFF
--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -294,7 +294,8 @@ class ApplyHistoryBest(DispatchContext):
             # use model as key to build best map
             key = (inp.target.model, inp.task.workload)
             if key not in best_by_model:
-                best_by_model[key] = (inp, res)
+                if inp.target.model != 'unknown':
+                    best_by_model[key] = (inp, res)
             else:
                 _, other_res = best_by_model[key]
                 if np.mean(other_res.costs) > np.mean(res.costs):


### PR DESCRIPTION
- When using heterogeneous execution, the both config history of llvm and cuda are stored in ApplyBestConfig. (https://github.com/dmlc/tvm/blob/master/python/tvm/relay/build_module.py#L253)
- Dispatcher can load config of llvm for gpu (or cuda for cpu) from ApplyBestConfig.best_by_model, when the target device model is unknown. 

This results in mismatch of the search space config and convolution algorithm. (like following example)

```Python
import tvm
import tvm.relay as relay
import numpy as np

R""" The network is as following:                                                                                                                         
           x     y                                                                                                                                        
            \   /                                                                                                                                         
             add                                                                                                                                                                                                                                                                                    
              |                                                                                                                                           
             conv                                                                                                                                         
"""

batch_size = 1
dshape = (batch_size, 64, 56, 56)
wshape = (64, 64, 3, 3)
fallback_device = tvm.context("cpu")
target = {"cpu": "llvm", "cuda": "cuda"}
dev_ctx = tvm.context("cuda")
cpu_ctx = fallback_device

x = relay.var("x", shape=dshape)
y = relay.var("y", shape=dshape)
weight = relay.var("weight", shape=wshape)
add = relay.add(x, y)

conv = relay.nn.conv2d(
    add,
    weight,
    channels=64,
    kernel_size=(3, 3),
    padding=(1, 1))

_add = relay.annotation.on_device(add, cpu_ctx)
_conv = relay.annotation.on_device(conv, dev_ctx)

func = relay.Function([x, y], relay.Tuple(tvm.convert([_add, _conv, conv])))
func = relay.ir_pass.infer_type(func)
func = relay.ir_pass.rewrite_annotated_ops(func, cpu_ctx.device_type)
func = relay.ir_pass.infer_type(func)
func = relay.Function(relay.ir_pass.free_vars(func.body[2]), func.body[2])

d1 = np.random.uniform(size=dshape).astype('float32')
d2 = np.random.uniform(size=dshape).astype('float32')
w = np.random.uniform(size=wshape).astype('float32')
config = {"opt_level": 1}
target = {"cpu": "llvm", "cuda": "cuda"}
params = {"weight": w}
with relay.build_config(**config):
    graph, lib, params = relay.build(
        func,
        target,
        params = params)
contexts = [tvm.cpu(0), tvm.context("cuda")]
mod = tvm.contrib.graph_runtime.create(graph, lib, contexts)
mod.set_input(**params)
mod.set_input("x",d1)
mod.set_input("y",d2)
mod.run()
```
result
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-9-f1b0de6c9f0d> in <module>()
     52         func,
     53         target,
---> 54         params = params)
     55 contexts = [tvm.cpu(0), tvm.context("cuda")]
     56 mod = tvm.contrib.graph_runtime.create(graph, lib, contexts)

/home/morinaga/tvm/tvm/python/tvm/relay/build_module.py in build(func, target, target_host, params)
    271         func = ir_pass.infer_type(func)
    272         graph_gen = _graph_gen.GraphRuntimeCodegen(mod=None, target=target)
--> 273         graph_json, lowered_funcs, params = graph_gen.codegen(func)
    274         mod = _tvm_build_module(
    275             lowered_funcs, target=target, target_host=target_host)

/home/morinaga/tvm/tvm/python/tvm/relay/backend/graph_runtime_codegen.py in codegen(self, func)
    407         # Then we compile the body into a graph which can depend
    408         # on input variables.
--> 409         self.heads = self.visit(func.body)
    410         graph_json = self._get_json()
    411 

/home/morinaga/tvm/tvm/python/tvm/relay/expr_functor.py in visit(self, expr)
     26             res = self.visit_function(expr)
     27         elif isinstance(expr, Call):
---> 28             res = self.visit_call(expr)
     29         elif isinstance(expr, Let):
     30             res = self.visit_let(expr)

/home/morinaga/tvm/tvm/python/tvm/relay/backend/graph_runtime_codegen.py in visit_call(self, call)
    258                                 "{0}".format(call_dev_type))
    259             cached_func = self.compile_engine.lower(func,
--> 260                                                     self.target[call_dev_type])
    261         else:
    262             raise ValueError("self.target must be the type of str," +

/home/morinaga/tvm/tvm/python/tvm/relay/backend/compile_engine.pyc in lower(self, source_func, target)
     84             msg += source_func.astext(show_meta_data=False)
     85             msg += "--------------------------\n"
---> 86             raise RuntimeError(msg)
     87 
     88     def jit(self, source_func, target=None):

RuntimeError: Traceback (most recent call last):
  File "tvm/relay/backend/compile_engine.py", line 78, in lower
    return _backend._CompileEngineLower(self, key)
  File "tvm/_ffi/_ctypes/function.py", line 185, in __call__
    ctypes.byref(ret_val), ctypes.byref(ret_tcode)))
  File "tvm/_ffi/base.py", line 72, in check_call
    raise TVMError(py_str(_LIB.TVMGetLastError()))
TVMError: TVMCall CFunc Error:
Traceback (most recent call last):
  File "tvm/_ffi/_ctypes/function.py", line 55, in cfun
    rv = local_pyfunc(*pyargs)
  File "tvm/relay/op/nn/_nn.py", line 97, in schedule_conv2d
    return topi.generic.schedule_conv2d_nchw(outs)
  File "<decorator-gen-163>", line 2, in schedule_conv2d_nchw
  File "tvm/target.py", line 356, in dispatch_func
    return dispatch_dict[k](*args, **kwargs)
  File "<decorator-gen-210>", line 2, in config_dispatcher
  File "tvm/autotvm/task/dispatcher.py", line 204, in dispatch_func
    return dispatch_dict[cfg.template_key](cfg, *args, **kwargs)
  File "tvm/autotvm/task/topi_integration.py", line 369, in template_call
    return f(cfg, outs, *args, **kwargs)
  File "/home/morinaga/.local/lib/python2.7/site-packages/topi-0.5.dev0-py2.7.egg/topi/cuda/conv2d.py", line 136, in schedule_conv2d_nchw_cuda
    traverse_inline(s, outs[0].op, _callback)
  File "/home/morinaga/.local/lib/python2.7/site-packages/topi-0.5.dev0-py2.7.egg/topi/util.py", line 35, in traverse_inline
    _traverse(final_op)
  File "/home/morinaga/.local/lib/python2.7/site-packages/topi-0.5.dev0-py2.7.egg/topi/util.py", line 33, in _traverse
    callback(op)
  File "/home/morinaga/.local/lib/python2.7/site-packages/topi-0.5.dev0-py2.7.egg/topi/cuda/conv2d.py", line 130, in _callback
    schedule_direct_cuda(cfg, s, op.output(0))
  File "/home/morinaga/.local/lib/python2.7/site-packages/topi-0.5.dev0-py2.7.egg/topi/cuda/conv2d_direct.py", line 56, in schedule_direct_cuda
    bf, vf, tf, fi = cfg["tile_f"].apply(s, output, f)
  File "tvm/autotvm/task/space.py", line 758, in __getitem__
    return self._entity_map[name]
KeyError: 'tile_f'

Error during compile func
--------------------------
fn (%p0: Tensor[(1, 64, 56, 56), float32],
    %p1: Tensor[(64, 64, 3, 3), float32])
    -> Tensor[(1, 64, 56, 56), float32] {
  %0 = nn.conv2d(%p0, %p1, padding=[1, 1], channels=64, kernel_size=[3, 3]) # ty=Tensor[(1, 64, 56, 56), float32]
  %0
}
--------------------------
```
This PR is for fix this bug.
@zhiics @merrymercy could you help review? Thank you!
