### PR TITLE
[Relay] Ensure nested higher-order functions are treated correctly

### DIFF
--- a/python/tvm/relay/prelude.py
+++ b/python/tvm/relay/prelude.py
@@ -395,8 +395,7 @@ class Prelude:
         x = Var("x", self.nat())
         y = Var("y", self.nat())
         z = Var("z")
-        z_case = Clause(PatternConstructor(self.z), Function([z], z))
-        # todo: fix typechecker so Function([z], z) can be replaced by self.id
+        z_case = Clause(PatternConstructor(self.z), self.id)
         s_case = Clause(PatternConstructor(self.s, [PatternVar(y)]),
                         self.compose(f, self.iterate(f, y)))
         self.mod[self.iterate] = Function([f, x],

--- a/python/tvm/relay/prelude.py
+++ b/python/tvm/relay/prelude.py
@@ -394,7 +394,6 @@ class Prelude:
         f = Var("f", FuncType([a], a))
         x = Var("x", self.nat())
         y = Var("y", self.nat())
-        z = Var("z")
         z_case = Clause(PatternConstructor(self.z), self.id)
         s_case = Clause(PatternConstructor(self.s, [PatternVar(y)]),
                         self.compose(f, self.iterate(f, y)))

--- a/tests/python/relay/test_type_infer.py
+++ b/tests/python/relay/test_type_infer.py
@@ -133,6 +133,25 @@ def test_incomplete_call():
     assert ft.checked_type == relay.FuncType([tt, f_type], tt)
 
 
+def test_higher_order_argument():
+    a = relay.TypeVar('a')
+    x = relay.Var('x', a)
+    id_func = relay.Function([x], x, a, [a])
+
+    b = relay.TypeVar('b')
+    f = relay.Var('f', relay.FuncType([b], b))
+    y = relay.Var('y', b)
+    ho_func = relay.Function([f, y], f(y), b, [b])
+
+    # id func should be an acceptable argument to the higher-order
+    # function even though id_func takes a type parameter
+    ho_call = ho_func(id_func, relay.const(0, 'int32'))
+
+    hc = relay.ir_pass.infer_type(ho_call)
+    expected = relay.scalar_type('int32')
+    assert hc.checked_type == expected
+
+
 def test_tuple():
     tp = relay.TensorType((10,))
     x = relay.var("x", tp)


### PR DESCRIPTION
This PR addresses an issue that @MarisaKirisame brought to my attention (and indeed, resulted in a TODO in code that was merged into mainline). Namely, if a higher-order function (e.g., a polymorphic `id` function) were nested inside another function, it could cause type-checking to fail because Relay presently only supports polymorphism at the top level.

This PR attempts to solve that problem by instantiating any nested polymorphic types whenever they occur in type inference. As it happens, doing this inside `Unify()` in the type checker handles almost all cases, though I would appreciate any review as to whether there may be missing cases. (Or suggestions as to what might be a less clumsy approach to this problem.)