### PR TITLE
[CODEGEN NVPTX] Initialize llvm before lookup for the target

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -151,7 +151,7 @@ def find_libdevice_path(arch):
     selected_ver = 0
     selected_path = None
     cuda_ver = get_cuda_version(cuda_path)
-    if cuda_ver in (9.0, 9.1):
+    if cuda_ver in (9.0, 9.1, 10.0):
         path = os.path.join(lib_path, "libdevice.10.bc")
     else:
         for fn in os.listdir(lib_path):

--- a/src/codegen/llvm/codegen_amdgpu.cc
+++ b/src/codegen/llvm/codegen_amdgpu.cc
@@ -156,6 +156,7 @@ inline int DetectROCMComputeVersion(const std::string& target) {
 }
 
 runtime::Module BuildAMDGPU(Array<LoweredFunc> funcs, std::string target) {
+  InitializeLLVM();
   CHECK(target.length() >= 4 &&
         target.substr(0, 4) == "rocm");
   std::ostringstream config;

--- a/src/codegen/llvm/codegen_nvptx.cc
+++ b/src/codegen/llvm/codegen_nvptx.cc
@@ -166,6 +166,7 @@ inline int DetectCUDAComputeVersion() {
 }
 
 runtime::Module BuildNVPTX(Array<LoweredFunc> funcs, std::string target) {
+  InitializeLLVM();
   CHECK(target.length() >= 5 &&
         target.substr(0, 5) == "nvptx");
   int compute_ver = DetectCUDAComputeVersion();


### PR DESCRIPTION
LLVMTargetInfo, TargetMachine and so on should be initialized before lookup for the specific target.

   ```
    n = tvm.var ("n")
    A = tvm.placeholder ((n ,n), name='A', dtype="float32")
    B = tvm.placeholder ((n, n), name='B', dtype="float32")
    C = tvm.compute (A.shape, lambda *i: A(*i) + B(*i), name='C')
    s = tvm.create_schedule (C.op)

    bx, tx = s[C].split (C.op.axis[0], factor=64)
    s[C].bind (bx, tvm.thread_axis("blockIdx.x"))
    s[C].bind (tx, tvm.thread_axis("threadIdx.x"))
    module = tvm.build(s, [A, B, C], "nvptx", target_host="llvm")
```

This code fails with error:
`Unable to find target for this triple (no targets are registered) target_triple=nvptx64_nvidia_cuda`