### PR TITLE
[RELAY] Fix get_int_tuple for shape like '(1001,)'

### DIFF
--- a/python/tvm/relay/frontend/common.py
+++ b/python/tvm/relay/frontend/common.py
@@ -106,7 +106,7 @@ class StrAttrsDict(object):
         """
         if key in self.attrs:
             tshape = self.attrs[key]
-            return tuple(int(x.strip()) for x in tshape.strip('()[]').split(','))
+            return tuple(int(x.strip()) for x in tshape.strip('()[]').split(',') if x)
         if isinstance(default, RequiredAttr):
             raise AttributeError("Required attribute {} not found.".format(key))
         return default


### PR DESCRIPTION
 tshape.strip('()[]').split(',') will make a list ['1001',''] but the empty one isn't needed.

