### PR TITLE
[DOCKER] Switch from yes|apt-get to apt-get -y

### DIFF
--- a/docker/install/ubuntu_install_python.sh
+++ b/docker/install/ubuntu_install_python.sh
@@ -2,7 +2,7 @@
 apt-get update && apt-get install -y python-dev
 
 # python 3.6
-apt-get update && yes | apt-get install software-properties-common
+apt-get update && apt-get install -y software-properties-common
 add-apt-repository ppa:jonathonf/python-3.6 &&\
     apt-get update && apt-get install -y python-pip python-dev python3.6 python3.6-dev
 


### PR DESCRIPTION
The yes | apt-get idom guarantees that the 'yes' process always exists
with exit code 141 (pipe broken).  This is fine while the script
generally ignores failures but won't work when the script behaviour is
tightened to robustly catch errors.

