### PR TITLE
Pin pylint version 2.2.2

### DIFF
--- a/docker/Dockerfile.ci_lint
+++ b/docker/Dockerfile.ci_lint
@@ -6,4 +6,4 @@ RUN apt-get update && apt-get install -y sudo wget
 COPY install/ubuntu_install_python.sh /install/ubuntu_install_python.sh
 RUN bash /install/ubuntu_install_python.sh
 RUN apt-get install -y doxygen graphviz
-RUN pip3 install cpplint pylint mypy
+RUN pip3 install cpplint pylint==2.2.2 mypy

--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -1,3 +1,3 @@
 # install libraries for python package on ubuntu
-pip2 install nose pylint six numpy nose-timer cython decorator scipy tornado typing antlr4-python2-runtime attrs
-pip3 install nose pylint six numpy nose-timer cython decorator scipy tornado typed_ast pytest mypy orderedset antlr4-python3-runtime attrs
+pip2 install nose pylint==2.2.2 six numpy nose-timer cython decorator scipy tornado typing antlr4-python2-runtime attrs
+pip3 install nose pylint==2.2.2 six numpy nose-timer cython decorator scipy tornado typed_ast pytest mypy orderedset antlr4-python3-runtime attrs


### PR DESCRIPTION
pylint is evolving, new versions of pylint add new diagnostics.
Pinning the pylint version ensures that the pylint behaviour in a
build environment is consistent between developers and CI and the
environment itself is re-creatable.

As pylint evolves the TVM project will need to periodically 'clean'
the code base w.r.t a new current version of pylint and then update
the pinned version.