### PR TITLE
[DOCKER] Drop unused pylint install.

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -1,3 +1,4 @@
 # install libraries for python package on ubuntu
-pip2 install nose pylint six numpy nose-timer cython decorator scipy tornado typing antlr4-python2-runtime attrs
-pip3 install nose pylint six numpy nose-timer cython decorator scipy tornado typed_ast pytest mypy orderedset antlr4-python3-runtime attrs
+
+pip2 install nose six numpy nose-timer cython decorator scipy tornado typing antlr4-python2-runtime attrs
+pip3 install nose six numpy nose-timer cython decorator scipy tornado typed_ast pytest mypy orderedset antlr4-python3-runtime attrs


### PR DESCRIPTION
The "linting" environment is installed by the ubuntu_install_python.sh
script, the install of pylint in ubuntu_install_python_package.sh is
not used in CI.  Remove the import.

