### PR TITLE
[Relay][Quantization] Speed-aware quantization scheme improvement

### DIFF
--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -192,6 +192,8 @@ def add_rewrite(ref_call, new_args, ctx):
         else:
             # quantize rhs to INPUT field if it is not Constant
             rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
+    if lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.ACTIVATION:
+        rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
 
     expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
     return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -193,7 +193,7 @@ def add_rewrite(ref_call, new_args, ctx):
             # quantize rhs to INPUT field if it is not Constant
             rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
     if lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.ACTIVATION:
-        rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
+        rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT) # the other branch
 
     expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
     return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -193,7 +193,8 @@ def add_rewrite(ref_call, new_args, ctx):
             # quantize rhs to INPUT field if it is not Constant
             rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
     if lhs_kind == QAnnotateKind.ACTIVATION and rhs_kind == QAnnotateKind.ACTIVATION:
-        rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT) # the other branch
+        # quantize rhs to INPUT field if both lhs and rhs are ACTIVATION
+        rhs_expr = attach_simulated_quantize(rhs_expr, QAnnotateKind.INPUT)
 
     expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
     return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)

--- a/python/tvm/relay/quantize/quantize.py
+++ b/python/tvm/relay/quantize/quantize.py
@@ -58,6 +58,7 @@ class QConfig(NodeBase):
         "round_for_shift": True,
         "store_lowbit_output": True,
         "debug_enabled_ops": None,
+        "use_stop_fusion": True
     }
 
     # pylint: disable=no-member
@@ -128,6 +129,10 @@ def qconfig(**kwargs):
     store_lowbit_output: boolean
         Whether to store low-bit integer back as output before dequantizing.
         Some accelerators need this, e.g. VTA.
+
+    use_stop_fusion: boolean
+        Whether add stop_fusion when casting to dtype_activation. stop_fusion forces lowbit
+        results to be stored in memory.
 
     Returns
     -------

--- a/src/relay/pass/quantize.cc
+++ b/src/relay/pass/quantize.cc
@@ -355,7 +355,9 @@ Array<Expr> UnifyDTypeScale(const Array<Expr>& ref_args,
     } else if (ref_arg && ref_arg->op.same_as(simulated_quantize) &&
                ref_arg->attrs.as<SimulatedQuantizeAttrs>()->kind == kQInput) {
       auto new_arg = Cast(ret[i], cfg->dtype_input);
-      new_arg = StopFusion(new_arg);
+      if (cfg->use_stop_fusion) {
+        new_arg = StopFusion(new_arg);
+      }
       ret.Set(i, Cast(new_arg, dtype));
     }
   }
@@ -543,7 +545,8 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
   p->stream << "skip_k_conv==" << op->skip_k_conv << ", ";
   p->stream << "round_for_shift==" << op->round_for_shift << ", ";
   p->stream << "store_lowbit_output==" << op->store_lowbit_output << ", ";
-  p->stream << "debug_enabled_ops==" << op->debug_enabled_ops;
+  p->stream << "debug_enabled_ops==" << op->debug_enabled_ops << ", ";
+  p->stream << "use_stop_fusion==" << op->use_stop_fusion;
   p->stream << ")";
 });
 

--- a/src/relay/pass/quantize.h
+++ b/src/relay/pass/quantize.h
@@ -110,6 +110,7 @@ class QConfigNode : public Node {
   bool round_for_shift = true;
   bool store_lowbit_output = true;
   Array<Expr> debug_enabled_ops = Array<Expr>(NodePtr<Node>(nullptr));
+  bool use_stop_fusion = true;
 
   void VisitAttrs(AttrVisitor* v) final {
     v->Visit("nbit_input", &nbit_input);
@@ -123,6 +124,7 @@ class QConfigNode : public Node {
     v->Visit("round_for_shift", &round_for_shift);
     v->Visit("store_lowbit_output", &store_lowbit_output);
     v->Visit("debug_enabled_ops", &debug_enabled_ops);
+    v->Visit("use_stop_fusion", &use_stop_fusion);
   }
 
   static constexpr const char* _type_key = "relay.quantize.QConfig";


### PR DESCRIPTION
Writing int32 result to global memory can be much slower than int8. This PR does the following change:
 - in `add_rewrite`, quantize rhs to int8 so that read/write of rhs can be performed in int8.
 - In `UnifyDtypeScale`, if the input is simulated_quantize(QInput), cast the input to int8 before casting to int32.

@ZihengJiang 