### PR TITLE
[RUNTIME][OPENCL] clFinish before releasing memory

### DIFF
--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -110,6 +110,10 @@ void* OpenCLWorkspace::AllocDataSpace(
 }
 
 void OpenCLWorkspace::FreeDataSpace(TVMContext ctx, void* ptr) {
+  // We have to make sure that the memory object is not in the command queue
+  // for some OpenCL platforms.
+  OPENCL_CALL(clFinish(this->GetQueue(ctx)));
+
   cl_mem mptr = static_cast<cl_mem>(ptr);
   OPENCL_CALL(clReleaseMemObject(mptr));
 }


### PR DESCRIPTION
The OpenCL specification says that it is safe to call [clReleaseMemObject](https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clReleaseMemObject.html) even when the memory object is in use, but some OpenCL platforms violate the specification unfortunately.
- Xilinx SDAccel (reference counts are not incremented)
https://forums.xilinx.com/t5/SDAccel/clEnqueueWriteBuffer-doesn-t-increase-reference-counts/td-p/932401
- Intel FPGA SDK for OpenCL (segfault if the released memory is in use)
https://forums.intel.com/s/question/0D50P0000462rYaSAI/clreleasememobject-just-after-clenqueuetask-causes-segfault

This PR calls clFinish before clReleaseMemObject to make sure that the memory object is not in use.  This change doesn't have impact on performance since memory objects are cached by workspace pool of TVM and they are not released at run time usually.

@tqchen @Laurawly @nishi-t please help review this PR.