### PR TITLE
[RUNTIME][OPENCL] set type_key even when platform is not available

### DIFF
--- a/src/runtime/opencl/opencl_device_api.cc
+++ b/src/runtime/opencl/opencl_device_api.cc
@@ -233,6 +233,7 @@ void OpenCLWorkspace::Init(const std::string& type_key, const std::string& devic
   std::lock_guard<std::mutex> lock(this->mu);
   if (initialized_) return;
   if (context != nullptr) return;
+  this->type_key = type_key;
   // matched platforms
   std::vector<cl_platform_id> platform_ids = cl::GetPlatformIDs();
   if (platform_ids.size() == 0) {
@@ -250,7 +251,6 @@ void OpenCLWorkspace::Init(const std::string& type_key, const std::string& devic
       devices_matched = cl::GetDeviceIDs(platform_id, "cpu");
     }
     if (devices_matched.size() > 0) {
-      this->type_key = type_key;
       this->platform_id = platform_id;
       this->platform_name = cl::GetPlatformInfo(platform_id, CL_PLATFORM_NAME);
       this->device_type = device_type;


### PR DESCRIPTION
To use OpenCL devices via RPC, if there is no OpenCL devices on the client side, we have to build TVM with OpenCL disabled on the client.  This PR fixes the problem.

@eqy please help review this PR.
