### PR TITLE
Improvements to the conda build

### DIFF
--- a/conda/cross-linux.cmake
+++ b/conda/cross-linux.cmake
@@ -1,0 +1,20 @@
+# this one is important
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_PLATFORM Linux)
+#this one not so much
+set(CMAKE_SYSTEM_VERSION 1)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER $ENV{CC})
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH $ENV{PREFIX} $ENV{BUILD_PREFIX}/$ENV{HOST}/sysroot)
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# god-awful hack because it seems to not run correct tests to determine this:
+set(__CHAR_UNSIGNED___EXITCODE 1)

--- a/conda/nnvm/meta.yaml
+++ b/conda/nnvm/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 3
+  number: 0
   skip: True  # [win]
 
 requirements:

--- a/conda/nnvm/meta.yaml
+++ b/conda/nnvm/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 1
+  number: 3
   skip: True  # [win]
 
 requirements:

--- a/conda/topi/meta.yaml
+++ b/conda/topi/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   host:

--- a/conda/topi/meta.yaml
+++ b/conda/topi/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 3
+  number: 0
 
 requirements:
   host:

--- a/conda/tvm-libs/build.sh
+++ b/conda/tvm-libs/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Fix for OSX build to hide the clang LLVM
+rm -f ${BUILD_PREFIX}/bin/llvm-config
+rm -rf ${BUILD_PREFIX}/lib/cmake
+
 set -e
 
 if [ -z "$PREFIX" ]; then
@@ -12,10 +16,26 @@ else
     CUDA_OPT="-DUSE_CUDA=ON"
 fi
 
+if [ "$target_platform" == "osx-64" ]; then
+    # macOS 64 bits
+    METAL_OPT=""  # Conda can only target 10.9 for now
+    TOOLCHAIN_OPT=""
+else
+    METAL_OPT=""
+    if [ "$target_platform" == "linux-64" ]; then
+        # Linux 64 bits
+        TOOLCHAIN_OPT="-DCMAKE_TOOLCHAIN_FILE=${RECIPE_DIR}/../cross-linux.cmake"
+    else
+        # Windows (or 32 bits, which we don't support)
+        METAL_OPT=""
+        TOOLCHAIN_OPT=""
+    fi
+fi
+
 rm -rf build || true
 mkdir -p build
 cd build
-cmake $CUDA_OPT -DUSE_LLVM=ON -DINSTALL_DEV=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" ..
-make -j4 VERBOSE=1
+cmake $METAL_OPT $CUDA_OPT -DUSE_LLVM=ON -DINSTALL_DEV=ON -DCMAKE_INSTALL_PREFIX="$PREFIX" $TOOLCHAIN_OPT ..
+make -j${CPU_COUNT} VERBOSE=1
 make install
 cd ..

--- a/conda/tvm-libs/build.sh
+++ b/conda/tvm-libs/build.sh
@@ -13,7 +13,7 @@ fi
 if [ -z "$cuda" ] || [ "$cuda" == "False" ]; then
     CUDA_OPT=""
 else
-    CUDA_OPT="-DUSE_CUDA=ON"
+    CUDA_OPT="-DUSE_CUDA=ON -DUSE_CUBLAS=ON"
 fi
 
 if [ "$target_platform" == "osx-64" ]; then

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -13,16 +13,12 @@ build:
 
 requirements:
   build:
-    - {{ compiler('cxx') }}  # [linux]
-    - llvmdev ==6.0.0  # [osx]
-  host:
     # The OS X build will require some manual setup or it will break
-    # See https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html#macos-sdk
-    # It is also ass-backward because of llvm brokeness when mixed with the
-    # conda OS X compiler
-    - {{ compiler('cxx') }}  # [osx]
+    # See https://docs.conda.io/projects/conda-build/en/latest/source/resources/compiler-tools.html#macos-sdk
+    - {{ compiler('cxx') }}
+  host:
     - cmake
-    - llvmdev ==6.0.0  # [linux]
+    - llvmdev ==6.0.0
     - zlib  # [linux]
   run:
     - {{ pin_compatible('cudatoolkit', lower_bound=cuda_version, max_pin='x.x') }}  # [cuda]

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 1
+  number: 3
   string: cuda{{ cuda_version }}_{{ PKG_BUILDNUM }}  # [cuda]
 
 requirements:

--- a/conda/tvm-libs/meta.yaml
+++ b/conda/tvm-libs/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 3
+  number: 0
   string: cuda{{ cuda_version }}_{{ PKG_BUILDNUM }}  # [cuda]
 
 requirements:

--- a/conda/tvm/meta.yaml
+++ b/conda/tvm/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   build:

--- a/conda/tvm/meta.yaml
+++ b/conda/tvm/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: ../..
 
 build:
-  number: 3
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
A collection to small fixes:
 - Add cublas to the cuda builds
 - Reset build numbers following the version bump
 - Some fixes to the build process

I've tried building support for Metal on OS X, but the anaconda compilers are stuck in the 10.9 era before the framework existed so not much luck there.  I still want to revisit that later and probably switch to using the system compilers for that.