### PR TITLE
[Relay/TOPI][Op] Add shape op in Relay and TOPI

### DIFF
--- a/docs/api/python/topi.rst
+++ b/docs/api/python/topi.rst
@@ -75,6 +75,7 @@ List of operators
    topi.stack
    topi.repeat
    topi.tile
+   topi.shape
    topi.layout_transform
    topi.image.resize
 
@@ -136,6 +137,7 @@ topi
 .. autofunction:: topi.stack
 .. autofunction:: topi.repeat
 .. autofunction:: topi.tile
+.. autofunction:: topi.shape
 .. autofunction:: topi.layout_transform
 
 topi.nn

--- a/docs/langref/relay_op.rst
+++ b/docs/langref/relay_op.rst
@@ -154,6 +154,7 @@ This level support backpropagation of broadcast operators. It is temporary.
    tvm.relay.broadcast_to_like
    tvm.relay.collapse_sum_like
    tvm.relay.slice_like
+   tvm.relay.shape_of
    tvm.relay.layout_transform
    tvm.relay.device_copy
    tvm.relay.annotation.on_device
@@ -273,6 +274,7 @@ Level 10 Definitions
 .. autofunction:: tvm.relay.broadcast_to_like
 .. autofunction:: tvm.relay.collapse_sum_like
 .. autofunction:: tvm.relay.slice_like
+.. autofunction:: tvm.relay.shape_of
 .. autofunction:: tvm.relay.layout_transform
 .. autofunction:: tvm.relay.device_copy
 .. autofunction:: tvm.relay.annotation.on_device

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -217,6 +217,7 @@ struct ClipAttrs : public tvm::AttrsNode<ClipAttrs> {
   }
 };
 
+/*! \brief Attributes for LayoutTransform operator */
 struct LayoutTransformAttrs : public tvm::AttrsNode<LayoutTransformAttrs> {
   std::string src_layout;
   std::string dst_layout;
@@ -226,6 +227,17 @@ struct LayoutTransformAttrs : public tvm::AttrsNode<LayoutTransformAttrs> {
         .describe("The source layout of the tensor. (e.g. NCHW)");
     TVM_ATTR_FIELD(dst_layout)
         .describe("The destination layout of the tensor. (e.g. NCHW16c)");
+  }
+};
+
+/*! \brief Attributes for ShapeOf operator */
+struct ShapeOfAttrs : public tvm::AttrsNode<ShapeOfAttrs> {
+  DataType dtype;
+
+  TVM_DECLARE_ATTRS(ShapeOfAttrs, "relay.attrs.ShapeOfAttrs") {
+    TVM_ATTR_FIELD(dtype)
+        .describe("Target data type")
+        .set_default(NullValue<DataType>());
   }
 };
 

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -488,6 +488,19 @@ def _mx_l2_normalize(inputs, attrs):
     return _op.nn.l2_normalize(inputs[0], **new_attrs)
 
 
+def _mx_shape_array(inputs, attrs):
+    assert len(inputs) == 1
+    if attrs.get_int("lhs_begin", None) != None:
+        raise RuntimeError("shape_array doesn't support lhs_begin")
+    if attrs.get_int("lhs_end", None) != None:
+        raise RuntimeError("shape_array doesn't support lhs_end")
+    if attrs.get_int("rhs_begin", None) != None:
+        raise RuntimeError("shape_array doesn't support rhs_begin")
+    if attrs.get_int("rhs_end", None) != None:
+        raise RuntimeError("shape_array doesn't support rhs_end")
+    return _op.shape_of(inputs[0], dtype='int64')
+
+
 # Note: due to attribute conversion constraint
 # ops in the identity set must be attribute free
 _identity_list = [
@@ -613,6 +626,7 @@ _convert_map = {
     "repeat"        : _mx_repeat,
     "tile"          : _mx_tile,
     "BlockGrad"     : _mx_BlockGrad,
+    "shape_array"   : _mx_shape_array,
     "SoftmaxOutput" : _mx_softmax_output,
     "SoftmaxActivation" : _mx_softmax_activation,
     # vision

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -490,13 +490,13 @@ def _mx_l2_normalize(inputs, attrs):
 
 def _mx_shape_array(inputs, attrs):
     assert len(inputs) == 1
-    if attrs.get_int("lhs_begin", None) != None:
+    if attrs.get_int("lhs_begin", None) is not None:
         raise RuntimeError("shape_array doesn't support lhs_begin")
-    if attrs.get_int("lhs_end", None) != None:
+    if attrs.get_int("lhs_end", None) is not None:
         raise RuntimeError("shape_array doesn't support lhs_end")
-    if attrs.get_int("rhs_begin", None) != None:
+    if attrs.get_int("rhs_begin", None) is not None:
         raise RuntimeError("shape_array doesn't support rhs_begin")
-    if attrs.get_int("rhs_end", None) != None:
+    if attrs.get_int("rhs_end", None) is not None:
         raise RuntimeError("shape_array doesn't support rhs_end")
     return _op.shape_of(inputs[0], dtype='int64')
 

--- a/python/tvm/relay/op/_tensor.py
+++ b/python/tvm/relay/op/_tensor.py
@@ -40,6 +40,7 @@ register_schedule("maximum", schedule_injective)
 register_schedule("minimum", schedule_injective)
 register_schedule("right_shift", schedule_injective)
 register_schedule("left_shift", schedule_injective)
+register_schedule("shape_of", schedule_injective)
 
 # zeros
 @register_compute("zeros")

--- a/python/tvm/relay/op/tensor.py
+++ b/python/tvm/relay/op/tensor.py
@@ -715,7 +715,7 @@ def device_copy(data, src_dev, dst_dev):
     return _make.device_copy(data, src_dev, dst_dev)
 
 
-def shape_of(data):
+def shape_of(data, dtype="int32"):
     """Get shape of a tensor.
 
     Parameters
@@ -723,9 +723,12 @@ def shape_of(data):
     data : tvm.relay.Expr
         The input tensor.
 
+    dtype : str, optional
+        The target data type.
+
     Returns
     -------
     result : tvm.relay.Expr
         The shape tensor.
     """
-    return _make.shape_of(data)
+    return _make.shape_of(data, dtype)

--- a/python/tvm/relay/op/tensor.py
+++ b/python/tvm/relay/op/tensor.py
@@ -713,3 +713,19 @@ def device_copy(data, src_dev, dst_dev):
         raise ValueError("dst_dev is expected to be the type of TVMContext or "
                          "str, but received %s" % (type(dst_dev)))
     return _make.device_copy(data, src_dev, dst_dev)
+
+
+def shape_of(data):
+    """Get shape of a tensor.
+
+    Parameters
+    ----------
+    data : tvm.relay.Expr
+        The input tensor.
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The shape tensor.
+    """
+    return _make.shape_of(data)

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -7,6 +7,7 @@
 #include <tvm/relay/op.h>
 #include <tvm/relay/attrs/transform.h>
 #include <topi/elemwise.h>
+#include <topi/transform.h>
 #include "../type_relations.h"
 #include "../op_common.h"
 
@@ -188,6 +189,49 @@ RELAY_REGISTER_UNARY_OP("logical_not")
 )code" TVM_ADD_FILELINE)
 .set_support_level(4)
 .set_attr<FTVMCompute>("FTVMCompute", RELAY_UNARY_COMPUTE(topi::logical_not));
+
+
+// shape_of
+bool ShapeOfRel(const Array<Type>& types,
+                  int num_inputs,
+                  const Attrs& attrs,
+                  const TypeReporter& reporter) {
+  CHECK(num_inputs == 1);
+  auto tt = types[0].as<TensorTypeNode>();
+  CHECK(tt != nullptr);
+  tvm::Type odtype = ::tvm::Int(32);
+  auto vector_out = tvm::Integer(tt->shape.size());
+  auto otype = TensorTypeNode::make({ vector_out }, odtype);
+  reporter->Assign(types[1], otype);
+  return true;
+}
+
+Array<Tensor> ShapeOfCompute(const Attrs& attrs,
+                             const Array<Tensor>& inputs,
+                             const Type& out_type,
+                             const Target& target) {
+    CHECK(inputs.size() == 1);
+    return {topi::shape(inputs[0])};
+}
+
+TVM_REGISTER_API("relay.op._make.shape_of")
+    .set_body_typed<Expr(Expr)>([](Expr data) {
+        static const Op& op = Op::Get("shape_of");
+        return CallNode::make(op, {data}, Attrs(), {});
+      });
+
+RELAY_REGISTER_OP("shape_of")
+  .describe(R"code(Returns a tensor representing the shape of a tensor..
+  )code" TVM_ADD_FILELINE)
+  .set_num_inputs(1)
+  .add_argument("data", "Tensor", "The input tensor.")
+  .add_type_rel("ShapeOf", ShapeOfRel)
+  .set_attr<TOpIsStateful>("TOpIsStateful", false)
+  .set_attr<TOpPattern>("TOpPattern", kInjective)
+  .set_attr<FInferCorrectLayout>("FInferCorrectLayout",
+                                 ElemwiseArbitraryLayout)
+  .set_support_level(10)
+  .set_attr<FTVMCompute>("FTVMCompute", ShapeOfCompute);
 
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/op/tensor/unary.cc
+++ b/src/relay/op/tensor/unary.cc
@@ -198,7 +198,7 @@ bool ShapeOfRel(const Array<Type>& types,
                 int num_inputs,
                 const Attrs& attrs,
                 const TypeReporter& reporter) {
-  CHECK(num_inputs == 1);
+  CHECK_EQ(num_inputs, 1);
   auto tt = types[0].as<TensorTypeNode>();
   CHECK(tt != nullptr);
   const auto* param = attrs.as<ShapeOfAttrs>();
@@ -212,18 +212,18 @@ Array<Tensor> ShapeOfCompute(const Attrs& attrs,
                              const Array<Tensor>& inputs,
                              const Type& out_type,
                              const Target& target) {
-    CHECK(inputs.size() == 1);
-    const auto* param = attrs.as<ShapeOfAttrs>();
-    CHECK(param != nullptr);
-    return {topi::shape(inputs[0], param->dtype)};
+  CHECK_EQ(inputs.size(), 1);
+  const auto* param = attrs.as<ShapeOfAttrs>();
+  CHECK(param != nullptr);
+  return {topi::shape(inputs[0], param->dtype)};
 }
 
 TVM_REGISTER_API("relay.op._make.shape_of")
 .set_body_typed<Expr(Expr, DataType)>([](Expr data, DataType dtype) {
-    auto attrs = make_node<ShapeOfAttrs>();
-    attrs->dtype = dtype;
-    static const Op& op = Op::Get("shape_of");
-    return CallNode::make(op, {data}, Attrs(attrs), {});
+  auto attrs = make_node<ShapeOfAttrs>();
+  attrs->dtype = dtype;
+  static const Op& op = Op::Get("shape_of");
+  return CallNode::make(op, {data}, Attrs(attrs), {});
 });
 
 RELAY_REGISTER_OP("shape_of")

--- a/tests/python/relay/test_op_level10.py
+++ b/tests/python/relay/test_op_level10.py
@@ -177,6 +177,16 @@ def test_batch_matmul():
     verify_batch_matmul((5, 16, 32), (5, 20, 32), (5, 16, 20))
     verify_batch_matmul((30, 16, 32), (30, 20, 32), (30, 16, 20))
 
+def test_shape_of():
+    x = relay.var("x", shape=(10, 5, 10))
+    func = relay.Function([x], relay.op.shape_of(x))
+    func = relay.ir_pass.infer_type(func)
+    x_data = np.random.rand(10, 5, 10).astype('float32')
+    for target, ctx in ctx_list():
+        for kind in ["graph", "debug"]:
+            intrp = relay.create_executor(kind, ctx=ctx, target=target)
+            op_res = intrp.evaluate(func)(x_data)
+            tvm.testing.assert_allclose(op_res.asnumpy(), np.array([10, 5, 10]), rtol=1e-5)
 
 if __name__ == "__main__":
     test_collapse_sum_like()
@@ -184,3 +194,4 @@ if __name__ == "__main__":
     test_slice_like()
     test_reverse_reshape()
     test_batch_matmul()
+    test_shape_of()

--- a/tests/python/relay/test_pass_fold_constant.py
+++ b/tests/python/relay/test_pass_fold_constant.py
@@ -97,28 +97,27 @@ def test_fold_concat():
 
 def test_fold_shape_of():
     c_shape = (8, 9, 10)
-    def before():
+    def before(dtype):
         x = relay.var("x", shape=c_shape, dtype="float32")
         y = relay.var("y", shape=c_shape, dtype="float32")
-        z = relay.shape_of(x + y)
+        z = relay.shape_of(x + y, dtype)
         return relay.Function([x, y], z)
 
-    def expected():
+    def expected(dtype):
         x = relay.var("x", shape=c_shape, dtype="float32")
         y = relay.var("y", shape=c_shape, dtype="float32")
-        z = relay.const(np.array(c_shape).astype("int32"))
+        z = relay.const(np.array(c_shape).astype(dtype), dtype=dtype)
         return relay.ir_pass.infer_type(relay.Function([x, y], z))
 
-    zbefore = before()
-    zz = relay.ir_pass.fold_constant(zbefore)
-    assert relay.ir_pass.graph_equal(zz, zbefore)
+    for dtype in ["int32", "float32"]:
+        zbefore = before(dtype)
+        zz = relay.ir_pass.fold_constant(zbefore)
+        assert relay.ir_pass.graph_equal(zz, zbefore)
 
-    zz = relay.ir_pass.infer_type(zbefore)
-    zz = relay.ir_pass.fold_constant(zz)
-    print(zz.astext())
-    zexpected = expected()
-    print(zexpected.astext())
-    assert relay.ir_pass.graph_equal(zz, zexpected)
+        zz = relay.ir_pass.infer_type(zbefore)
+        zz = relay.ir_pass.fold_constant(zz)
+        zexpected = expected(dtype)
+        assert relay.ir_pass.graph_equal(zz, zexpected)
 
 
 if __name__ == "__main__":

--- a/tests/python/relay/test_pass_fold_constant.py
+++ b/tests/python/relay/test_pass_fold_constant.py
@@ -95,8 +95,35 @@ def test_fold_concat():
     assert relay.ir_pass.graph_equal(zz, zexpected)
 
 
+def test_fold_shape_of():
+    c_shape = (8, 9, 10)
+    def before():
+        x = relay.var("x", shape=c_shape, dtype="float32")
+        y = relay.var("y", shape=c_shape, dtype="float32")
+        z = relay.shape_of(x + y)
+        return relay.Function([x, y], z)
+
+    def expected():
+        x = relay.var("x", shape=c_shape, dtype="float32")
+        y = relay.var("y", shape=c_shape, dtype="float32")
+        z = relay.const(np.array(c_shape).astype("int32"))
+        return relay.ir_pass.infer_type(relay.Function([x, y], z))
+
+    zbefore = before()
+    zz = relay.ir_pass.fold_constant(zbefore)
+    assert relay.ir_pass.graph_equal(zz, zbefore)
+
+    zz = relay.ir_pass.infer_type(zbefore)
+    zz = relay.ir_pass.fold_constant(zz)
+    print(zz.astext())
+    zexpected = expected()
+    print(zexpected.astext())
+    assert relay.ir_pass.graph_equal(zz, zexpected)
+
+
 if __name__ == "__main__":
     test_fold_const()
     test_fold_let()
     test_fold_tuple()
     test_fold_concat()
+    test_fold_shape_of()

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -1089,19 +1089,19 @@ inline Tensor layout_transform(const Tensor& src,
  * \return Tensor of input shape.
  */
 inline Tensor shape(const Tensor& src,
+                    Type dtype,
                     const std::string name = "shape",
                     const std::string tag = kInjective) {
   int ndim = static_cast<int>(src->shape.size());
   Array<Expr> out_shape{ndim};
-  return compute(
-      out_shape, [&](const Array<Var>& indices) {
-                   auto idx = indices[0];
-                   Expr ret = 0;
-                   for (int i = 0; i < ndim; ++i) {
-                     ret = tvm::if_then_else(idx == i, src->shape[i], ret);
-                   }
-                   return ret;
-                 }, name, tag);
+  return compute(out_shape, [&](const Array<Var>& indices) {
+    auto idx = indices[0];
+    Expr ret = 0;
+    for (int i = 0; i < ndim; ++i) {
+      ret = tvm::if_then_else(idx == i, src->shape[i], ret);
+    }
+    return tvm::cast(dtype, ret);
+  }, name, tag);
 }
 
 }  // namespace topi

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -1081,5 +1081,28 @@ inline Tensor layout_transform(const Tensor& src,
   }, name, tag);
 }
 
+/*!
+ * \brief Get the shape of input tensor.
+ * \param src the input tensor.
+ * \param name output tensor name.
+ * \param tag output tensor tag.
+ * \return Tensor of input shape.
+ */
+inline Tensor shape(const Tensor& src,
+                    const std::string name = "shape",
+                    const std::string tag = kInjective) {
+  int ndim = static_cast<int>(src->shape.size());
+  Array<Expr> out_shape{ndim};
+  return compute(
+      out_shape, [&](const Array<Var>& indices) {
+                   auto idx = indices[0];
+                   Expr ret = 0;
+                   for (int i = 0; i < ndim; ++i) {
+                     ret = tvm::if_then_else(idx == i, src->shape[i], ret);
+                   }
+                   return ret;
+                 }, name, tag);
+}
+
 }  // namespace topi
 #endif  // TOPI_TRANSFORM_H_

--- a/topi/python/topi/transform.py
+++ b/topi/python/topi/transform.py
@@ -395,7 +395,7 @@ def layout_transform(array, src_layout, dst_layout):
     return cpp.layout_transform(array, src_layout, dst_layout)
 
 
-def shape(array):
+def shape(array, dtype="int32"):
     """Get the shape of input array
 
     Parameters
@@ -403,9 +403,12 @@ def shape(array):
     array : tvm.Tensor
         The source tenosr.
 
+    dtype : str, optional
+        The target data type.
+
     Returns
     -------
     result : tvm.Tensor
         The resulting tensor.
     """
-    return cpp.shape(array)
+    return cpp.shape(array, dtype)

--- a/topi/python/topi/transform.py
+++ b/topi/python/topi/transform.py
@@ -393,3 +393,19 @@ def layout_transform(array, src_layout, dst_layout):
         the destination layout.
     """
     return cpp.layout_transform(array, src_layout, dst_layout)
+
+
+def shape(array):
+    """Get the shape of input array
+
+    Parameters
+    ----------
+    array : tvm.Tensor
+        The source tenosr.
+
+    Returns
+    -------
+    result : tvm.Tensor
+        The resulting tensor.
+    """
+    return cpp.shape(array)

--- a/topi/src/topi.cc
+++ b/topi/src/topi.cc
@@ -273,8 +273,8 @@ TVM_REGISTER_GLOBAL("topi.stack")
 
 TVM_REGISTER_GLOBAL("topi.shape")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
-  *rv = shape(args[0]);
-  });
+  *rv = shape(args[0], args[1]);
+});
 
 TVM_REGISTER_GLOBAL("topi.split")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
@@ -283,7 +283,7 @@ TVM_REGISTER_GLOBAL("topi.split")
   } else {
     *rv = split(args[0], args[1], args[2]);
   }
-  });
+});
 
 TVM_REGISTER_GLOBAL("topi.layout_transform")
 .set_body([](TVMArgs args, TVMRetValue *rv) {

--- a/topi/src/topi.cc
+++ b/topi/src/topi.cc
@@ -271,6 +271,11 @@ TVM_REGISTER_GLOBAL("topi.stack")
   *rv = stack(args[0], args[1]);
 });
 
+TVM_REGISTER_GLOBAL("topi.shape")
+.set_body([](TVMArgs args, TVMRetValue *rv) {
+  *rv = shape(args[0]);
+  });
+
 TVM_REGISTER_GLOBAL("topi.split")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
   if (args[1].type_code() == kDLInt || args[1].type_code() == kDLUInt) {

--- a/topi/tests/python/test_topi_transform.py
+++ b/topi/tests/python/test_topi_transform.py
@@ -566,11 +566,12 @@ def test_layout_transform():
 
 def test_shape():
     in_shape = (8, 7, 13)
+    dtype = "int32"
     A = tvm.placeholder(shape=in_shape, dtype="float32", name="A")
-    B = topi.shape(A)
+    B = topi.shape(A, dtype)
 
     input = np.random.uniform(size=in_shape).astype(A.dtype)
-    output = np.asarray(in_shape).astype("int32")
+    output = np.asarray(in_shape).astype(dtype)
 
     def check_device(device):
         ctx = tvm.context(device, 0)
@@ -578,7 +579,7 @@ def test_shape():
             print("Skip because %s is not enabled" % device)
             return
         tvm_input = tvm.nd.array(input, ctx)
-        tvm_output = tvm.nd.empty(output.shape, ctx=ctx, dtype="int32")
+        tvm_output = tvm.nd.empty(output.shape, ctx=ctx, dtype=dtype)
         print("Running on target: %s" % device)
         with tvm.target.create(device):
             s = topi.generic.schedule_injective(B)


### PR DESCRIPTION
This PR adds the shape op in Relay and TOPI. Shape op returns the shape tensor of the input tensor.

More specifically, this PR includes
- shape op in TOPI
- shape_of op in Relay
- Constant folding for shape_of op in Relay

Thanks @jroesch for the help in Relay part.