### PR TITLE
[ANDROID] fix android rpc build

### DIFF
--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -14,7 +14,9 @@ include $(config)
 APP_ABI ?= armeabi-v7a arm64-v8a x86 x86_64 mips
 APP_STL := c++_static
 
-APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DTVM4J_ANDROID=1 -std=c++11 -Oz -frtti
+# We assume a little endian machine by default,
+# change -DDMLC_CMAKE_LITTLE_ENDIAN to 0 if you are using a big endian machine
+APP_CPPFLAGS += -DDMLC_LOG_STACK_TRACE=0 -DDMLC_CMAKE_LITTLE_ENDIAN=1 -DTVM4J_ANDROID=1 -std=c++11 -Oz -frtti
 ifeq ($(USE_OPENCL), 1)
     APP_CPPFLAGS += -DTVM_OPENCL_RUNTIME=1
 endif


### PR DESCRIPTION
I think we can just add little-endian as a default for now.