### PR TITLE
Make topi cuda nms_gpu method signature similar to non_max_suppression

### DIFF
--- a/topi/python/topi/cuda/nms.py
+++ b/topi/python/topi/cuda/nms.py
@@ -182,8 +182,15 @@ def nms_ir(data, sort_result, valid_count, out, nms_threshold, force_suppress, n
 
 
 @non_max_suppression.register(["cuda", "gpu"])
-def nms_gpu(data, valid_count, return_indices, iou_threshold=0.5, force_suppress=False,
-            topk=-1, id_index=0, invalid_to_bottom=False):
+def nms_gpu(data,
+            valid_count,
+            max_output_size=-1,
+            iou_threshold=0.5,
+            force_suppress=False,
+            top_k=-1,
+            id_index=0,
+            return_indices=True,
+            invalid_to_bottom=False):
     """Non-maximum suppression operator for object detection.
 
     Parameters
@@ -205,7 +212,7 @@ def nms_gpu(data, valid_count, return_indices, iou_threshold=0.5, force_suppress
     force_suppress : optional, boolean
         Whether to suppress all detections regardless of class_id.
 
-    topk : optional, int
+    top_k : optional, int
         Keep maximum top k detections before nms, -1 for no limit.
 
     id_index : optional, int
@@ -229,7 +236,7 @@ def nms_gpu(data, valid_count, return_indices, iou_threshold=0.5, force_suppress
         valid_count = tvm.placeholder((dshape[0],), dtype="int32", name="valid_count")
         iou_threshold = 0.7
         force_suppress = True
-        topk = -1
+        top_k = -1
         out = nms(data, valid_count, iou_threshold, force_suppress, topk)
         np_data = np.random.uniform(dshape)
         np_valid_count = np.array([4])
@@ -273,7 +280,7 @@ def nms_gpu(data, valid_count, return_indices, iou_threshold=0.5, force_suppress
                    [data, sort_tensor, valid_count],
                    lambda ins, outs: nms_ir(
                        ins[0], ins[1], ins[2], outs[0], iou_threshold,
-                       force_suppress, topk),
+                       force_suppress, top_k),
                    dtype="float32",
                    in_buffers=[data_buf, sort_tensor_buf, valid_count_buf],
                    tag="nms")


### PR DESCRIPTION
Before this fix I got the following error when I tried to compile mxnet-ssd models for `target=opencl, target_host=llvm`

```
Traceback (most recent call last):
  File "./compile.py", line 76, in <module>
    net, target, {"data": dshape}, params=params, target_host=target_host)
  File "/usr/local/lib/python3.6/dist-packages/nnvm-0.8.0-py3.6.egg/nnvm/compiler/build_module.py", line 305, in build
    graph = graph.apply("GraphCompile")
  File "/usr/local/lib/python3.6/dist-packages/nnvm-0.8.0-py3.6.egg/nnvm/graph.py", line 234, in apply
    check_call(_LIB.NNGraphApplyPasses(self.handle, npass, cpass, ctypes.byref(ghandle)))
  File "/usr/local/lib/python3.6/dist-packages/nnvm-0.8.0-py3.6.egg/nnvm/_base.py", line 75, in check_call
    raise NNVMError(py_str(_LIB.NNGetLastError()))
nnvm._base.NNVMError: TVMCall CFunc Error:
Traceback (most recent call last):
  File "tvm/_ffi/_cython/./function.pxi", line 38, in tvm._ffi._cy3.core.tvm_callback
  File "/usr/local/lib/python3.6/dist-packages/nnvm-0.8.0-py3.6.egg/nnvm/top/vision.py", line 83, in compute_nms
    id_index, return_indices, invalid_to_bottom)
  File "</usr/local/lib/python3.6/dist-packages/decorator.py:decorator-gen-103>", line 2, in non_max_suppression
  File "/usr/local/lib/python3.6/dist-packages/tvm-0.6.dev0-py3.6-linux-x86_64.egg/tvm/target.py", line 356, in dispatch_func
    return dispatch_dict[k](*args, **kwargs)
TypeError: nms_gpu() takes from 3 to 8 positional arguments but 9 were given
```