### PR TITLE
Make cpptest build on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ if(GTEST_LIB)
     add_executable(${__execname} ${__srcpath})
     list(APPEND TEST_EXECS ${__execname})
     target_link_libraries(${__execname}
-      tvm ${GTEST_LIB} pthread)
+      tvm ${GTEST_LIB} pthread dl)
     set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
     set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
   endforeach()

--- a/docs/contribute/pull_request.rst
+++ b/docs/contribute/pull_request.rst
@@ -40,14 +40,15 @@ C++
   TVM_ROOT=`pwd`
 
   # you need to install google test first, gtest will be installed to $TVM_ROOT/lib
+  apt-get install -y libgtest-dev
   CACHE_PREFIX=. make -f 3rdparty/dmlc-core/scripts/packages.mk gtest
 
   mkdir build
   cd build
-  GTEST_LIB=$TVM_ROOT/lib cmake ..
-  make cpptest -j
+  GTEST_LIB=$TVM_ROOT/lib cmake -DUSE_LLVM=ON ..
+  make cpptest -j$(nproc)
   for test in *_test; do
-    ./$test || exit -1
+    ./$test
   done
 
 Python


### PR DESCRIPTION
Changes in code:
1. add `dl` to `target_link_libraries` in `CMakeLists.txt` for Tests to solve  undefined reference to dl* issue
```
libtvm.so: undefined reference to `dlopen'
libtvm.so: undefined reference to `dlclose'
libtvm.so: undefined reference to `dlerror'
libtvm.so: undefined reference to `dlsym'
```
https://discuss.tvm.ai/t/make-cpptest-failed

Changes in docs:
1. add `apt` command to install `gtest`
2. Add `USE_LLVM=ON` param to cmake because llvm target should be enabled for one of the tests
3. replace `make -j` with `make -j$(nproc)` because just `-j` starts building for all files in parallel (list of files is quite big).
4. remove `|| exit -1` from test loop.
`exit -1` makes it exists from the shell where you run the command in case of test failure.
We might want to `break` the loop but not to exist from the shell.
Anyway, usual junit practice is to run all tests and check the results.