### PR TITLE
CVE-2019-9658

### DIFF
--- a/jvm/core/pom.xml
+++ b/jvm/core/pom.xml
@@ -57,7 +57,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.12</version>
+            <version>[8.18,)</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Fix for https://nvd.nist.gov/vuln/detail/CVE-2019-9658