### PR TITLE
[tvm4j] Upgrade java style-check due to CVE-2019-9658

### DIFF
--- a/jvm/conf/google_checks.xml
+++ b/jvm/conf/google_checks.xml
@@ -57,9 +57,6 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>

--- a/jvm/core/pom.xml
+++ b/jvm/core/pom.xml
@@ -57,7 +57,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.12</version>
+            <version>[8.18,)</version>
           </dependency>
         </dependencies>
         <executions>

--- a/jvm/core/src/main/java/ml/dmlc/tvm/Base.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/Base.java
@@ -161,7 +161,7 @@ final class Base {
 
   // helper function definitions
   /**
-   * Check the return value of C API call
+   * Check the return value of C API call.
    * <p>
    * This function will raise exception when error occurs.
    * Wrap every API call with this function

--- a/jvm/core/src/main/java/ml/dmlc/tvm/Function.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/Function.java
@@ -75,7 +75,7 @@ public class Function extends TVMValue {
   }
 
   /**
-   * Initialize the function with handle
+   * Initialize the function with handle.
    * @param handle the handle to the underlying function.
    * @param isResident Whether this is a resident function in jvm
    */

--- a/jvm/core/src/main/java/ml/dmlc/tvm/Module.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/Module.java
@@ -122,6 +122,7 @@ public class Module extends TVMValue {
   }
 
   /**
+   * Get type key of the module.
    * @return type key of the module.
    */
   public String typeKey() {

--- a/jvm/core/src/main/java/ml/dmlc/tvm/NDArrayBase.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/NDArrayBase.java
@@ -45,7 +45,7 @@ public class NDArrayBase extends TVMValue {
   }
 
   /**
-   * Copy array to target
+   * Copy array to target.
    * @param target The target array to be copied, must have same shape as this array.
    * @return target
    */

--- a/jvm/core/src/main/java/ml/dmlc/tvm/contrib/GraphModule.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/contrib/GraphModule.java
@@ -72,7 +72,7 @@ public class GraphModule {
   }
 
   /**
-   * Set inputs to the module
+   * Set inputs to the module.
    * @param key The input key.
    * @param value The input value.
    * @return self.

--- a/jvm/core/src/main/java/ml/dmlc/tvm/rpc/NativeServerLoop.java
+++ b/jvm/core/src/main/java/ml/dmlc/tvm/rpc/NativeServerLoop.java
@@ -31,7 +31,7 @@ public class NativeServerLoop implements Runnable {
   private final int sockFd;
 
   /**
-   * Constructor for NativeServerLoop
+   * Constructor for NativeServerLoop.
    * @param nativeSockFd native socket file descriptor.
    */
   public NativeServerLoop(final int nativeSockFd) {


### PR DESCRIPTION
Thanks @szha for the fixing https://github.com/dmlc/tvm/pull/2814
Just turned out it requires some trivial changes after upgrading the style-check plugin, thus make another PR.

https://nvd.nist.gov/vuln/detail/CVE-2019-9658