### PR TITLE
Enhance upsample operator to adapt onnx opset version 9

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -447,8 +447,13 @@ class Upsample(OnnxOpConverter):
     """
 
     @classmethod
-    def _impl_v7(cls, inputs, attr, params):
+    def _impl_v9(cls, inputs, attr, params):
         scales = attr.get('scales')
+        if not scales:
+            #Here we are going to higher OPSET version.
+            assert len(inputs) == 2, "Upsample op take 2 inputs, {} given".format(len(inputs))
+            scales = params[inputs[1].name_hint].asnumpy()
+            inputs = inputs[:1]
         assert len(scales) == 4 and scales[0] == 1.0 and scales[1] == 1.0 and scales[2] == scales[3]
         mode = attr.get('mode')
         if mode == b'nearest':


### PR DESCRIPTION
This PR is from closed https://github.com/dmlc/tvm/pull/2792, since the topic changed.

"scales" now is an input instead of an attribute in ONNX OPSET 9, so if we compile a OPSET 9 onnx model, below error may occur if there is upsample op in the model:  

```bash
assert len(scales) == 4 and scales[0] == 1.0 and scales[1] == 1.0 and scales[2] == scales[3]
TypeError: object of type 'NoneType' has no len()
```
This commit will fix this.
