### PR TITLE
[DOCKER] Revert git shallow clone change.

### DIFF
--- a/docker/install/ubuntu_install_nnpack.sh
+++ b/docker/install/ubuntu_install_nnpack.sh
@@ -7,7 +7,8 @@ set -o pipefail
 apt-get update && apt-get install -y --no-install-recommends git cmake
 
 # TODO: specific tag?
-git clone --branch=1e005b0c2 --depth=1 https://github.com/Maratyszcza/NNPACK NNPACK
+git clone https://github.com/Maratyszcza/NNPACK NNPACK
+(cd NNPACK && git checkout 1e005b0c2)
 
 mkdir -p NNPACK/build
 cd NNPACK/build


### PR DESCRIPTION
This patch reverts one of my earlier patches (squashed in #2710) to
reduce bandwidth requirements of git clone, in this particular case we
are checking out a specific hash rather than a tag or branch name. The
--branch option to git clone permits tags or branches but does not
permit a specific hash.
