### PR TITLE
[Relay][Frontend][ONNX] Outdated renaming for flatten in ONNX to Relay converter

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -807,7 +807,7 @@ def _get_convert_map(opset):
         # 'InstanceNormalization'
         # 'LpNormalization'
         'Dropout': AttrCvt('dropout', {'ratio': 'rate'}, ignores=['is_test']),
-        'Flatten': Renamer('flatten'),
+        'Flatten': Renamer('batch_flatten'),
         'LRN': LRN.get_converter(opset),
 
         # defs/reduction


### PR DESCRIPTION
An incorrect operator renaming was performed in the ONNX frontend converter; `flatten` was renamed to `batch_flatten`. Incidentally, this bug was triggered using the ONNX model zoo's publicly posted version of Resnet-18, which I notice the Relay tests don't use. Should the tests be updated to use that version?