### PR TITLE
[Relay][Frontend][keras] added interpolation method of Upsampling2D

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -336,7 +336,11 @@ def _convert_upsample(inexpr, keras_layer, _):
         params = {'scale': h}
 
         if hasattr(keras_layer, 'interpolation'):
-            params['method'] = 'NEAREST_NEIGHBOR' if keras_layer.interpolation == 'nearest' else 'BILINEAR'
+            interpolation = keras_layer.interpolation
+            if interpolation == 'nearest':
+                params['method'] = 'NEAREST_NEIGHBOR'
+            else:
+                params['method'] = 'BILINEAR'
 
     elif upsample_type == 'UpSampling3D':
         h, w, d = keras_layer.size

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -334,6 +334,10 @@ def _convert_upsample(inexpr, keras_layer, _):
             raise TypeError("Unsupported upsampling type with different axes size : {}"
                             .format(keras_layer.size))
         params = {'scale': h}
+
+        if hasattr(keras_layer, 'interpolation'):
+            params['method'] = 'NEAREST_NEIGHBOR' if keras_layer.interpolation == 'nearest' else 'BILINEAR'
+
     elif upsample_type == 'UpSampling3D':
         h, w, d = keras_layer.size
         if h != w or w != d:

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -133,9 +133,9 @@ def test_forward_conv():
         verify_keras_frontend(keras_model)
 
 
-def test_forward_upsample():
+def test_forward_upsample(interpolation='nearest'):
     data = keras.layers.Input(shape=(32,32,3))
-    x = keras.layers.UpSampling2D(size=(3,3))(data)
+    x = keras.layers.UpSampling2D(size=(3,3), interpolation=interpolation)(data)
     keras_model = keras.models.Model(data, x)
     verify_keras_frontend(keras_model)
 
@@ -246,7 +246,8 @@ if __name__ == '__main__':
     test_forward_dense()
     test_forward_pool()
     test_forward_conv()
-    test_forward_upsample()
+    test_forward_upsample(interpolation='nearest')
+    test_forward_upsample(interpolation='bilinear')
     test_forward_reshape()
     test_forward_crop()
     test_forward_multi_inputs()


### PR DESCRIPTION
During converting keras model to relay, upsampling2d always uses nearest interpolation method but keras supports bilinear and nearest methods.
