### PR TITLE
Add dense schedules to __init__ for cpu

### DIFF
--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -1084,6 +1084,7 @@ inline Tensor layout_transform(const Tensor& src,
 /*!
  * \brief Get the shape of input tensor.
  * \param src the input tensor.
+ * \param dtype the type of the elements in the tensor.
  * \param name output tensor name.
  * \param tag output tensor tag.
  * \return Tensor of input shape.

--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -10,3 +10,4 @@ from .injective import *
 from .pooling import schedule_pool, schedule_global_pool
 from .bitserial_conv2d import schedule_bitserial_conv2d
 from .depthwise_conv2d import schedule_depthwise_conv2d_NCHWc
+from .dense import _schedule_dense, _schedule_dense_pack, _schedule_dense_nopack

--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -11,3 +11,4 @@ from .pooling import schedule_pool, schedule_global_pool
 from .bitserial_conv2d import schedule_bitserial_conv2d
 from .depthwise_conv2d import schedule_depthwise_conv2d_NCHWc
 from .dense import _schedule_dense, _schedule_dense_pack, _schedule_dense_nopack
+from .batch_matmul import schedule_batch_matmul


### PR DESCRIPTION
A new x86/dense.py file containing the same functions previously in x86/nn.py was made for cpu dense op.
Adding import for scheduling functions to x86/init.py

was causing a problem where TaskExtractor was returning workload=None for dense op.