### PR TITLE
Consistent result of DetectLinearEquation() when an empy vars is passed

### DIFF
--- a/src/arithmetic/detect_linear_equation.cc
+++ b/src/arithmetic/detect_linear_equation.cc
@@ -127,25 +127,21 @@ Array<Expr> DetectLinearEquation(const Expr& e, const Array<Var>& vars) {
   Expr base = e;
   Array<Expr> coeff;
 
-  if (0 == vars.size()) {
-    coeff.push_back(make_const(Int(32), 1));
-  } else {
-    for (Var v : vars) {
-      LinearEqEntry ret;
-      if (!LinearEqDetector(v).Detect(base, &ret)) {
-        return Array<Expr>();
-      }
-      coeff.push_back(ret.coeff);
-      base = std::move(ret.base);
+  for (Var v : vars) {
+    LinearEqEntry ret;
+    if (!LinearEqDetector(v).Detect(base, &ret)) {
+      return Array<Expr>();
     }
+    coeff.push_back(ret.coeff);
+    base = std::move(ret.base);
+  }
 
-    std::unordered_set<const Variable*> vset;
-    for (size_t i = vars.size(); i != 1; --i) {
-      vset.insert(vars[i - 1].get());
-      // The previous coeff contains the variable
-      if (ExprUseVar(coeff[i - 2], vset)) {
-        return Array<Expr>();
-      }
+  std::unordered_set<const Variable*> vset;
+  for (size_t i = vars.size(); i > 1; --i) {
+    vset.insert(vars[i - 1].get());
+    // The previous coeff contains the variable
+    if (ExprUseVar(coeff[i - 2], vset)) {
+      return Array<Expr>();
     }
   }
   coeff.push_back(base);

--- a/src/pass/inject_copy_intrin.cc
+++ b/src/pass/inject_copy_intrin.cc
@@ -39,7 +39,6 @@ class CopyIntrinInjector : public IRMutator {
   bool MatchCopyPattern(Stmt stmt, Stmt *out) {
     using namespace arith;
     Stmt body = stmt;
-    bool is_single_point_copy = false;
 
     // strip the loops
     std::vector<const For*> loops;
@@ -60,7 +59,6 @@ class CopyIntrinInjector : public IRMutator {
     const Cast* cast = store->value.as<Cast>();
     const Load* load = store->value.as<Load>();
     if (0 == loops.size()) {
-      is_single_point_copy = true;
       CHECK(!has_cond);
     }
     // for now only support true condition matching
@@ -83,9 +81,8 @@ class CopyIntrinInjector : public IRMutator {
         arith::DetectLinearEquation(load->index, loop_vars);
     if (load_strides.size()  == 0 || store_strides.size() == 0) return false;
     Array<Expr> dst_shape;
-    auto loop_var_size = loop_vars.size();
-    if (is_single_point_copy) {
-      loop_var_size = 1;
+    const size_t loop_var_size = loop_vars.size();
+    if (loop_var_size == 0) {
       dst_shape.push_back(make_const(Int(32), 1));
     } else {
       for (const For* op : loops) {
@@ -132,6 +129,10 @@ class CopyIntrinInjector : public IRMutator {
     CHECK_EQ(load_strides.size(), loop_var_size + 1);
     Array<Expr> src_strides(load_strides.begin(), load_strides.begin() + loop_var_size);
     Array<Expr> dst_strides(store_strides.begin(), store_strides.begin() + loop_var_size);
+    if(loop_var_size == 0) {
+        src_strides.push_back(make_const(Int(32), 1));
+        dst_strides.push_back(make_const(Int(32), 1));
+    }
     Buffer dst = BufferNode::make(
         Var(store->buffer_var.node_),
         store->value.type(),

--- a/src/pass/inject_copy_intrin.cc
+++ b/src/pass/inject_copy_intrin.cc
@@ -129,7 +129,7 @@ class CopyIntrinInjector : public IRMutator {
     CHECK_EQ(load_strides.size(), loop_var_size + 1);
     Array<Expr> src_strides(load_strides.begin(), load_strides.begin() + loop_var_size);
     Array<Expr> dst_strides(store_strides.begin(), store_strides.begin() + loop_var_size);
-    if(loop_var_size == 0) {
+    if (loop_var_size == 0) {
         src_strides.push_back(make_const(Int(32), 1));
         dst_strides.push_back(make_const(Int(32), 1));
     }

--- a/tests/python/unittest/test_arith_detect_linear_equation.py
+++ b/tests/python/unittest/test_arith_detect_linear_equation.py
@@ -20,6 +20,11 @@ def test_basic():
     m = tvm.arith.DetectLinearEquation(b * 7, [a])
     assert m[0].value == 0
 
+    m = tvm.arith.DetectLinearEquation(b * 7, [])
+    assert len(m) == 2
+    assert m[0].value == 1
+    assert tvm.ir_pass.Simplify(m[1] - b * 7).value == 0
+
 def test_multivariate():
     v = [tvm.var("v%d" % i) for i in range(4)]
     b = tvm.var("b")
@@ -40,6 +45,11 @@ def test_multivariate():
 
     m = tvm.arith.DetectLinearEquation((v[0] - v[1]), [v[2]])
     assert(m[0].value == 0)
+    assert(tvm.ir_pass.Simplify(m[1] - (v[0] - v[1])).value == 0)
+
+    m = tvm.arith.DetectLinearEquation((v[0] - v[1]), [])
+    assert(len(m) == 2)
+    assert(m[0].value == 1)
     assert(tvm.ir_pass.Simplify(m[1] - (v[0] - v[1])).value == 0)
 
 if __name__ == "__main__":

--- a/tests/python/unittest/test_arith_detect_linear_equation.py
+++ b/tests/python/unittest/test_arith_detect_linear_equation.py
@@ -21,9 +21,8 @@ def test_basic():
     assert m[0].value == 0
 
     m = tvm.arith.DetectLinearEquation(b * 7, [])
-    assert len(m) == 2
-    assert m[0].value == 1
-    assert tvm.ir_pass.Simplify(m[1] - b * 7).value == 0
+    assert len(m) == 1
+    assert tvm.ir_pass.Simplify(m[0] - b * 7).value == 0
 
 def test_multivariate():
     v = [tvm.var("v%d" % i) for i in range(4)]
@@ -48,9 +47,8 @@ def test_multivariate():
     assert(tvm.ir_pass.Simplify(m[1] - (v[0] - v[1])).value == 0)
 
     m = tvm.arith.DetectLinearEquation((v[0] - v[1]), [])
-    assert(len(m) == 2)
-    assert(m[0].value == 1)
-    assert(tvm.ir_pass.Simplify(m[1] - (v[0] - v[1])).value == 0)
+    assert(len(m) == 1)
+    assert(tvm.ir_pass.Simplify(m[0] - (v[0] - v[1])).value == 0)
 
 if __name__ == "__main__":
     test_basic()


### PR DESCRIPTION
@tqchen commented as 
`Maybe we can simply generalize DetectLinearEquation to accept empty list of loop_var, which returns everything as base. This is well-defined and consistent with original defition.` in https://github.com/dmlc/tvm/pull/863#pullrequestreview-93714075 .
I found that the current implementation returns '1' and the base. I think not returning '1' is more consistent behavior.

My PR consists of 3 commits.
1) Add a test to show the current behavior
2) Update the funtion DetectLinearEquation() and the test in 1)
3) Update InjectCopyIntrin(), which uses DetectLinearEquation() so that it works as before.

I personally think that it is better to handle single point copy in InjectCopyIntrin() as 0-demension array.
Then the immediate value of '1' is not necesary in the function.
Because I don't know much about the user of InjectCopyIntrin(), I don't change its behavior in this PR.