### PR TITLE
[Relay] Fix Relay ARM CPU depthwise spatial pack schedule alter op layout issue.

### DIFF
--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -85,7 +85,6 @@ def compute_conv2d(attrs, inputs, out_type, target):
             inputs[0], inputs[1], strides, padding,
             dilation, layout, out_dtype=out_dtype)
     elif layout == "NCHW" and \
-         kernel_layout == "OIHW" and \
          get_const_int(inputs[1].shape[0]) == groups and \
          get_const_int(inputs[1].shape[1]) == 1:
         out = topi.nn.depthwise_conv2d_nchw(

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -186,7 +186,7 @@ tuning_option = {
     'log_filename': log_file,
 
     'tuner': 'xgb',
-    'n_trial': 1000,
+    'n_trial': 2000,
     'early_stopping': 800,
 
     'measure_option': autotvm.measure_option(

--- a/tutorials/autotvm/tune_relay_arm.py
+++ b/tutorials/autotvm/tune_relay_arm.py
@@ -186,7 +186,7 @@ tuning_option = {
     'log_filename': log_file,
 
     'tuner': 'xgb',
-    'n_trial': 2000,
+    'n_trial': 1500,
     'early_stopping': 800,
 
     'measure_option': autotvm.measure_option(


### PR DESCRIPTION
When we use `contrib_spatial_pack` schedule for ARM CPU, the depthwise kernel layout could be `OIHWxO`. i.e. 5D. This issue doesn't exist in NNVM, just Relay.

Also update tutorial of tune_relay_arm.py, `n_trials` set to be `2000`, because `contrib_spatial_pack` of depthwise convolution need more trials to get best result.

@merrymercy please help to review.