### PR TITLE
Fix setting up hints for getaddrinfo

### DIFF
--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -65,7 +65,7 @@ struct SockAddr {
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = PF_UNSPEC;
     hints.ai_flags = AI_PASSIVE;
-    hints.ai_protocol = SOCK_STREAM;
+    hints.ai_socktype = SOCK_STREAM;
     addrinfo *res = NULL;
     int sig = getaddrinfo(host, NULL, &hints, &res);
     CHECK(sig == 0 && res != NULL)


### PR DESCRIPTION
SOCK_STREAM is a socket type, not a protocol.  This actually caused connection failures on FreeBSD.