### PR TITLE
Add missing sgx includes

### DIFF
--- a/cmake/modules/SGX.cmake
+++ b/cmake/modules/SGX.cmake
@@ -48,4 +48,6 @@ if(NOT USE_SGX STREQUAL "OFF")
     -L${USE_SGX}/lib64 -l${_urts_lib}
     -L${RUST_SGX_SDK}/sgx_ustdc -lsgx_ustdc)
   list(APPEND RUNTIME_SRCS ${RUNTIME_SGX_SRCS})
+
+  include_directories(${RUST_SGX_SDK}/edl ${RUST_SGX_SDK}/common)
 endif()


### PR DESCRIPTION
[rust-sgx-sdk added some includes to their edls](https://github.com/baidu/rust-sgx-sdk/blob/master/edl/sgx_file.edl#L34) that reference [include dirs in their repo](https://github.com/baidu/rust-sgx-sdk/tree/master/edl/inc). This PR updates the cmake build to include them.

resolves #2790 (cc @wuzhiyu666)