### PR TITLE
[DOCKER] Pin flatbuffers checkout to the last release tag (#2823).

### DIFF
--- a/docker/install/ubuntu_install_tflite.sh
+++ b/docker/install/ubuntu_install_tflite.sh
@@ -5,7 +5,7 @@ set -u
 set -o pipefail
 
 # Download, build and install flatbuffers
-git clone --depth=1 --recursive https://github.com/google/flatbuffers.git
+git clone --branch=v1.10.0 --depth=1 --recursive https://github.com/google/flatbuffers.git
 cd flatbuffers
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
 make install -j8


### PR DESCRIPTION
Prevent future breakage of the form exposed in #2823, pin the flatbuffer version to most recent release tag.