### PR TITLE
Fix x86 dense

### DIFF
--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import as _abs
 from .conv2d import schedule_conv2d, schedule_conv2d_nhwc
 from .binarize_pack import schedule_binarize_pack
 from .binary_dense import schedule_binary_dense
+from .dense import *
 from .nn import *
 from .injective import *
 from .pooling import schedule_pool, schedule_global_pool

--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import as _abs
 
 from .conv2d import schedule_conv2d, schedule_conv2d_nhwc
+from .batch_matmul import schedule_batch_matmul
 from .binarize_pack import schedule_binarize_pack
 from .binary_dense import schedule_binary_dense
 from .dense import *


### PR DESCRIPTION
Currently tvm can't correctly locate decl and schedule for x86 dense. This patch fixes the issue.
@yzhliu @icemelon9 