### PR TITLE
[Relay][Text Format] Reverse CallNode Print Order

### DIFF
--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -416,11 +416,13 @@ class PrettyPrinter :
 
   Doc VisitExpr_(const CallNode* op) final {
     Doc doc;
-    doc << Print(op->op);
+    // visit args first so they are lifted before the op
+    // this places op closer to its call site
     std::vector<Doc> args;
     for (Expr arg : op->args) {
       args.push_back(Print(arg));
     }
+    doc << Print(op->op);
     return doc << "(" << PrintVec(args) << PrintAttrs(op->attrs, op->op) << ")";
   }
 

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -154,7 +154,9 @@ def test_densenet():
     net.astext()
 
 def test_call_node_order():
-    assert relay.fromtext(SEMVER+"(fn(%x) { %x })((fn(%y) { %y })(1))").astext() == SEMVER + \
+    x = relay.var("x")
+    y = relay.var("y")
+    assert relay.Call(relay.Function([x], x), [relay.Call(relay.Function([y], y), [relay.const(1)])]).astext() == SEMVER + \
         ("%0 = fn (%y) {\n"
          "  %y\n"
          "}\n"

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -152,6 +152,17 @@ def test_densenet():
     net, params = tvm.relay.testing.densenet.get_workload(batch_size=1)
     net.astext()
 
+def test_call_node_order():
+    assert relay.fromtext("v0.0.1\n(fn(%x) { %x })((fn(%y) { %y })(1))").astext(show_meta_data=False) == ("v0.0.1\n"
+                               "%0 = fn (%y) {\n"
+                               "  %y\n"
+                               "}\n"
+                               "%1 = %0(1)\n"
+                               "%2 = fn (%x) {\n"
+                               "  %x\n"
+                               "}\n"
+                               "%3 = %2(%1)\n"
+                               "%3")
 
 if __name__ == "__main__":
     do_print[0] = True
@@ -170,3 +181,4 @@ if __name__ == "__main__":
     test_call_attrs()
     test_let_if_scope()
     test_variable_name()
+    test_call_node_order()

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -3,8 +3,9 @@ import tvm.relay.testing
 import numpy as np
 from tvm import relay
 
-
 do_print = [False]
+
+SEMVER = "v0.0.1\n"
 
 def show(text):
     if do_print[0]:
@@ -153,16 +154,17 @@ def test_densenet():
     net.astext()
 
 def test_call_node_order():
-    assert relay.fromtext("v0.0.1\n(fn(%x) { %x })((fn(%y) { %y })(1))").astext(show_meta_data=False) == ("v0.0.1\n"
-                               "%0 = fn (%y) {\n"
-                               "  %y\n"
-                               "}\n"
-                               "%1 = %0(1)\n"
-                               "%2 = fn (%x) {\n"
-                               "  %x\n"
-                               "}\n"
-                               "%3 = %2(%1)\n"
-                               "%3")
+    assert relay.fromtext(SEMVER+"(fn(%x) { %x })((fn(%y) { %y })(1))").astext() == SEMVER + \
+        ("v0.0.1\n"
+         "%0 = fn (%y) {\n"
+         "  %y\n"
+         "}\n"
+         "%1 = %0(1)\n"
+         "%2 = fn (%x) {\n"
+         "  %x\n"
+         "}\n"
+         "%3 = %2(%1)\n"
+         "%3")
 
 if __name__ == "__main__":
     do_print[0] = True

--- a/tests/python/relay/test_ir_text_printer.py
+++ b/tests/python/relay/test_ir_text_printer.py
@@ -155,8 +155,7 @@ def test_densenet():
 
 def test_call_node_order():
     assert relay.fromtext(SEMVER+"(fn(%x) { %x })((fn(%y) { %y })(1))").astext() == SEMVER + \
-        ("v0.0.1\n"
-         "%0 = fn (%y) {\n"
+        ("%0 = fn (%y) {\n"
          "  %y\n"
          "}\n"
          "%1 = %0(1)\n"


### PR DESCRIPTION
GNFs args of call node before the operator. See https://discuss.tvm.ai/t/relay-sub-functions-printed-in-reverse-order/1984.

cc @vinx13 @tqchen.