### PR TITLE
[Rust] Use version invariant rustfmt

### DIFF
--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -9,12 +9,10 @@ apt-get update && apt-get install -y --no-install-recommends curl
 export RUSTUP_HOME=/opt/rust
 export CARGO_HOME=/opt/rust
 # this rustc is one supported by the installed version of rust-sgx-sdk
-curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2019-01-28
+curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2019-03-24
 . $CARGO_HOME/env
-rustup component add rust-src
-cargo install sccache
-cargo install rustfmt-nightly --version 1.0.1 --force
-cargo install xargo
+rustup component add rustfmt
+cargo install sccache --no-default-features
 
 # make rust usable by all users
 chmod -R a+w /opt/rust

--- a/rust/.rustfmt.toml
+++ b/rust/.rustfmt.toml
@@ -45,7 +45,6 @@ use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
 color = "Auto"
-required_version = "1.0.1"
 unstable_features = false
 disable_all_formatting = false
 skip_children = false


### PR DESCRIPTION
Fixes the build issue currently plaguing #2616 

This breaks sgx support, but there's a PR on the way for a new SGX framework (#2885)