### PR TITLE
[Apps] [howto_deploy] fix cxx-flags order and build directory

### DIFF
--- a/apps/howto_deploy/Makefile
+++ b/apps/howto_deploy/Makefile
@@ -31,4 +31,4 @@ lib/cpp_deploy_pack: cpp_deploy.cc lib/test_addone_sys.o lib/libtvm_runtime_pack
 # Deploy using pre-built libtvm_runtime.so
 lib/cpp_deploy_normal: cpp_deploy.cc lib/test_addone_sys.o
 	@mkdir -p $(@D)
-	$(CXX) $(PKG_CFLAGS) -o $@  $^ $(PKG_LDFLAGS) -ltvm_runtime
+	$(CXX) $(PKG_CFLAGS) -o $@  $^ -ltvm_runtime $(PKG_LDFLAGS)

--- a/apps/howto_deploy/run_example.sh
+++ b/apps/howto_deploy/run_example.sh
@@ -3,8 +3,8 @@ echo "Build the libraries.."
 mkdir -p lib
 make
 echo "Run the example"
-export LD_LIBRARY_PATH=../../lib:${LD_LIBRARY_PATH}
-export DYLD_LIBRARY_PATH=../../lib:${DYLD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=../../build:${LD_LIBRARY_PATH}
+export DYLD_LIBRARY_PATH=../../build:${DYLD_LIBRARY_PATH}
 
 echo "Run the deployment with all in one packed library..."
 lib/cpp_deploy_pack


### PR DESCRIPTION
This fix two issues on howto_deploy app:

1. Linking issue with `libtvm_runtime`, because this library now depends on `-ldl` and `lpthread`
2. Rename dir `lib` to `build` in the bash script, so `libtvm_runtime.so` can be found
