### PR TITLE
[TESTS] Improve script robustness

### DIFF
--- a/tests/scripts/task_cpp_unittest.sh
+++ b/tests/scripts/task_cpp_unittest.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+
+set -e
+
 export LD_LIBRARY_PATH=lib:${LD_LIBRARY_PATH}
 
-make cpptest -j8 || exit -1
+make cpptest -j8
 for test in build/*_test; do
-    ./$test || exit -1
+    ./$test
 done

--- a/tests/scripts/task_java_unittest.sh
+++ b/tests/scripts/task_java_unittest.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 export PYTHONPATH=python
 export LD_LIBRARY_PATH=lib:${LD_LIBRARY_PATH}
 
@@ -6,18 +9,18 @@ CURR_DIR=$(cd `dirname $0`; pwd)
 SCRIPT_DIR=$CURR_DIR/../../jvm/core/src/test/scripts
 TEMP_DIR=$(mktemp -d)
 
-python $SCRIPT_DIR/test_add_cpu.py $TEMP_DIR || exit -1
-python $SCRIPT_DIR/test_add_gpu.py $TEMP_DIR || exit -1
-python $SCRIPT_DIR/test_graph_runtime.py $TEMP_DIR || exit -1
+python $SCRIPT_DIR/test_add_cpu.py $TEMP_DIR
+python $SCRIPT_DIR/test_add_gpu.py $TEMP_DIR
+python $SCRIPT_DIR/test_graph_runtime.py $TEMP_DIR
 
 # start rpc proxy server
 PORT=$(( ( RANDOM % 1000 )  + 9000 ))
 python $SCRIPT_DIR/test_rpc_proxy_server.py $PORT 30 &
 
-make jvmpkg || exit -1
+make jvmpkg
 make jvmpkg JVM_TEST_ARGS="-DskipTests=false \
   -Dtest.tempdir=$TEMP_DIR \
   -Dtest.rpc.proxy.host=localhost \
-  -Dtest.rpc.proxy.port=$PORT" || exit -1
+  -Dtest.rpc.proxy.port=$PORT"
 
 rm -rf $TEMP_DIR

--- a/tests/scripts/task_python_docs.sh
+++ b/tests/scripts/task_python_docs.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+set -e
+set -u
+
 mkdir -p docs/_build/html
 rm -rf docs/_build/html/jsdoc
 rm -rf docs/_build/html/javadoc
@@ -10,17 +14,17 @@ rm -rf docs/tutorials
 make doc
 
 # JS doc
-jsdoc web/tvm_runtime.js web/README.md || exit -1
-mv out docs/_build/html/jsdoc || exit -1
+jsdoc web/tvm_runtime.js web/README.md
+mv out docs/_build/html/jsdoc
 
 # Java doc
-make javadoc || exit -1
-mv jvm/core/target/site/apidocs docs/_build/html/javadoc || exit -1
+make javadoc
+mv jvm/core/target/site/apidocs docs/_build/html/javadoc
 
 rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
 
 cd docs
-PYTHONPATH=`pwd`/../python make html || exit -1
+PYTHONPATH=`pwd`/../python make html
 cd _build/html
 tar czf docs.tgz *
 mv docs.tgz ../../../

--- a/tests/scripts/task_python_frontend.sh
+++ b/tests/scripts/task_python_frontend.sh
@@ -1,55 +1,58 @@
 #!/bin/bash
 
+set -e
+set -u
+
 export PYTHONPATH=nnvm/python:python:topi/python
 # to avoid openblas threading error
 export OMP_NUM_THREADS=1
 
 # Rebuild cython
-make cython || exit -1
-make cython3 || exit -1
-
-echo "Running nnvm unittest..."
-python -m nose -v nnvm/tests/python/unittest || exit -1
-python3 -m nose -v nnvm/tests/python/unittest || exit -1
-
-echo "Running nnvm compiler test..."
-python3 -m nose -v nnvm/tests/python/compiler || exit -1
-
-echo "Running nnvm ONNX frontend test..."
-python3 -m nose -v nnvm/tests/python/frontend/onnx || exit -1
-
-echo "Running nnvm MXNet frontend test..."
-python3 -m nose -v nnvm/tests/python/frontend/mxnet || exit -1
-
-echo "Running nnvm Keras frontend test..."
-python3 -m nose -v nnvm/tests/python/frontend/keras || exit -1
-
-echo "Running nnvm Tensorflow frontend test..."
-python3 -m nose -v nnvm/tests/python/frontend/tensorflow || exit -1
-
-echo "Running nnvm CoreML frontend test..."
-python3 -m nose -v nnvm/tests/python/frontend/coreml || exit -1
-
-echo "Running relay MXNet frontend test..."
-python3 -m nose -v tests/python/frontend/mxnet || exit -1
-
-echo "Running relay Keras frontend test..."
-python3 -m nose -v tests/python/frontend/keras || exit -1
-
-echo "Running relay ONNX frondend test..."
-python3 -m nose -v tests/python/frontend/onnx || exit -1
-
-echo "Running relay CoreML frondend test..."
-python3 -m nose -v tests/python/frontend/coreml || exit -1
-
-echo "Running relay Tensorflow frontend test..."
-python3 -m nose -v tests/python/frontend/tensorflow || exit -1
-
-echo "Running nnvm to relay frontend test..."
-python3 -m nose -v tests/python/frontend/nnvm_to_relay || exit -1
+make cython
+make cython3
 
 echo "Running relay TFLite frontend test..."
-python3 -m nose -v tests/python/frontend/tflite || exit -1
+python3 -m nose -v tests/python/frontend/tflite
+
+echo "Running nnvm unittest..."
+python -m nose -v nnvm/tests/python/unittest
+python3 -m nose -v nnvm/tests/python/unittest
+
+echo "Running nnvm compiler test..."
+python3 -m nose -v nnvm/tests/python/compiler
+
+echo "Running nnvm ONNX frontend test..."
+python3 -m nose -v nnvm/tests/python/frontend/onnx
+
+echo "Running nnvm MXNet frontend test..."
+python3 -m nose -v nnvm/tests/python/frontend/mxnet
+
+echo "Running nnvm Keras frontend test..."
+python3 -m nose -v nnvm/tests/python/frontend/keras
+
+echo "Running nnvm Tensorflow frontend test..."
+python3 -m nose -v nnvm/tests/python/frontend/tensorflow
+
+echo "Running nnvm CoreML frontend test..."
+python3 -m nose -v nnvm/tests/python/frontend/coreml
+
+echo "Running relay MXNet frontend test..."
+python3 -m nose -v tests/python/frontend/mxnet
+
+echo "Running relay Keras frontend test..."
+python3 -m nose -v tests/python/frontend/keras
+
+echo "Running relay ONNX frondend test..."
+python3 -m nose -v tests/python/frontend/onnx
+
+echo "Running relay CoreML frondend test..."
+python3 -m nose -v tests/python/frontend/coreml
+
+echo "Running nnvm to relay frontend test..."
+python3 -m nose -v tests/python/frontend/nnvm_to_relay
+
+echo "Running relay Tensorflow frontend test..."
+python3 -m nose -v tests/python/frontend/tensorflow
 
 echo "Running relay caffe2 frondend test..."
-python3 -m nose -v tests/python/frontend/caffe2 || exit -1
+python3 -m nose -v tests/python/frontend/caffe2

--- a/tests/scripts/task_python_integration.sh
+++ b/tests/scripts/task_python_integration.sh
@@ -1,28 +1,31 @@
 #!/bin/bash
+
+set -e
+
 export PYTHONPATH=python:topi/python:apps/extension/python
 export LD_LIBRARY_PATH=build:${LD_LIBRARY_PATH}
 
 rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
 
 # Test TVM
-make cython || exit -1
-make cython3 || exit -1
+make cython
+make cython3
 
 # Test extern package
 cd apps/extension
 rm -rf lib
-make || exit -1
+make
 cd ../..
-python -m nose -v apps/extension/tests || exit -1
+python -m nose -v apps/extension/tests
 
-TVM_FFI=cython python -m nose -v tests/python/integration || exit -1
-TVM_FFI=ctypes python3 -m nose -v tests/python/integration || exit -1
-TVM_FFI=cython python -m nose -v tests/python/contrib || exit -1
-TVM_FFI=ctypes python3 -m nose -v tests/python/contrib || exit -1
+TVM_FFI=cython python -m nose -v tests/python/integration
+TVM_FFI=ctypes python3 -m nose -v tests/python/integration
+TVM_FFI=cython python -m nose -v tests/python/contrib
+TVM_FFI=ctypes python3 -m nose -v tests/python/contrib
 
-TVM_FFI=cython python -m nose -v tests/python/relay || exit -1
-TVM_FFI=ctypes python3 -m nose -v tests/python/relay || exit -1
+TVM_FFI=cython python -m nose -v tests/python/relay
+TVM_FFI=ctypes python3 -m nose -v tests/python/relay
 
 # Do not enable OpenGL
-# TVM_FFI=cython python -m nose -v tests/webgl || exit -1
-# TVM_FFI=ctypes python3 -m nose -v tests/webgl || exit -1
+# TVM_FFI=cython python -m nose -v tests/webgl
+# TVM_FFI=ctypes python3 -m nose -v tests/webgl

--- a/tests/scripts/task_python_topi.sh
+++ b/tests/scripts/task_python_topi.sh
@@ -1,11 +1,14 @@
+set -e
+set -u
+
 export PYTHONPATH=python:topi/python
 
 # Rebuild cython
-make cython || exit -1
-make cython3 || exit -1
+make cython
+make cython3
 
 rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
 rm -rf topi/python/topi/*.pyc topi/python/topi/*/*.pyc topi/python/topi/*/*/*.pyc topi/python/topi/*/*/*/*.pyc 
 
-python -m nose -v topi/tests/python || exit -1
-python3 -m nose -v topi/tests/python || exit -1
+python -m nose -v topi/tests/python
+python3 -m nose -v topi/tests/python

--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+set -e
+set -u
+
 export PYTHONPATH=python:topi/python
 
 rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
 
-TVM_FFI=ctypes python -m nose -v tests/python/unittest || exit -1
-TVM_FFI=ctypes python3 -m nose -v tests/python/unittest || exit -1
-make cython || exit -1
-make cython3 || exit -1
-TVM_FFI=cython python -m nose -v tests/python/unittest || exit -1
-TVM_FFI=cython python3 -m nose -v tests/python/unittest || exit -1
+TVM_FFI=ctypes python -m nose -v tests/python/unittest
+TVM_FFI=ctypes python3 -m nose -v tests/python/unittest
+make cython
+make cython3
+TVM_FFI=cython python -m nose -v tests/python/unittest
+TVM_FFI=cython python3 -m nose -v tests/python/unittest

--- a/tests/scripts/task_python_vta.sh
+++ b/tests/scripts/task_python_vta.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
+set -e
+set -u
+
 export PYTHONPATH=python:nnvm/python:vta/python:topi/python
 
 rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc python/tvm/*/*/*/*.pyc
 rm -rf ~/.tvm
 
 # Rebuild cython
-make cython || exit -1
-make cython3 || exit -1
+make cython
+make cython3
 
 echo "Running unittest..."
-python -m nose -v vta/tests/python/unittest || exit -1
-python3 -m nose -v vta/tests/python/unittest || exit -1
+python -m nose -v vta/tests/python/unittest
+python3 -m nose -v vta/tests/python/unittest
 
 echo "Running integration test..."
-python -m nose -v vta/tests/python/integration || exit -1
-python3 -m nose -v vta/tests/python/integration || exit -1
+python -m nose -v vta/tests/python/integration
+python3 -m nose -v vta/tests/python/integration

--- a/tests/scripts/task_verilog_test.sh
+++ b/tests/scripts/task_verilog_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+
+set -e
+set -u
+
 export PYTHONPATH=python
-make verilog || exit -1
-nosetests -v tests/verilog/unittest || exit -1
-nosetests -v tests/verilog/integration || exit -1
+make verilog
+nosetests -v tests/verilog/unittest
+nosetests -v tests/verilog/integration

--- a/tests/scripts/task_web_test.sh
+++ b/tests/scripts/task_web_test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+set -e
+set -u
+
 export PYTHONPATH=python
 
 cp /emsdk-portable/.emscripten ~/.emscripten
@@ -11,13 +15,13 @@ echo "Build TVM Web runtime..."
 make web
 
 echo "Prepare test libraries..."
-python tests/web/prepare_test_libs.py || exit -1
+python tests/web/prepare_test_libs.py
 
 echo "Start testing..."
 
 for test in tests/web/test_*.js; do
     echo node $test
-    node $test || exit -1
+    node $test
 done
 
 echo "All tests finishes..."


### PR DESCRIPTION
A number of test scripts use the '|| exit 1' idiom.  This has two
issues, first process exit codes are defined to be in the range 0-255.
Second, more importantly, the idiom is fragile because it requires
that every possible failure point be explicitly coded.  This patch
removes the idiom in favour of "set -e" as used in the docker scripts
as a more robust mechanism to ensure that script failures are always
caught and propagated by default.