### PR TITLE
[WIP] Add support for TupleGetItem node in Operator fusion

### DIFF
--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -217,7 +217,6 @@ def test_tuple_strided_slice():
     assert not relay.ir_pass.free_vars(zz)
     after = relay.ir_pass.infer_type(expected(dshape))
     assert relay.ir_pass.alpha_equal(zz, after)
-    print(zz.astext())
 
 
 def test_stop_fusion():
@@ -287,6 +286,81 @@ def test_fuse_myia_regression():
     assert relay.ir_pass.alpha_equal(f, after)
 
 
+def test_gru():
+    def before(rnn_dim):
+        X = relay.var("X", shape=(1, rnn_dim))
+        W = relay.var("W", shape=(3 * rnn_dim, rnn_dim))
+        matmul = relay.nn.dense(X, W)
+        splitted = relay.split(matmul, indices_or_sections=3, axis=1)
+        out = relay.sigmoid(splitted[0]) + relay.tanh(splitted[1]) * relay.exp(splitted[2])
+        return relay.Function([X, W], out)
+
+    def expected(rnn_dim):
+        p0 = relay.var("p0", shape=(1, rnn_dim))
+        p1 = relay.var("p1", shape=(3 * rnn_dim, rnn_dim))
+        matmul = relay.nn.dense(p0, p1)
+        f0 = relay.Function([p0, p1], matmul)
+
+        p01 = relay.var("p01", shape=(1, 3 * rnn_dim))
+        splitted = relay.split(p01, indices_or_sections=3, axis=1)
+        out = relay.sigmoid(splitted[0]) + relay.tanh(splitted[1]) * relay.exp(splitted[2])
+        f1 = relay.Function([p01], out)
+
+        X = relay.var("X", shape=(1, rnn_dim))
+        W = relay.var("W", shape=(3 * rnn_dim, rnn_dim))
+        y = relay.Call(f0, [X, W])
+        z = relay.Call(f1, [y])
+        return relay.Function([X, W], z)
+
+    rnn_dim = 10
+    z = before(rnn_dim)
+    z = relay.ir_pass.infer_type(z)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=0)
+    assert not relay.ir_pass.free_vars(zz)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=2)
+    zz = relay.ir_pass.infer_type(zz)
+    assert not relay.ir_pass.free_vars(zz)
+    after = relay.ir_pass.infer_type(expected(rnn_dim))
+    assert relay.ir_pass.alpha_equal(zz, after)
+
+
+def test_tuple_get_root():
+    def before(dim):
+        X = relay.var("X", shape=(1, 3 * dim))
+        W = relay.var("W", shape=(dim, dim))
+        splitted = relay.split(X, indices_or_sections=3, axis=1)
+        out = relay.nn.dense(splitted[0], W)
+        return relay.Function([X, W], out)
+
+    def expected(dim):
+        p0 = relay.var("p0", shape=(1, 3 * dim))
+        splitted = relay.split(p0, indices_or_sections=3, axis=1)
+        out = splitted[0]
+        f0 = relay.Function([p0], out)
+
+        p01 = relay.var("p01", shape=(1, dim))
+        p1 = relay.var("p1", shape=(dim, dim))
+        out = relay.nn.dense(p01, p1)
+        f1 = relay.Function([p01, p1], out)
+
+        X = relay.var("X", shape=(1, 3 * dim))
+        W = relay.var("W", shape=(dim, dim))
+        y = relay.Call(f0, [X])
+        z = relay.Call(f1, [y, W])
+        return relay.Function([X, W], z)
+
+    dim = 10
+    z = before(dim)
+    z = relay.ir_pass.infer_type(z)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=0)
+    assert not relay.ir_pass.free_vars(zz)
+    zz = relay.ir_pass.fuse_ops(z, opt_level=2)
+    zz = relay.ir_pass.infer_type(zz)
+    assert not relay.ir_pass.free_vars(zz)
+    after = relay.ir_pass.infer_type(expected(dim))
+    assert relay.ir_pass.alpha_equal(zz, after)
+
+
 if __name__ == "__main__":
     test_fuse_simple()
     test_conv2d_fuse()
@@ -295,3 +369,5 @@ if __name__ == "__main__":
     test_tuple_strided_slice()
     test_stop_fusion()
     test_fuse_myia_regression()
+    test_gru()
+    test_tuple_get_root()


### PR DESCRIPTION
A partial fix for #2890. It can enable fuse through TupleGetItem node.

Example: GRU
```
%14 = fn (%X: Tensor[(1, 10), float32], %W: Tensor[(30, 10), float32]) -> Tensor[(1, 10), float32] {
  %1 = fn (%p0: Tensor[(1, 10), float32], %p1: Tensor[(30, 10), float32], __dict__=meta[StrMap][0]) -> Tensor[(1, 30), float32] {
    %0 = nn.dense(%p0, %p1, units=None)
    %0
  }
  %2 = %1(%X, %W)
  %12 = fn (%p01: Tensor[(1, 30), float32], __dict__=meta[StrMap][1]) -> Tensor[(1, 10), float32] {
    %3 = split(%p01, indices_or_sections=int64(3), axis=1)
    %4 = %3.0
    %5 = sigmoid(%4)
    %6 = %3.1
    %7 = tanh(%6)
    %8 = %3.2
    %9 = exp(%8)
    %10 = multiply(%7, %9)
    %11 = add(%5, %10)
    %11
  }
  %13 = %12(%2)
  %13
}
``` 