### PR TITLE
[Relay] clean up hd, change tl

### DIFF
--- a/python/tvm/relay/prelude.py
+++ b/python/tvm/relay/prelude.py
@@ -29,7 +29,6 @@ class Prelude:
         x = Var("x", self.l(a))
         y = Var("y")
         z = Var("z")
-        # Don't match nil() since it will break type checking
         cons_case = Clause(PatternConstructor(self.cons, [PatternVar(y), PatternVar(z)]), y)
         self.mod[self.hd] = Function([x], Match(x, [cons_case]), a, [a])
 
@@ -43,9 +42,8 @@ class Prelude:
         x = Var("x", self.l(a))
         y = Var("y")
         z = Var("z")
-        nil_case = Clause(PatternConstructor(self.nil, []), self.nil())
         cons_case = Clause(PatternConstructor(self.cons, [PatternVar(y), PatternVar(z)]), z)
-        self.mod[self.tl] = Function([x], Match(x, [nil_case, cons_case]), self.l(a), [a])
+        self.mod[self.tl] = Function([x], Match(x, [cons_case]), self.l(a), [a])
 
     def define_list_nth(self):
         """Defines a function to get the nth element of a list.


### PR DESCRIPTION
the comment for hd is wrong - type checking fail because it should (there is no sensible match)
and I strongly argue against having a nil_case for tl that return silently:
0: it is bad to silent error and return a 'very innocent value'. suppose tl actually got passed a nil somewhere in code. it will return a nil, and it will continue execution as if everything is normal (because nil is completely normal in list (it does not mean null)). it might trigger more silent error, returning more and more 'nil', and in the end you get the wrong value. Now this is extremely hard to debug, as you can not know which nil is 'nil because of failed tl match' or 'nil because it denote a completely normal empty list'. 
1: it is not how tl/cdr is defined in scheme/ocaml/haskell/etc. it will confuse people.

@wweic does this sounds reasonable to you?