### PR TITLE
[Debug Graph Runtime] Export TVM DebugResult trace to Chrome Tracing format

### DIFF
--- a/python/tvm/contrib/debugger/debug_runtime.py
+++ b/python/tvm/contrib/debugger/debug_runtime.py
@@ -220,7 +220,9 @@ class GraphModuleDebug(graph_runtime.GraphModule):
         self._run_debug()
         # Step 2. Dump the output tensors to the dump folder
         self.debug_datum.dump_output_tensor()
-        # Step 3. Display the collected information
+        # Step 3. Dump the Chrome trace to the dump folder
+        self.debug_datum.dump_chrome_trace()
+        # Step 4. Display the collected information
         self.debug_datum.display_debug_result()
 
     def run_individual(self, number, repeat=1, min_repeat_ms=0):

--- a/tests/python/unittest/test_runtime_graph_debug.py
+++ b/tests/python/unittest/test_runtime_graph_debug.py
@@ -64,6 +64,22 @@ def test_graph_simple():
         #Verify the tensors are dumped
         assert(len(os.listdir(directory)) > 1)
 
+        CHROME_TRACE_FILE_NAME = '_tvmdbg_execution_trace.json'
+        assert(os.path.exists(os.path.join(directory, CHROME_TRACE_FILE_NAME)))
+
+        with open(os.path.join(directory, CHROME_TRACE_FILE_NAME)) as f:
+            trace = json.load(f)
+        assert trace["displayTimeUnit"] == "ns"
+        events = trace["traceEvents"]
+        assert len(events) == 4
+        assert all(event["ph"] in ('B', 'E') for event in events)
+        assert all(event["pid"] == 1 for event in events)
+        assert all(event["tid"] == 1 for event in events)
+        assert all(event["name"] == 'x' for event in events[:2])
+        assert all(event["name"] == 'add' for event in events[2:])
+        assert events[0]["ts"] == 0
+        assert events[0]["ph"] == 'B'
+
         #verify the output is correct
         out = mod.get_output(0, tvm.nd.empty((n,)))
         np.testing.assert_equal(out.asnumpy(), a + 1)


### PR DESCRIPTION
[The trace viewer in `chrome://tracing/`](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool) (for Chrome users) is a useful tool for analysing profile traces. This is a simple diff to export node spans to the Chrome Tracing format (documented https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/), to enable easy analysis. 

The output in tracing (for the model in the unit test) looks like:

<img width="1399" alt="Screenshot 2019-03-28 16 31 32" src="https://user-images.githubusercontent.com/1121581/55199329-f9c5ee80-5176-11e9-847c-b16f420c172b.png">
