### PR TITLE
Fix makedirs() condition in contrib.

### DIFF
--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -59,7 +59,7 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
     # Stateful start time
     start_time = time.time()
     dirpath = os.path.dirname(path)
-    if not os.path.isdir(dirpath):
+    if os.path.isdir(dirpath):
         os.makedirs(dirpath)
     random_uuid = str(uuid.uuid4())
     tempfile = os.path.join(dirpath, random_uuid)


### PR DESCRIPTION
Fixes  creation of folder path when using contrib.download module.

