### PR TITLE
[TEXPR][PASS] Fix thread all reduce to avoid write after read hazzard

### DIFF
--- a/src/pass/lower_thread_allreduce.cc
+++ b/src/pass/lower_thread_allreduce.cc
@@ -175,6 +175,9 @@ class ThreadAllreduceBuilder final : public IRMutator {
     }
     std::vector<Stmt> seq;
     std::vector<Var> shared_bufs(size);
+    // This sync is necessary because there might be incomplete read of
+    // previous iteration on the same buffer.
+    seq.emplace_back(SyncThread("shared"));
     for (size_t idx = 0; idx < size; ++idx) {
       shared_bufs[idx] = Var("red_buf"+std::to_string(idx), Handle());
       Expr pred = const_true(types[idx].lanes());


### PR DESCRIPTION
The bug was rare but can affect some of the code. Insert explicit sync before write to shared memory in thread_allreduce

```c++
__shared__ sbuf[65]
loop:
    // need add sync here, before the read may not yet finished.
    __syncthreads();
    sbuf[threadIdx.x] = x
    // all reduce code ...
    // read
    result = sbuf[0]
```
