### PR TITLE
Fix makedirs() condition in contrib.

### DIFF
--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -59,7 +59,7 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
     # Stateful start time
     start_time = time.time()
     dirpath = os.path.dirname(path)
-    if not os.path.isdir(dirpath):
+    if dirpath and not os.path.isdir(dirpath):
         os.makedirs(dirpath)
     random_uuid = str(uuid.uuid4())
     tempfile = os.path.join(dirpath, random_uuid)


### PR DESCRIPTION
This fix contrib.download when only the filename is specified as destination.


* See the failure and debug below:
```
------------->>>>> tvm/contrib/download.py <<<<--------------
    dirpath = os.path.dirname(path)
    print ("DBG: dirpath:[%s] path:[%s]" % (dirpath,path))
    if not os.path.isdir(dirpath):
        print ("DBG: not os.path.isdir(dirpath) is [True]")
        os.makedirs(dirpath)
-------------<<<<< tvm/contrib/download.py >>>>--------------

[cbalint@tune]$ ./test_tune.py 
Downloading from url https://sample.com/nn/my.weights to my.weights
DBG: dirpath:[] path:[my.weights]
DBG: not os.path.isdir(dirpath) is [True]

Traceback (most recent call last):
  File "./test_tune.py", line 137, in <module>
    download(WEIGHTS_URL, WEIGHTS_NAME)
  File "/usr/lib64/python3.7/site-packages/tvm/contrib/download.py", line 65, in download
    os.makedirs(dirpath)
  File "/usr/lib64/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```
