### PR TITLE
Fix Tutorial Examples

### DIFF
--- a/tutorials/frontend/deploy_ssd_gluoncv.py
+++ b/tutorials/frontend/deploy_ssd_gluoncv.py
@@ -4,7 +4,18 @@ Deploy Single Shot Multibox Detector(SSD) model
 **Author**: `Yao Wang <https://github.com/kevinthesun>`_
 
 This article is an introductory tutorial to deploy SSD models with TVM.
-We will use GluonCV pre-trained SSD model and convert it to Relay IR
+We will use GluonCV pre-trained SSD model and convert it to Relay IR.
+
+For us to begin with, GluonCV module is required to be installed.
+
+A quick solution is to install via pip
+
+.. code-block:: bash
+
+    pip install -U gluoncv --user
+
+or please refer to official site
+https://github.com/dmlc/gluon-cv/
 """
 import tvm
 

--- a/tutorials/frontend/deploy_ssd_gluoncv.py
+++ b/tutorials/frontend/deploy_ssd_gluoncv.py
@@ -12,7 +12,7 @@ from matplotlib import pyplot as plt
 from tvm.relay.testing.config import ctx_list
 from tvm import relay
 from tvm.contrib import graph_runtime
-from tvm.contrib.download import download_testdata
+from tvm.contrib.download import download
 from gluoncv import model_zoo, data, utils
 
 
@@ -50,9 +50,10 @@ target_list = ctx_list()
 ######################################################################
 # Download and pre-process demo image
 
-im_fname = download_testdata('https://github.com/dmlc/web-data/blob/master/' +
-                             'gluoncv/detection/street_small.jpg?raw=true',
-                             'street_small.jpg', module='data')
+im_fname = 'street_small.jpg'
+download('https://github.com/dmlc/web-data/blob/master/' +
+         'gluoncv/detection/street_small.jpg?raw=true',
+         im_fname)
 x, img = data.transforms.presets.ssd.load_test(im_fname, short=512)
 
 ######################################################################

--- a/tutorials/frontend/from_caffe2.py
+++ b/tutorials/frontend/from_caffe2.py
@@ -37,12 +37,13 @@ resnet50 = Model('resnet50')
 # Load a test image
 # ------------------
 # A single cat dominates the examples!
-from tvm.contrib.download import download_testdata
+from tvm.contrib.download import download
 from PIL import Image
 from matplotlib import pyplot as plt
 import numpy as np
 img_url = 'https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true'
-img_path = download_testdata(img_url, 'cat.png', module='data')
+img_path = 'cat.png'
+download(img_url, img_path)
 img = Image.open(img_path).resize((224, 224))
 plt.imshow(img)
 plt.show()
@@ -105,8 +106,8 @@ synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',
                       'imagenet1000_clsid_to_human.txt'])
 synset_name = 'imagenet1000_clsid_to_human.txt'
-synset_path = download_testdata(synset_url, synset_name, module='data')
-with open(synset_path) as f:
+download(synset_url, synset_name)
+with open(synset_name) as f:
     synset = eval(f.read())
 print('Relay top-1 id: {}, class name: {}'.format(top1_tvm, synset[top1_tvm]))
 # confirm correctness with caffe2 output

--- a/tutorials/frontend/from_coreml.py
+++ b/tutorials/frontend/from_coreml.py
@@ -84,7 +84,7 @@ synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',
                       'imagenet1000_clsid_to_human.txt'])
 synset_name = 'imagenet1000_clsid_to_human.txt'
-synset_path = download_testdata(synset_url, synset_name, module='data')
-with open(synset_path) as f:
+download_testdata(synset_url, synset_name)
+with open(synset_name) as f:
     synset = eval(f.read())
 print('Top-1 id', top1, 'class name', synset[top1])

--- a/tutorials/frontend/from_coreml.py
+++ b/tutorials/frontend/from_coreml.py
@@ -19,7 +19,7 @@ https://github.com/apple/coremltools
 """
 import tvm
 import tvm.relay as relay
-from tvm.contrib.download import download_testdata
+from tvm.contrib.download import download
 import coremltools as cm
 import numpy as np
 from PIL import Image
@@ -31,17 +31,18 @@ from PIL import Image
 # provided by apple in this example
 model_url = 'https://docs-assets.developer.apple.com/coreml/models/MobileNet.mlmodel'
 model_file = 'mobilenet.mlmodel'
-model_path = download_testdata(model_url, model_file, module='coreml')
+download(model_url, model_file)
 # Now you have mobilenet.mlmodel on disk
-mlmodel = cm.models.MLModel(model_path)
+mlmodel = cm.models.MLModel(model_file)
 
 ######################################################################
 # Load a test image
 # ------------------
 # A single cat dominates the examples!
 img_url = 'https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true'
-img_path = download_testdata(img_url, 'cat.png', module='data')
-img = Image.open(img_path).resize((224, 224))
+img_file = 'cat.png'
+download(img_url, img_file)
+img = Image.open(img_file).resize((224, 224))
 x = np.transpose(img, (2, 0, 1))[np.newaxis, :]
 
 ######################################################################

--- a/tutorials/frontend/from_keras.py
+++ b/tutorials/frontend/from_keras.py
@@ -20,7 +20,7 @@ https://keras.io/#installation
 """
 import tvm
 import tvm.relay as relay
-from tvm.contrib.download import download_testdata
+from tvm.contrib.download import download
 import keras
 import numpy as np
 
@@ -31,10 +31,10 @@ import numpy as np
 weights_url = ''.join(['https://github.com/fchollet/deep-learning-models/releases/',
                        'download/v0.2/resnet50_weights_tf_dim_ordering_tf_kernels.h5'])
 weights_file = 'resnet50_weights.h5'
-weights_path = download_testdata(weights_url, weights_file, module='keras')
+download(weights_url, weights_file)
 keras_resnet50 = keras.applications.resnet50.ResNet50(include_top=True, weights=None,
                                                       input_shape=(224, 224, 3), classes=1000)
-keras_resnet50.load_weights(weights_path)
+keras_resnet50.load_weights(weights_file)
 
 ######################################################################
 # Load a test image
@@ -44,8 +44,9 @@ from PIL import Image
 from matplotlib import pyplot as plt
 from keras.applications.resnet50 import preprocess_input
 img_url = 'https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true'
-img_path = download_testdata(img_url, 'cat.png', module='data')
-img = Image.open(img_path).resize((224, 224))
+img_file = 'cat.png'
+download(img_url, img_file)
+img = Image.open(img_file).resize((224, 224))
 plt.imshow(img)
 plt.show()
 # input preprocess
@@ -81,7 +82,7 @@ synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',
                       'imagenet1000_clsid_to_human.txt'])
 synset_name = 'imagenet1000_clsid_to_human.txt'
-synset_path = download_testdata(synset_url, synset_name, module='data')
+synset_path = download_testdata(synset_url, synset_name)
 with open(synset_path) as f:
     synset = eval(f.read())
 print('Relay top-1 id: {}, class name: {}'.format(top1_tvm, synset[top1_tvm]))

--- a/tutorials/frontend/from_keras.py
+++ b/tutorials/frontend/from_keras.py
@@ -82,8 +82,8 @@ synset_url = ''.join(['https://gist.githubusercontent.com/zhreshold/',
                       '596b27d23537e5a1b5751d2b0481ef172f58b539/',
                       'imagenet1000_clsid_to_human.txt'])
 synset_name = 'imagenet1000_clsid_to_human.txt'
-synset_path = download_testdata(synset_url, synset_name)
-with open(synset_path) as f:
+download(synset_url, synset_name)
+with open(synset_name) as f:
     synset = eval(f.read())
 print('Relay top-1 id: {}, class name: {}'.format(top1_tvm, synset[top1_tvm]))
 # confirm correctness with keras output

--- a/tutorials/frontend/from_onnx.py
+++ b/tutorials/frontend/from_onnx.py
@@ -20,7 +20,7 @@ import onnx
 import numpy as np
 import tvm
 import tvm.relay as relay
-from tvm.contrib.download import download_testdata
+from tvm.contrib.download import download
 
 ######################################################################
 # Load pretrained ONNX model
@@ -32,7 +32,8 @@ model_url = ''.join(['https://gist.github.com/zhreshold/',
                      'bcda4716699ac97ea44f791c24310193/raw/',
                      '93672b029103648953c4e5ad3ac3aadf346a4cdc/',
                      'super_resolution_0.2.onnx'])
-model_path = download_testdata(model_url, 'super_resolution.onnx', module='onnx')
+model_path = 'super_resolution.onnx'
+download(model_url, model_path)
 # now you have super_resolution.onnx on disk
 onnx_model = onnx.load(model_path)
 
@@ -42,7 +43,8 @@ onnx_model = onnx.load(model_path)
 # A single cat dominates the examples!
 from PIL import Image
 img_url = 'https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true'
-img_path = download_testdata(img_url, 'cat.png', module='data')
+img_path = 'cat.png'
+download(img_url, img_path)
 img = Image.open(img_path).resize((224, 224))
 img_ycbcr = img.convert("YCbCr")  # convert to YCbCr
 img_y, img_cb, img_cr = img_ycbcr.split()


### PR DESCRIPTION
Some tutorial examples were not working because download_testdata() API seems to have been changed to download(). After those changes, the examples should be now working.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
