### PR TITLE
fix undefined reference to dlopen, etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ include_directories("3rdparty/compiler-rt")
 
 # initial variables
 set(TVM_LINKER_LIBS "")
-set(TVM_RUNTIME_LINKER_LIBS "")
+set(TVM_RUNTIME_LINKER_LIBS ${CMAKE_DL_LIBS})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Generic compilation options


### PR DESCRIPTION
Occasionally seeing complaints in the discussion forum about the following error:

```
libtvm.so: undefined reference to `dlopen'
libtvm.so: undefined reference to `dlclose'
libtvm.so: undefined reference to `dlerror'
libtvm.so: undefined reference to `dlsym'
```

This is due to missing `-ldl` when using compilers like clang. The more cmake way to address this should be adding the ${CMAKE_DL_LIBS} flag directly.

CC: @icemelon9 