### PR TITLE
[tvm4j] provide error msg for failure function call

### DIFF
--- a/jvm/native/src/main/native/ml_dmlc_tvm_native_c_api.cc
+++ b/jvm/native/src/main/native/ml_dmlc_tvm_native_c_api.cc
@@ -178,6 +178,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_tvm_LibInfo_tvmFuncCall(
   int ret = TVMFuncCall(reinterpret_cast<TVMFunctionHandle>(jhandle),
     &argValues[0], &argTypes[0], numArgs, &retVal, &retTypeCode);
 
+  if (ret != 0) {
+    return ret;
+  }
+
   for (auto iter = pushedStrs.cbegin(); iter != pushedStrs.cend(); iter++) {
     env->ReleaseStringUTFChars(iter->first, iter->second);
     env->DeleteGlobalRef(iter->first);


### PR DESCRIPTION
This is to resolve the problem that people always see things like "Do NOT know how to handle return type code 28672" in tvm4j. If function call fails, it should return immediately so that the wrapper can get the last error message, otherwise it would fail in `tvmRetValueToJava`. @tqchen 