### PR TITLE
Vendor gtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "3rdparty/rang"]
 	path = 3rdparty/rang
 	url = https://github.com/agauniyal/rang
+[submodule "3rdparty/gtest"]
+	path = 3rdparty/gtest
+	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,21 +223,25 @@ target_include_directories(
 # Tests
 set(TEST_EXECS "")
 file(GLOB TEST_SRCS tests/cpp/*.cc)
-find_library(GTEST_LIB gtest "$ENV{GTEST_LIB}")
 
-if(GTEST_LIB)
-  foreach(__srcpath ${TEST_SRCS})
-    get_filename_component(__srcname ${__srcpath} NAME)
-    string(REPLACE ".cc" "" __execname ${__srcname})
-    add_executable(${__execname} ${__srcpath})
-    list(APPEND TEST_EXECS ${__execname})
-    target_link_libraries(${__execname}
-      tvm ${GTEST_LIB} pthread dl)
-    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
-    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
-  endforeach()
-  add_custom_target(cpptest DEPENDS ${TEST_EXECS})
-endif()
+add_subdirectory(3rdparty/gtest)
+set_target_properties(gtest PROPERTIES EXCLUDE_FROM_ALL 1)
+set_target_properties(gtest PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+set_target_properties(gtest_main PROPERTIES EXCLUDE_FROM_ALL 1)
+set_target_properties(gtest_main PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+
+foreach(__srcpath ${TEST_SRCS})
+  get_filename_component(__srcname ${__srcpath} NAME)
+  string(REPLACE ".cc" "" __execname ${__srcname})
+  add_executable(${__execname} ${__srcpath})
+  list(APPEND TEST_EXECS ${__execname})
+  target_link_libraries(${__execname}
+    tvm gtest pthread dl)
+  set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
+  set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+  target_include_directories(${__execname} PRIVATE 3rdparty/gtest/include)
+endforeach()
+add_custom_target(cpptest DEPENDS ${TEST_EXECS})
 
 # Custom targets
 add_custom_target(runtime DEPENDS tvm_runtime)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.2)
 project(tvm C CXX)
 
+# Does this fix the jenkins issue?
+get_filename_component(CMAKE_CXX_COMPILER "${CMAKE_CXX_COMPILER}" REALPATH BASE_DIR "/" CACHE)
+# Log for debugging
+message(STATUS path $ENV{PATH})
+
 # Utility functions
 include(cmake/util/Util.cmake)
 include(cmake/util/FindCUDA.cmake)

--- a/docs/contribute/pull_request.rst
+++ b/docs/contribute/pull_request.rst
@@ -61,17 +61,8 @@ C++
   # assume you are in tvm source root
   TVM_ROOT=`pwd`
 
-  # you need to install google test first, gtest will be installed to $TVM_ROOT/lib
-  apt-get install -y libgtest-dev
-  CACHE_PREFIX=. make -f 3rdparty/dmlc-core/scripts/packages.mk gtest
-
-  mkdir build
-  cd build
-  GTEST_LIB=$TVM_ROOT/lib cmake -DUSE_LLVM=ON ..
-  make cpptest -j$(nproc)
-  for test in *_test; do
-    ./$test
-  done
+  # build + run all cpp tests
+  ./tests/scripts/task_cpp_unittest.sh
 
 Python
 ^^^^^^

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -30,7 +30,6 @@ if [ ${TASK} == "verilog_test" ] || [ ${TASK} == "all_test" ]; then
 fi
 
 if [ ${TASK} == "cpp_test" ] || [ ${TASK} == "all_test" ]; then
-    make -f dmlc-core/scripts/packages.mk gtest
     ./tests/scripts/task_cpp_unittest.sh || exit -1
 fi
 


### PR DESCRIPTION
This PR adds googletest as a submodule to make it easier for new contributors to run tests; it's challenging to globally install googletest on OS X, this makes things a little simpler. It's a small download (5mb), a fast build (like 5 seconds), and has a permissive license, so i don't forsee this causing problems. Of course, it is another vendored dependency, so if people don't think it's worth it I understand.

I used the 1.7.0 release tag since that was what travis seemed to be using.
