### PR TITLE
[Relay][RFC][Fix] Rename RelayPrint to AsText

### DIFF
--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -562,16 +562,16 @@ inline const TTypeNode* ExprNode::type_as() const {
 }
 
 /*!
- * \brief Print node as text format.
- * \param node The node to be printed.
+ * \brief Render the node as a string in the Relay text format.
+ * \param node The node to be rendered.
  * \param show_meta_data Whether to print meta data section.
  * \param annotate An optional callback function for attaching
  *        additional comment block to an expr.
  * \return The text representation.
  */
-std::string RelayPrint(const NodeRef& node,
-                       bool show_meta_data = true,
-                       runtime::TypedPackedFunc<std::string(Expr)> annotate = nullptr);
+std::string AsText(const NodeRef& node,
+                    bool show_meta_data = true,
+                    runtime::TypedPackedFunc<std::string(Expr)> annotate = nullptr);
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_EXPR_H_

--- a/python/tvm/relay/base.py
+++ b/python/tvm/relay/base.py
@@ -78,7 +78,7 @@ class RelayNode(NodeBase):
         text : str
             The text format of the expression.
         """
-        return _expr.RelayPrint(self, show_meta_data, annotate)
+        return _expr.AsText(self, show_meta_data, annotate)
 
     def set_span(self, span):
         _base.set_span(self, span)

--- a/src/relay/ir/error.cc
+++ b/src/relay/ir/error.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -110,7 +110,7 @@ void ErrorReporter::RenderErrors(const Module& module, bool use_color) {
     //
     // The annotation callback will annotate the error messages
     // contained in the map.
-    annotated_prog << RelayPrint(func, false, [&err_map](tvm::relay::Expr expr) {
+    annotated_prog << AsText(func, false, [&err_map](tvm::relay::Expr expr) {
       auto it = err_map.find(expr);
       if (it != err_map.end()) {
         return it->second;

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -709,9 +709,9 @@ std::string PrettyPrint_(const NodeRef& node,
   return doc.str();
 }
 
-std::string RelayPrint(const NodeRef& node,
-                       bool show_meta_data,
-                       runtime::TypedPackedFunc<std::string(Expr)> annotate) {
+std::string AsText(const NodeRef& node,
+                    bool show_meta_data,
+                    runtime::TypedPackedFunc<std::string(Expr)> annotate) {
   return PrettyPrint_(node, show_meta_data, annotate, true);
 }
 
@@ -722,7 +722,7 @@ std::string PassDebugPrint(const NodeRef& node,
   return PrettyPrint_(node, show_meta_data, annotate, gnf);
 }
 
-TVM_REGISTER_API("relay._expr.RelayPrint")
+TVM_REGISTER_API("relay._expr.AsText")
 .set_body_typed<std::string(const NodeRef&,
                             bool,
                             runtime::TypedPackedFunc<std::string(Expr)>)>(RelayPrint);

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -725,7 +725,7 @@ std::string PassDebugPrint(const NodeRef& node,
 TVM_REGISTER_API("relay._expr.AsText")
 .set_body_typed<std::string(const NodeRef&,
                             bool,
-                            runtime::TypedPackedFunc<std::string(Expr)>)>(RelayPrint);
+                            runtime::TypedPackedFunc<std::string(Expr)>)>(AsText);
 
 TVM_REGISTER_API("relay._ir_pass.pass_debug_print")
 .set_body_typed<std::string(const NodeRef&,

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -890,7 +890,7 @@ class FuseMutator : private ExprMutator {
 
   // Debug function, dump the group assignment in text.
   void DebugDumpGroup(const Expr& body) {
-    std::string text = RelayPrint(body, false, [this](const Expr& expr) -> std::string {
+    std::string text = AsText(body, false, [this](const Expr& expr) -> std::string {
         auto it = gmap_.find(expr.get());
         if (it == gmap_.end()) return "";
         std::ostringstream os;


### PR DESCRIPTION
Change the name of RelayPrint to AsText to mirror the higher level API (see #2955).