### PR TITLE
[Relay][WIP] Make dense.py broadcast.

### DIFF
--- a/topi/python/topi/nn/dense.py
+++ b/topi/python/topi/nn/dense.py
@@ -26,7 +26,7 @@ def dense_default(data, weight, bias=None):
     ----------
     data : tvm.Tensor
         Tensor with shape [batch0, batch1, batch2..., in_dim]
-    
+
     weight : tvm.Tensor
         2-D with shape [out_dim, in_dim]
 


### PR DESCRIPTION
so in MXnet, dense broadcast, and relay's doc for dense/typerel all support broadcast for dense too.
This add broadcast to the actual compute so it work.

However, this pr does not do the job, as there is many other dense file (x86, cuda). cuda seems to dont support broadcast dense, and I have no idea how to do schedule for this.

@eqy @tqchen @jroesch @ZihengJiang can you guys help?