### PR TITLE
[AutoTVM] Fix typos

### DIFF
--- a/tutorials/autotvm/tune_simple_template.py
+++ b/tutorials/autotvm/tune_simple_template.py
@@ -63,7 +63,7 @@ from tvm import autotvm
 # --------------------------------
 # In this section, we will rewrite a deterministic tvm schedule code to a
 # tunable schedule template. You can regard the process of search space definition
-# as the parametrization of our exiting schedule code.
+# as the parametrization of our existing schedule code.
 #
 # To begin with, here is how we implement a blocked matrix multiplication in tvm.
 


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

I found a typo in the docs of autotvm here: https://docs.tvm.ai/tutorials/autotvm/tune_simple_template.html#step-1-define-the-search-space

While I am not sure if it works with such a comment-fix.