### PR TITLE
Update dmlc-core, fix default ctors of NodeEntry 

### DIFF
--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -56,7 +56,7 @@ struct NodeEntry {
     version(version)
   {}
 
-  NodeEntry(NodePtr node):
+  explicit NodeEntry(NodePtr node):
     node(std::move(node)),
     index(),
     version()

--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -62,6 +62,10 @@ struct NodeEntry {
     version()
   {}
 
+  /**
+   * MXNet assumes that a node with a null ptr doesn't have a gradient attached. Don't change this
+   * constructor.
+   */
   NodeEntry():
     node(nullptr),
     index(),

--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -63,7 +63,7 @@ struct NodeEntry {
   {}
 
   NodeEntry():
-    node(std::make_shared<Node>()),
+    node(nullptr),
     index(),
     version()
   {}

--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -56,8 +56,14 @@ struct NodeEntry {
     version(version)
   {}
 
+  NodeEntry(NodePtr node):
+    node(std::move(node)),
+    index(),
+    version()
+  {}
+
   NodeEntry():
-    node(),
+    node(std::make_shared<Node>()),
     index(),
     version()
   {}


### PR DESCRIPTION
MXNet uses nullptr to designate a node in which autograd is not enabled.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
