### PR TITLE
[Relay] fix PostOrderVisit declaration

### DIFF
--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -235,7 +235,7 @@ class ExprMutator
  * \param node The ir to be visited.
  * \param fvisit The visitor function to be applied.
  */
-void PostOrderVisit(const NodeRef& node, std::function<void(const NodeRef&)> fvisit);
+void PostOrderVisit(const Expr& node, std::function<void(const Expr&)> fvisit);
 
 /*
  * \brief Bind function parameters or free variables.


### PR DESCRIPTION
Just a minor fix to the function signature. I believe this is a copy-paste bug.
[PostOrderVisit](https://github.com/dmlc/tvm/blob/master/src/relay/ir/expr_functor.cc#L344) function is now public.

please review @jroesch @MarisaKirisame @tqchen  
 
