### PR TITLE
[Relay, OpFusion] Prevent returning a tuple from a fused function 

### DIFF
--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -748,10 +748,10 @@ class RemoveRootTupleVisitor : ExprVisitor {
   void VisitExpr_(const TupleNode* tuple) {
     const GraphPartitioner::Group* tuple_group = gmap_.at(tuple)->FindRoot();
     if (tuple_group == gmap_.at(tuple)) {
-      IndexedForwardGraph::Node* tuple_node = graph_->node_map[tuple];
+      IndexedForwardGraph::Node* tuple_node = graph_->node_map.at(tuple);
       tuple_node->pattern = kOpaque;
       for (auto field : tuple->fields) {
-        IndexedForwardGraph::Node* tuple_filed_node = graph_->node_map[field.get()];
+        IndexedForwardGraph::Node* tuple_filed_node = graph_->node_map.at(field.get());
         tuple_filed_node->extern_ref = true;
       }
     }

--- a/tests/python/relay/test_backend_compile_engine.py
+++ b/tests/python/relay/test_backend_compile_engine.py
@@ -69,8 +69,16 @@ def test_compile_injective_with_tuple():
     relay.build(func, 'llvm')
 
 
+def test_compile_tuple_dup():
+    x = relay.var("data", shape=(16, 16))
+    log = relay.log(x)
+    output = relay.Tuple([log, log])
+    f = relay.Function([x], output)
+    relay.build(f, 'llvm')
+
+
 if __name__ == "__main__":
     test_compile_engine()
     test_compile_placeholder_bypass()
     test_compile_injective_with_tuple()
-
+    test_compile_tuple_dup()

--- a/tests/python/relay/test_pass_fuse_ops.py
+++ b/tests/python/relay/test_pass_fuse_ops.py
@@ -176,54 +176,16 @@ def test_tuple_root():
         f0 = relay.Function([x], pooled)
 
         p0 = relay.var("p0", shape=(dshape[0], dshape[1], dshape[2]//2, dshape[3]//2))
-        p1 = relay.var("p1", shape=(dshape[0], dshape[1], dshape[2], dshape[3]))
-        p1_copy = relay.copy(p1)
         upsampled = relay.nn.upsampling(p0, scale=2, layout="NCHW")
-        out = relay.Tuple((upsampled, p1_copy))
-        f1 = relay.Function([p0, p1], out)
+        f1 = relay.Function([p0], upsampled)
 
         x = relay.var("x", shape=dshape)
         y = relay.Call(f0, [x])
-        z = relay.Call(f1, [y, x])
-        return relay.Function([x], z)
+        z = relay.Call(f1, [y])
+        tup = relay.Tuple((z, x))
+        return relay.Function([x], tup)
 
     dshape = (1, 16, 64, 64)
-    z = before(dshape)
-    z = relay.ir_pass.infer_type(z)
-    zz = relay.ir_pass.fuse_ops(z, opt_level=0)
-    assert not relay.ir_pass.free_vars(zz)
-    zz = relay.ir_pass.fuse_ops(z, opt_level=2)
-    zz = relay.ir_pass.infer_type(zz)
-    assert not relay.ir_pass.free_vars(zz)
-    after = relay.ir_pass.infer_type(expected(dshape))
-    assert relay.ir_pass.alpha_equal(zz, after)
-
-
-def test_tuple_strided_slice():
-    """
-    Test fusion case where the number of fields of tuple and
-    the number of parameters to the function containing the tuple are different
-    """
-
-    def before(dshape):
-        x = relay.var("x", shape=dshape)
-        slice1 = relay.strided_slice(x, begin=[0, 0], end=[dshape[1]//2, dshape[1]], strides=[1,1])
-        slice2 = relay.strided_slice(x, begin=[dshape[1]//2, 0], end=[dshape[0], dshape[1]], strides=[1,1])
-        out = relay.Tuple((slice1, slice2))
-        return relay.Function([x], out)
-
-    def expected(dshape):
-        x = relay.var("x", shape=dshape)
-        slice1 = relay.strided_slice(x, begin=[0, 0], end=[dshape[1]//2, dshape[1]], strides=[1,1])
-        slice2 = relay.strided_slice(x, begin=[dshape[1]//2, 0], end=[dshape[0], dshape[1]], strides=[1,1])
-        out = relay.Tuple((slice1, slice2))
-        f0 = relay.Function([x], out)
-
-        x = relay.var("x", shape=dshape)
-        y = relay.Call(f0, [x])
-        return relay.Function([x], y)
-
-    dshape = (64, 64)
     z = before(dshape)
     z = relay.ir_pass.infer_type(z)
     zz = relay.ir_pass.fuse_ops(z, opt_level=0)
@@ -382,7 +344,6 @@ if __name__ == "__main__":
     test_conv2d_fuse()
     test_concatenate()
     test_tuple_root()
-    test_tuple_strided_slice()
     test_stop_fusion()
     test_fuse_myia_regression()
     test_fuse_tuple_get_elemwise()


### PR DESCRIPTION
See #3039 for the context. This is my take on fixing tuple fusion.

* a tuple that is an intermediate value in its group can be fused. [The existing test case](https://github.com/dmlc/tvm/blob/master/tests/python/relay/test_pass_fuse_ops.py#L123) passes unmodified.

* a tuple that is the root in its group is lifted out of a subfunction. Before this PR, the tuple is the return value of the subfunction

Here is the approach:
* First, tuples are marked as Injective so that they can be fused as much as possible.
* After fusion step, chech if there are tuples that are roots in their groups
* Update the data flow graph to detach root tuples from predecessors
* Run DomTree construction and fusion step again. The tuples are no longer roots.

Please review @tqchen @zhiics @vinx13 @MarisaKirisame 

