### PR TITLE
Improved FFI error messages

### DIFF
--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -49,7 +49,17 @@ else:
 def _load_lib():
     """Load libary by searching possible path."""
     lib_path = libinfo.find_lib_path()
-    lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
+    try:
+      lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
+    except:
+      # Add user-friendly error messages
+      sys.stderr.write('Got an error while loading TVM library from {}:\n\n'.format(lib_path[0]))
+      sys.stderr.write(
+          'Please consider updating environment variable TVM_LIBRARY_PATH to the right position,\n'
+          'or checking https://github.com/dmlc/tvm/issues/281 for more information '
+          'about which paths TVM will look up for its libraries.\n\n')
+      raise
+
     # DMatrix functions
     lib.TVMGetLastError.restype = ctypes.c_char_p
     return lib, os.path.basename(lib_path[0])

--- a/python/tvm/_ffi/base.py
+++ b/python/tvm/_ffi/base.py
@@ -50,15 +50,16 @@ def _load_lib():
     """Load libary by searching possible path."""
     lib_path = libinfo.find_lib_path()
     try:
-      lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
+        lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
     except:
-      # Add user-friendly error messages
-      sys.stderr.write('Got an error while loading TVM library from {}:\n\n'.format(lib_path[0]))
-      sys.stderr.write(
-          'Please consider updating environment variable TVM_LIBRARY_PATH to the right position,\n'
-          'or checking https://github.com/dmlc/tvm/issues/281 for more information '
-          'about which paths TVM will look up for its libraries.\n\n')
-      raise
+        # Add user-friendly error messages
+        sys.stderr.write('Got an error while loading TVM library from {}:\n\n'.format(lib_path[0]))
+        sys.stderr.write(
+            'Please consider updating environment variable TVM_LIBRARY_PATH '
+            'to the right position,\n'
+            'or checking https://github.com/dmlc/tvm/issues/281 for more information '
+            'about which paths TVM will look up for its libraries.\n\n')
+        raise
 
     # DMatrix functions
     lib.TVMGetLastError.restype = ctypes.c_char_p


### PR DESCRIPTION
Hello,

This is a tentative improvement for the library loading routine in the `_ffi` module.

Issues (e.g. caused by loading `libtvm.so` from an unexpected path)  might be hard to understand and fix without explicitly mention the solution while the exception is being raised.

An exemplary error message after adopting this PR will be:

```
Got an error while loading TVM library from [ERROR_PATH]/libtvm.so:

Please consider updating environment variable TVM_LIBRARY_PATH to the right position,
or checking https://github.com/dmlc/tvm/issues/281 for more information about which paths TVM will look up for its libraries.

Traceback (most recent call last):
   [OMITTED]
    self._handle = _dlopen(self._name, mode)
OSError: [ERROR_PATH]/libtvm.so: undefined symbol: [OMITTED]
```

Please do not hesitate to let me know about any improvement I should make. Thanks!

@tqchen A review from you will be really appreciated 