### PR TITLE
Fix bug in ONNX importer

### DIFF
--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -944,7 +944,10 @@ class GraphProto(object):
                                               dtype=self._params[i_name].dtype)
             else:
                 self._num_input += 1
-                tshape = self._shape[i_name] if i_name in self._shape else ()
+                if i_name in self._shape:
+                    tshape = self._shape[i_name]
+                else:
+                    raise ValueError("Must provide an input shape for `{0}`.".format(i_name))
                 if isinstance(self._dtype, dict):
                     dtype = self._dtype[i_name] if i_name in self._dtype else d_type
                 else:

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -694,10 +694,15 @@ def verify_constantfill(is_shape, input_dim, out_dim, value, dtype, **kwargs):
     else:
         fill_node = helper.make_node("ConstantFill", ["input_a"], ["out"], value=value, dtype=dtype, **kwargs)
 
+    if is_shape == True:
+        inputs = []
+    else:
+        inputs = [helper.make_tensor_value_info("input_a",
+                  TensorProto.FLOAT, list(input_dim))]
+
     graph = helper.make_graph([fill_node],
                               "fill_test",
-                              inputs = [helper.make_tensor_value_info("input_a",
-                                            TensorProto.FLOAT, list(input_dim))],
+                              inputs,
                               outputs = [helper.make_tensor_value_info("out",
                                             TensorProto.FLOAT, list(out.shape))])
 


### PR DESCRIPTION
Fixes small bug in the ONNX importer that is very confusing, fix for #3079. 

The importer previously would default to scalars when input shapes were not provided. This instead requires the user to explicitly provide all input shapes.


