### PR TITLE
Use bridge network and expose port on macOS when launch docker image

### DIFF
--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -35,7 +35,13 @@ DOCKER_IMAGE_NAME=("$1")
 
 if [ "$#" -eq 1 ]; then
     COMMAND="bash"
-    CI_DOCKER_EXTRA_PARAMS=("-it --net=host")
+    if [[ $(uname) == "Darwin" ]]; then
+        # Docker's host networking driver isn't supported on macOS.
+        # Use default bridge network and expose port.
+        CI_DOCKER_EXTRA_PARAMS=("-it -p 8888:8888")
+    else
+        CI_DOCKER_EXTRA_PARAMS=("-it --net=host")
+    fi
 else
     shift 1
     COMMAND=("$@")

--- a/docker/bash.sh
+++ b/docker/bash.sh
@@ -37,7 +37,7 @@ if [ "$#" -eq 1 ]; then
     COMMAND="bash"
     if [[ $(uname) == "Darwin" ]]; then
         # Docker's host networking driver isn't supported on macOS.
-        # Use default bridge network and expose port.
+        # Use default bridge network and expose port for jupyter notebook.
         CI_DOCKER_EXTRA_PARAMS=("-it -p 8888:8888")
     else
         CI_DOCKER_EXTRA_PARAMS=("-it --net=host")

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -46,7 +46,8 @@ This auxiliary script does the following things:
 
 - Mount current directory to /workspace
 - Switch user to be the same user that calls the bash.sh (so you can read/write host system)
-- Use the host-side network (so you can use jupyter notebook)
+- Use the host-side network on Linux. Use the bridge network and expose port 8888 on macOS,
+  because host networking driver isn't supported. (so you can use jupyter notebook)
 
 
 Then you can start a jupyter notebook by typing
@@ -55,6 +56,16 @@ Then you can start a jupyter notebook by typing
 
    jupyter notebook
 
+You might see an error ``OSError: [Errno 99] Cannot assign requested address`` when starting
+a jupyter notebook on macOS. You can change the binding IP address by
+
+.. code:: bash
+
+   jupyter notebook --ip=0.0.0.0
+
+Note that on macOS, because we use bridge network, jupyter notebook will be reportedly running
+at an URL like ``http://{container_hostname}:8888/?token=...``. You should replace the ``container_hostname``
+with ``localhost`` when pasting it into browser.
 
 Docker Source
 -------------


### PR DESCRIPTION
This is related to #2270. For Mac users, running `docker/bash.sh` command to launch docker image doesn't really work, because Docker's host networking driver isn't supported on macOS.

This patch adds a detect to the script. For macOS, it simply uses bridge network and expose port 8888. Then users can start jupyter network in the launched container.

Install docs for docker is also updated.