### PR TITLE
[Relay, OpFusion] Better tuple fusion implementation 

### DIFF
--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -43,12 +43,15 @@ enum OpPatternKind {
   kBroadcast = 1,
   // Injective operator, can always injectively map output axis to a single input axis.
   // All injective operator can still be safely fused to injective and reduction.
-  kInjective = 2,
+  kTuple = 2,
+  kInjective = 3,
   // Communicative reduction operator.
-  kCommReduce = 3,
+  kCommReduce = 4,
   // Complex operation, can still fuse elemwise operations into its output.
   // but cannot chain another complex op
-  kOutEWiseFusable = 4,
+  kOutEWiseFusable = 5,
+  kTupleField = 6,
+
   // Opaque operation, cannot fuse anything.
   kOpaque = 8
 };

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -41,17 +41,17 @@ enum OpPatternKind {
   // for example :code:`out[i, ax1, j, ax2] = input[i, j]`.
   // Note that the axis need to be in order so transpose is not a bcast operator.
   kBroadcast = 1,
-  // The pattern for tuple nodes. Can fuse into subsequent injective ops.
-  kTuple = 2,
   // Injective operator, can always injectively map output axis to a single input axis.
   // All injective operator can still be safely fused to injective and reduction.
-  kInjective = 3,
+  kInjective = 2,
   // Communicative reduction operator.
-  kCommReduce = 4,
+  kCommReduce = 3,
   // Complex operation, can still fuse elemwise operations into its output.
   // but cannot chain another complex op
-  kOutEWiseFusable = 5,
-
+  kOutEWiseFusable = 4,
+  // The pattern for tuple nodes. Can fuse into subsequent injective ops,
+  // but treated specially
+  kTuple = 7,
   // Opaque operation, cannot fuse anything.
   kOpaque = 8
 };

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -51,9 +51,6 @@ enum OpPatternKind {
   // Complex operation, can still fuse elemwise operations into its output.
   // but cannot chain another complex op
   kOutEWiseFusable = 5,
-  // The edge pattern between tuple and its fields. Tuple fields can fuse into
-  // a tuple if the tuple is intermediate node in its fusion group.
-  kTupleField = 6,
 
   // Opaque operation, cannot fuse anything.
   kOpaque = 8

--- a/include/tvm/relay/op_attr_types.h
+++ b/include/tvm/relay/op_attr_types.h
@@ -41,15 +41,18 @@ enum OpPatternKind {
   // for example :code:`out[i, ax1, j, ax2] = input[i, j]`.
   // Note that the axis need to be in order so transpose is not a bcast operator.
   kBroadcast = 1,
+  // The pattern for tuple nodes. Can fuse into subsequent injective ops.
+  kTuple = 2,
   // Injective operator, can always injectively map output axis to a single input axis.
   // All injective operator can still be safely fused to injective and reduction.
-  kTuple = 2,
   kInjective = 3,
   // Communicative reduction operator.
   kCommReduce = 4,
   // Complex operation, can still fuse elemwise operations into its output.
   // but cannot chain another complex op
   kOutEWiseFusable = 5,
+  // The edge pattern between tuple and its fields. Tuple fields can fuse into
+  // a tuple if the tuple is intermediate node in its fusion group.
   kTupleField = 6,
 
   // Opaque operation, cannot fuse anything.

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -114,8 +114,6 @@ class OpPattern(object):
     COMM_REDUCE = 4
     # Complex op, can still fuse ewise into it
     OUT_ELEMWISE_FUSABLE = 5
-    # Used to represent edge pattern between tuple and its fields
-    kTupleFiled = 6
     # Not fusable opaque op
     OPAQUE = 8
 

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -106,12 +106,14 @@ class OpPattern(object):
     ELEMWISE = 0
     # Broadcast operator
     BROADCAST = 1
+    kTuple = 2
     # Injective mapping
-    INJECTIVE = 2
+    INJECTIVE = 3
     # Communication
-    COMM_REDUCE = 3
+    COMM_REDUCE = 4
     # Complex op, can still fuse ewise into it
-    OUT_ELEMWISE_FUSABLE = 4
+    OUT_ELEMWISE_FUSABLE = 5
+    kTupleFiled = 6
     # Not fusable opaque op
     OPAQUE = 8
 

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -106,6 +106,7 @@ class OpPattern(object):
     ELEMWISE = 0
     # Broadcast operator
     BROADCAST = 1
+    # Represents tuple node
     kTuple = 2
     # Injective mapping
     INJECTIVE = 3
@@ -113,6 +114,7 @@ class OpPattern(object):
     COMM_REDUCE = 4
     # Complex op, can still fuse ewise into it
     OUT_ELEMWISE_FUSABLE = 5
+    # Used to represent edge pattern between tuple and its fields
     kTupleFiled = 6
     # Not fusable opaque op
     OPAQUE = 8

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -106,14 +106,14 @@ class OpPattern(object):
     ELEMWISE = 0
     # Broadcast operator
     BROADCAST = 1
+    # Injective mapping
+    INJECTIVE = 2
+    # Communication
+    COMM_REDUCE = 3
+    # Complex op, can still fuse ewise into it
+    OUT_ELEMWISE_FUSABLE = 4
     # Represents tuple node
     TUPLE = 2
-    # Injective mapping
-    INJECTIVE = 3
-    # Communication
-    COMM_REDUCE = 4
-    # Complex op, can still fuse ewise into it
-    OUT_ELEMWISE_FUSABLE = 5
     # Not fusable opaque op
     OPAQUE = 8
 

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -113,7 +113,7 @@ class OpPattern(object):
     # Complex op, can still fuse ewise into it
     OUT_ELEMWISE_FUSABLE = 4
     # Represents tuple node
-    TUPLE = 2
+    TUPLE = 7
     # Not fusable opaque op
     OPAQUE = 8
 

--- a/python/tvm/relay/op/op.py
+++ b/python/tvm/relay/op/op.py
@@ -107,7 +107,7 @@ class OpPattern(object):
     # Broadcast operator
     BROADCAST = 1
     # Represents tuple node
-    kTuple = 2
+    TUPLE = 2
     # Injective mapping
     INJECTIVE = 3
     # Communication

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -741,19 +741,15 @@ GraphPartitioner::Partition(const IndexedForwardGraph& graph) {
     this->RunFuse(graph, post_dom_tree, phase);
   }
   // Fuse intermediate tuples, if any
-  std::unordered_set<Group*> visited;
   for (size_t i = groups_.size(); i != 0; --i) {
     size_t nid = i - 1;
     Group* group = groups_[nid];
-    if (visited.count(group)) continue;
-    visited.insert(group);
     Group* root_group = group->FindRoot();
     if (root_group->pattern == kTuple) continue;
     if (group->pattern == kTuple && root_group->pattern <= kInjective) {
       for (Group* child_group : root_group->inputs) {
         if (child_group->FindRoot()->pattern <= kInjective) {
           MergeFromTo(child_group, group);
-          visited.insert(child_group);
         }
       }
     }

--- a/src/relay/pass/fuse_ops.cc
+++ b/src/relay/pass/fuse_ops.cc
@@ -675,6 +675,8 @@ class GraphPartitioner {
           auto fcond = [](OpPatternKind kind, bool is_sink) {
             return kind <= kInjective;
           };
+          // dom_root_group can also be tuple, as in inception layers
+          // CheckPath is needed to avoid fusing two intermediate tuples
           if (CheckPath(graph_node, dom_node->parent->gnode, fcond)) {
             CommitFuse(graph_node, dom_node->parent->gnode);
           }

--- a/tests/python/relay/test_backend_compile_engine.py
+++ b/tests/python/relay/test_backend_compile_engine.py
@@ -69,8 +69,16 @@ def test_compile_injective_with_tuple():
     relay.build(func, 'llvm')
 
 
+def test_compile_tuple_dup():
+    x = relay.var("data", shape=(16, 16))
+    log = relay.log(x)
+    output = relay.Tuple([log, log])
+    f = relay.Function([x], output)
+    relay.build(f, 'llvm')
+
+
 if __name__ == "__main__":
     test_compile_engine()
     test_compile_placeholder_bypass()
     test_compile_injective_with_tuple()
-
+    test_compile_tuple_dup()


### PR DESCRIPTION
See #3039 for the context and discussion.

This is my second cut at fixing tuple fusion, which I hope is a better approach than the rather ad hoc one in #3049 .

* Added two new op patterns, for marking tuple and tuple field nodes 
* Added a new attribute to the fusion group structure, to keep track of data flow between groups (think hypergraph where nodes correspond to fusion groups)
* After the existing fusion step, check each fusion group to see if we can further fuse the group and its input groups.  By now, we can determine If the tuple has been fused to subsequent ops or not. We can fuse tuple fields into the tuple here.  