### PR TITLE
Refactor Symbol::ListInputs to be static

### DIFF
--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -247,6 +247,7 @@ inline uint32_t Node::num_inputs() const {
   }
 }
 
+
 }  // namespace nnvm
 
 #endif  // NNVM_NODE_H_

--- a/nnvm/include/nnvm/node.h
+++ b/nnvm/include/nnvm/node.h
@@ -247,7 +247,6 @@ inline uint32_t Node::num_inputs() const {
   }
 }
 
-
 }  // namespace nnvm
 
 #endif  // NNVM_NODE_H_

--- a/nnvm/include/nnvm/symbolic.h
+++ b/nnvm/include/nnvm/symbolic.h
@@ -99,6 +99,10 @@ class NNVM_DLL Symbol {
    * \sa ListInputOption
    */
   std::vector<NodePtr> ListInputs(ListInputOption option) const;
+
+
+  static std::vector<NodePtr> ListInputs(ListInputOption option,
+                                         const std::vector<NodeEntry>& nodes);
   /*!
    * \brief List the input names.
    *

--- a/nnvm/src/core/symbolic.cc
+++ b/nnvm/src/core/symbolic.cc
@@ -206,10 +206,15 @@ Symbol Symbol::operator[] (size_t index) const {
 }
 
 std::vector<NodePtr> Symbol::ListInputs(ListInputOption option) const {
+  return ListInputs(option, this->outputs);
+}
+
+std::vector<NodePtr> Symbol::ListInputs(ListInputOption option,
+                                        const std::vector<NodeEntry>& nodes) {
   std::vector<NodePtr> ret;
   if (option == kAll) {
-    ret.reserve(this->outputs.size());
-    DFSVisit(this->outputs, [&ret](const NodePtr &node) {
+    ret.reserve(nodes.size());
+    DFSVisit(nodes, [&ret](const NodePtr &node) {
         if (node->is_variable()) {
           ret.push_back(node);
         }
@@ -217,9 +222,9 @@ std::vector<NodePtr> Symbol::ListInputs(ListInputOption option) const {
   } else {
     std::unordered_set<Node*> mutable_set;
     std::vector<NodePtr> vlist;
-    vlist.reserve(this->outputs.size());
+    vlist.reserve(nodes.size());
     static auto& fmutate_inputs = Op::GetAttr<FMutateInputs>("FMutateInputs");
-    DFSVisit(this->outputs, [&mutable_set, &vlist](const NodePtr &node) {
+    DFSVisit(nodes, [&mutable_set, &vlist](const NodePtr &node) {
         if (node->is_variable()) {
           vlist.push_back(node);
         } else if (fmutate_inputs.count(node->op())) {


### PR DESCRIPTION
This avoid needing to create an unused Symbol when needing to filter Nodes by Input Option.

For example here: https://github.com/apache/incubator-mxnet/blob/master/src/imperative/imperative.cc#L321

This code in MXNet is being refactored and depends on this refactor.

https://github.com/larroy/mxnet/tree/fc_higher_order_grad_2

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
