### PR TITLE
fix indices around nearest neighbor resize

### DIFF
--- a/topi/include/topi/image/resize.h
+++ b/topi/include/topi/image/resize.h
@@ -101,15 +101,12 @@ inline Tensor resize_nearest_neighbor_nhwc(const Tensor& input,
   out_shape.push_back(shape[1]);
   out_shape.push_back(input->shape[3]);
 
-  Expr h_ratio = shape[0] / input->shape[1];
-  Expr w_ratio = shape[1] / input->shape[2];
-
   return compute(
     out_shape, [&](const Array<Var>& indices) {
     Array<Expr> idx;
     idx.push_back(indices[0]);
-    idx.push_back(indices[1] / h_ratio);
-    idx.push_back(indices[2] / w_ratio);
+    idx.push_back(indices[1] * input->shape[1] / shape[0]);
+    idx.push_back(indices[2] * input->shape[2] / shape[1]);
     idx.push_back(indices[3]);
 
     return input(idx);
@@ -138,16 +135,13 @@ inline Tensor resize_nearest_neighbor_nchw(const Tensor& input,
   out_shape.push_back(shape[0]);
   out_shape.push_back(shape[1]);
 
-  Expr h_ratio = shape[0] / input->shape[2];
-  Expr w_ratio = shape[1] / input->shape[3];
-
   return compute(
     out_shape, [&](const Array<Var>& indices) {
     Array<Expr> idx;
     idx.push_back(indices[0]);
     idx.push_back(indices[1]);
-    idx.push_back(indices[2] / h_ratio);
-    idx.push_back(indices[3] / w_ratio);
+    idx.push_back(indices[2] * input->shape[2] / shape[0]);
+    idx.push_back(indices[3] * input->shape[3] / shape[1]);
 
     return input(idx);
     }, name, tag);
@@ -176,16 +170,13 @@ inline Tensor resize_nearest_neighbor_nchwc(const Tensor& input,
   out_shape.push_back(shape[1]);
   out_shape.push_back(input->shape[4]);
 
-  Expr h_ratio = shape[0] / input->shape[2];
-  Expr w_ratio = shape[1] / input->shape[3];
-
   return compute(
     out_shape, [&](const Array<Var>& indices) {
     Array<Expr> idx;
     idx.push_back(indices[0]);
     idx.push_back(indices[1]);
-    idx.push_back(indices[2] / h_ratio);
-    idx.push_back(indices[3] / w_ratio);
+    idx.push_back(indices[2] * input->shape[2] / shape[0]);
+    idx.push_back(indices[3] * input->shape[3] / shape[1]);
     idx.push_back(indices[4]);
 
      return input(idx);


### PR DESCRIPTION
Fixes a bug, when using nearest neighbor resizing with `size` that is NOT an integer multiple of the input size.
E.g. when resizing 
```
[[1,2], 
 [3,4]]
```
to `size=(3,3)`, the result was 
```
[[1,2,3],
 [3,4,x],
 [x,x,x]]
```
Where `x`'s are some values from uninitialized memory.
