### PR TITLE
[LINT] recover lint error

### DIFF
--- a/docs/dev/relay_add_pass.rst
+++ b/docs/dev/relay_add_pass.rst
@@ -1,3 +1,20 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
 .. _relay-add-pass:
 
 Adding a Compiler Pass to Relay

--- a/src/relay/pass/dependency_graph.cc
+++ b/src/relay/pass/dependency_graph.cc
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 /*!
  * Copyright (c) 2019 by Contributors
  * \file tvm/relay/pass/dependency_graph.cc

--- a/src/relay/pass/dependency_graph.h
+++ b/src/relay/pass/dependency_graph.h
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 /*!
  *  Copyright (c) 2019 by Contributors.
  * \file tvm/relay/pass/dependency_graph.h

--- a/tests/lint/add_asf_header.py
+++ b/tests/lint/add_asf_header.py
@@ -117,6 +117,9 @@ header_groovystyle = """
 """.strip()
 
 FMT_MAP = {
+    "cc" : header_cstyle,
+    "h" : header_cstyle,
+    "py" : header_pystyle,
     "toml" : header_pystyle,
     "yml": header_pystyle,
     "yaml": header_pystyle,
@@ -149,6 +152,8 @@ def main(args):
         print("Usage: python add_asf_header.py <file_list>")
 
     for l in open(args[1]):
+        if l.startswith("-----"):
+            continue
         if l.find("File:") != -1:
             l = l.split(":")[-1]
         fname = l.strip()

--- a/tests/lint/rat-excludes
+++ b/tests/lint/rat-excludes
@@ -39,6 +39,7 @@ MANIFEST
 .gitignore
 .gitmodules
 .clang-format
+.bash_history
 rat-excludes
 __init__.py
 pylintrc

--- a/tests/python/relay/test_pass_partial_eval.py
+++ b/tests/python/relay/test_pass_partial_eval.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import numpy as np
 import tvm
 from tvm import relay

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -26,8 +26,23 @@ cleanup()
 }
 trap cleanup 0
 
+
 echo "Check file types..."
 python3 tests/lint/check_file_type.py
+
+echo "Check ASF license header..."
+java -jar /bin/apache-rat.jar -E tests/lint/rat-excludes  -d . |grep "== File" > /tmp/$$.apache-rat.txt || true
+if grep --quiet -E "File" /tmp/$$.apache-rat.txt; then
+    echo "Need to add ASF header to the following files."
+    echo "----------------File List----------------"
+    cat /tmp/$$.apache-rat.txt
+    echo "-----------------------------------------"
+    echo "Use the following steps to add the headers:"
+    echo "- Create file_list.txt in your text editor"
+    echo "- Copy paste the above content in file-list into file_list.txt"
+    echo "- python3 tests/lint/add_asf_header.py file_list.txt"
+    exit -1
+fi
 
 echo "Check codestyle of c++ code..."
 make cpplint
@@ -35,6 +50,7 @@ echo "Check codestyle of python code..."
 make pylint
 echo "Check codestyle of jni code..."
 make jnilint
+
 echo "Check documentations of c++ code..."
 make doc 2>/tmp/$$.log.txt
 
@@ -42,4 +58,6 @@ grep -v -E "ENABLE_PREPROCESSING|unsupported tag" < /tmp/$$.log.txt > /tmp/$$.lo
 echo "---------Error Log----------"
 cat /tmp/$$.logclean.txt
 echo "----------------------------"
-grep -E "warning|error" < /tmp/$$.logclean.txt || true
+if grep --quiet -E "warning|error" < /tmp/$$.logclean.txt; then
+    exit -1
+fi

--- a/topi/include/topi/nn/bias_add.h
+++ b/topi/include/topi/nn/bias_add.h
@@ -40,7 +40,7 @@ namespace nn {
 *
 * \param data Tensor with shape [batch, in_dim]
 * \param bias Tensor with shape [batch].
-*
+* \param axis The axis to add the bias to.
 * \return Tensor with shape [batch, in_dim]
 */
 inline tvm::Tensor bias_add(const tvm::Tensor& data, const tvm::Tensor& bias, int axis) {

--- a/topi/include/topi/transform.h
+++ b/topi/include/topi/transform.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -617,6 +617,7 @@ inline Array<Tensor> split_sections(const Tensor& x,
 * \param a The source array.
 * \param indices The indices of the values to extract.
 * \param name The name of the operation.
+* \param mode The mode of to handle out of bound indices.
 * \param tag The tag to mark the operation.
 *
 * \return A Tensor whose op member is the take operation
@@ -655,6 +656,7 @@ inline Tensor take(const Tensor& a,
 * \param indices The indices of the values to extract.
 * \param axis The axis over which to select values. By default,
 * the flattened input array is used.
+* \param mode The mode of to handle out of bound indices.
 * \param name The name of the operation.
 * \param tag The tag to mark the operation.
 *

--- a/tutorials/frontend/deploy_model_on_android.py
+++ b/tutorials/frontend/deploy_model_on_android.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 """
 .. _tutorial-deploy-model-on-android:
 


### PR DESCRIPTION
Add ASF header check.

This PR also fix a previous problem that the docs no longer error out when there is a warning(cc @mjs-arm )