### PR TITLE
Fixing a doc nit

### DIFF
--- a/nnvm/tutorials/tune_nnvm_cuda.py
+++ b/nnvm/tutorials/tune_nnvm_cuda.py
@@ -17,7 +17,7 @@
 """
 Auto-tuning a convolutional network for NVIDIA GPU (NNVM)
 =========================================================
-**Author**: `Lianmin Zheng <https://https://github.com/merrymercy>`_
+**Author**: `Lianmin Zheng <https://github.com/merrymercy>`_
 
 Auto-tuning for specific devices and workloads is critical for getting the
 best performance. This is a tutorial on how to tune a whole convolutional

--- a/nnvm/tutorials/tune_nnvm_mobile_gpu.py
+++ b/nnvm/tutorials/tune_nnvm_mobile_gpu.py
@@ -17,7 +17,7 @@
 """
 Auto-tuning a convolutional network for Mobile GPU (NNVM)
 =========================================================
-**Author**: `Lianmin Zheng <https://https://github.com/merrymercy>`_
+**Author**: `Lianmin Zheng <https://github.com/merrymercy>`_
 
 Auto-tuning for a specific device is critical for getting the best
 performance. This is a tutorial about how to tune a whole convolutional

--- a/tutorials/autotvm/tune_conv2d_cuda.py
+++ b/tutorials/autotvm/tune_conv2d_cuda.py
@@ -17,7 +17,7 @@
 """
 Tuning High Performance Convolution on NVIDIA GPUs
 =========================================================================
-**Author**: `Lianmin Zheng <https://https://github.com/merrymercy>`_
+**Author**: `Lianmin Zheng <https://github.com/merrymercy>`_
 
 This is an advanced tutorial for writing high performance tunable template for
 NVIDIA GPU. By running auto-tuner on this template, we can outperform the

--- a/tutorials/autotvm/tune_relay_mobile_gpu.py
+++ b/tutorials/autotvm/tune_relay_mobile_gpu.py
@@ -17,7 +17,7 @@
 """
 Auto-tuning a convolutional network for Mobile GPU
 ==================================================
-**Author**: `Lianmin Zheng <https://https://github.com/merrymercy>`_, `Eddie Yan <https://github.com/eqy>`_
+**Author**: `Lianmin Zheng <https://github.com/merrymercy>`_, `Eddie Yan <https://github.com/eqy>`_
 
 Auto-tuning for a specific device is critical for getting the best
 performance. This is a tutorial about how to tune a whole convolutional

--- a/tutorials/autotvm/tune_simple_template.py
+++ b/tutorials/autotvm/tune_simple_template.py
@@ -17,7 +17,7 @@
 """
 Writing tunable template and Using auto-tuner
 =============================================
-**Author**: `Lianmin Zheng <https://https://github.com/merrymercy>`_
+**Author**: `Lianmin Zheng <https://github.com/merrymercy>`_
 
 This is an introduction tutorial to the auto-tuning module in tvm.
 


### PR DESCRIPTION
URLs to the authors repo for these tutorials had an extra
`https://`, this patch removes that.