### PR TITLE
[Bugfix][TOPI] conv2d_transpose bugfix

### DIFF
--- a/topi/python/topi/cuda/conv2d_transpose_nchw.py
+++ b/topi/python/topi/cuda/conv2d_transpose_nchw.py
@@ -174,7 +174,7 @@ def schedule_conv2d_transpose_nchw_cuda(cfg, outs):
             by, vy, ty, yi = cfg["tile_y"].apply(s, output, y)
             bx, vx, tx, xi = cfg["tile_x"].apply(s, output, x)
 
-            bf = s[output].fuse(n, bf)
+#            bf = s[output].fuse(n, bf)
             s[output].bind(bf, tvm.thread_axis("blockIdx.z"))
             s[output].bind(by, tvm.thread_axis("blockIdx.y"))
             s[output].bind(bx, tvm.thread_axis("blockIdx.x"))
@@ -184,7 +184,7 @@ def schedule_conv2d_transpose_nchw_cuda(cfg, outs):
             s[output].bind(tf, tvm.thread_axis("threadIdx.z"))
             s[output].bind(ty, tvm.thread_axis("threadIdx.y"))
             s[output].bind(tx, tvm.thread_axis("threadIdx.x"))
-            s[output].reorder(bf, by, bx, vf, vy, vx, tf, ty, tx, fi, yi, xi)
+            s[output].reorder(n, bf, by, bx, vf, vy, vx, tf, ty, tx, fi, yi, xi)
             s[OL].compute_at(s[output], tx)
 
             # tile reduction axes

--- a/topi/tests/python/test_topi_conv2d_transpose_nchw.py
+++ b/topi/tests/python/test_topi_conv2d_transpose_nchw.py
@@ -72,10 +72,11 @@ def verify_conv2d_transpose_nchw(batch, in_channel, in_size, num_filter, kernel,
 
 
 def test_conv2d_transpose_nchw():
-    verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 1, 0)
-    verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 2, 1)
-    verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 1, 0)
-    verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 2, 1)
+    #verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 1, 0)
+    #verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 2, 1)
+    #verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 1, 0)
+    #verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 2, 1)
+    verify_conv2d_transpose_nchw(1000, 2048, 7, 256, 2, 2, 0)
 
 
 if __name__ == "__main__":

--- a/topi/tests/python/test_topi_conv2d_transpose_nchw.py
+++ b/topi/tests/python/test_topi_conv2d_transpose_nchw.py
@@ -72,11 +72,11 @@ def verify_conv2d_transpose_nchw(batch, in_channel, in_size, num_filter, kernel,
 
 
 def test_conv2d_transpose_nchw():
-    #verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 1, 0)
-    #verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 2, 1)
-    #verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 1, 0)
-    #verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 2, 1)
-    verify_conv2d_transpose_nchw(1000, 2048, 7, 256, 2, 2, 0)
+    verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 1, 0)
+    verify_conv2d_transpose_nchw(1, 3, 224, 32, 3, 2, 1)
+    verify_conv2d_transpose_nchw(1, 3, 224, 32, 2, 2, 0)
+    verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 1, 0)
+    verify_conv2d_transpose_nchw(1, 32, 32, 128, 5, 2, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Deconv casts blockIdx.x blockIdx.y arguments not found error in some cases, bug fixed, corresponding tests added. @merrymercy  