### PR TITLE
[relay][frontend] fix python lint warnings

### DIFF
--- a/python/tvm/relay/frontend/coreml.py
+++ b/python/tvm/relay/frontend/coreml.py
@@ -17,8 +17,8 @@
 # pylint: disable=invalid-name, import-self, unused-argument, unused-variable, inconsistent-return-statements
 """CoreML frontend."""
 from __future__ import absolute_import as _abs
-import tvm
 import numpy as np
+import tvm
 from .. import ir_pass
 from .. import expr as _expr
 from .. import op as _op

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -18,8 +18,8 @@
 """Keras frontend."""
 from __future__ import absolute_import as _abs
 import sys
-import tvm
 import numpy as np
+import tvm
 from .. import ir_pass
 from .. import expr as _expr
 from .. import op as _op

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -19,8 +19,8 @@
 from __future__ import absolute_import as _abs
 
 import logging
-import tvm
 import numpy as np
+import tvm
 from ... import nd as _nd
 from .. import ir_pass
 from .. import expr as _expr


### PR DESCRIPTION
This PR fix some pylint warnings caused by the order of importing tvm.

@icemelon9 @jroesch @tqchen @yzhliu 