### PR TITLE
[HybridScript] Capture constant external python variables

### DIFF
--- a/python/tvm/hybrid/__init__.py
+++ b/python/tvm/hybrid/__init__.py
@@ -31,6 +31,8 @@ HalideIR.
 
 from __future__ import absolute_import as _abs
 
+import inspect
+
 from .._ffi.base import decorate
 from .._ffi.function import _init_api
 from ..build_module import form_body
@@ -55,7 +57,9 @@ def script(pyfunc):
         from .util import _is_tvm_arg_types
         if _is_tvm_arg_types(args):
             src = _pruned_source(func)
-            return source_to_op(src, func.__globals__, args)
+            closure_vars = inspect.getclosurevars(func).nonlocals
+            closure_vars.update(inspect.getclosurevars(func).globals)
+            return source_to_op(src, args, func.__globals__, closure_vars)
 
         from .runtime import _enter_hybrid_runtime, _restore_runtime
         intersect = _enter_hybrid_runtime(func)

--- a/python/tvm/hybrid/module.py
+++ b/python/tvm/hybrid/module.py
@@ -62,7 +62,7 @@ class HybridModule(object):
 
     def __call__(self, *args):
         if _is_tvm_arg_types(args):
-            return source_to_op(self.root_, globals(), args)
+            return source_to_op(self.root_, args, globals(), {})
         return self.func_(*args)
 
 

--- a/python/tvm/hybrid/util.py
+++ b/python/tvm/hybrid/util.py
@@ -101,3 +101,9 @@ def _is_tvm_arg_types(args):
         _internal_assert(isinstance(elem, np_arg_types), \
                          "Expect a numpy type but %s get!" % str(type(elem)))
     return False
+
+def _apply_indices(value, indices):
+    """Apply multidimensional index"""
+    if indices:
+        return _apply_indices(value[indices[0]], indices[1:])
+    return value

--- a/tests/python/unittest/test_hybrid_script.py
+++ b/tests/python/unittest/test_hybrid_script.py
@@ -768,6 +768,24 @@ def test_schedule():
 
     # Test loop binds
 
+def test_capture():
+    n = 8
+
+    constant_tuple = (10, n)
+    constant_list = [[1, 2], [3, n]]
+    const_value = 1
+
+    @tvm.hybrid.script
+    def add_something(a):
+        c = output_tensor((constant_tuple[1],), 'int32')
+        for i in range(constant_tuple[1]):
+            c[i] = a[i] + constant_list[1][const_value]
+        return c
+
+    a = tvm.placeholder((n, ), dtype='int32', name='a')
+
+    func, ins, outs = run_and_check(add_something, [a])
+    run_and_check(func, ins, outs=outs)
 
 if __name__ == "__main__":
     test_outer_product()
@@ -786,5 +804,6 @@ if __name__ == "__main__":
     test_bool()
     test_const_range()
     test_schedule()
+    test_capture()
     # TODO:
     # test_inplace()


### PR DESCRIPTION
Capture constant python variables (list/tuple/primitive) in HybridScript. We can use them to pass constant shape and attribute information.

cc @were @xqdan  @kevinthesun 