### PR TITLE
Fix a multithreaded bug in llvm LazyInitJIT

### DIFF
--- a/src/codegen/llvm/llvm_module.cc
+++ b/src/codegen/llvm/llvm_module.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -228,6 +228,9 @@ class LLVMModuleNode final : public runtime::ModuleNode {
   void LazyInitJIT() {
     CHECK(ee_ == nullptr);
     std::lock_guard<std::mutex> lock(mutex_);
+    if (ee_) {
+      return;
+    }
     llvm::EngineBuilder builder(std::move(module_));
     std::string triple, mcpu, mattr;
     llvm::TargetOptions opt;

--- a/src/codegen/llvm/llvm_module.cc
+++ b/src/codegen/llvm/llvm_module.cc
@@ -226,7 +226,6 @@ class LLVMModuleNode final : public runtime::ModuleNode {
 
  private:
   void LazyInitJIT() {
-    CHECK(ee_ == nullptr);
     std::lock_guard<std::mutex> lock(mutex_);
     if (ee_) {
       return;


### PR DESCRIPTION
When llvm module is being called concurrently and threads are contending to do `LazyInitJIT`, one will enter first and fulfill `ee_`. The rest of them should just use `ee_` instead of redoing the init jit process which will result in a coredump. 

cc: @ajtulloch @hlu1 @antinucleon 