### PR TITLE
Fix a tensorflow test bug.

### DIFF
--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -185,7 +185,7 @@ def _test_pooling_iteration(input_shape, **kwargs):
 def _test_pooling(input_shape, **kwargs):
     _test_pooling_iteration(input_shape, **kwargs)
 
-    if is_gpu_available():
+    if is_gpu_available() and (len(input_shape) == 4):
         input_shape = [input_shape[ii] for ii in (0, 3, 1, 2)]
         kwargs['data_format'] = 'NCHW'
         _test_pooling_iteration(input_shape, **kwargs)


### PR DESCRIPTION
  Length of input_shape isn't always 4 when _test_pooling called from test_forward_pooling.
@srkreddy1238 Will you please review？