### PR TITLE
Better relay graph parsing for TensorFlow

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -259,8 +259,8 @@ def _elemwise(name):
             params = args[0]
             if inputs[0].name_hint in params.keys() and inputs[1].name_hint in params.keys():
                 # Both inputs are defined and can be used for numpy.
-                in0 = params.pop(inputs[0].name_hint).asnumpy()
-                in1 = params.pop(inputs[1].name_hint).asnumpy()
+                in0 = params[inputs[0].name_hint].asnumpy()
+                in1 = params[inputs[1].name_hint].asnumpy()
                 np_op = _get_numpy_op(name)
                 output = np_op(in0, in1)
                 return output
@@ -493,8 +493,7 @@ def _resize_bilinear():
         # Need to handle constant shape inputs to determine output shape.
         if type(inputs[1]) == tvm.relay.expr.Var:
             if inputs[1].name_hint in params.keys():
-                #attr['_output_shapes'][0] = list(params.pop(inputs[1].name_hint).asnumpy())
-                H_out, W_out = list(params.pop(inputs[1].name_hint).asnumpy())
+                H_out, W_out = list(params[inputs[1].name_hint].asnumpy())
                 attr["_output_shapes"][0][1] = H_out
                 attr["_output_shapes"][0][2] = W_out
 
@@ -639,8 +638,6 @@ def _reshape():
                 ignores=['Tshape'])(inputs, attr)
     return _impl
 
-
-# Currently only supports NHWC, TODO add NCHW support.
 def _depth_to_space():
     def _impl(inputs, attr, params):
         # Need to handle data layouts differently.
@@ -675,7 +672,6 @@ def _depth_to_space():
             ignores=['data_format', 'block_size'])([transposed], attr)
 
     return _impl
-
 
 def _bias_add():
     def _impl(inputs, attr, params):

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -254,6 +254,7 @@ def _argx(func, func_name):
 def _elemwise(name):
     def _impl(inputs, attr, *args):
         assert len(inputs) == 2, "{} take 2 inputs, {} given".format(name, len(inputs))
+
         # Figure out if inputs are constants or not. If so, evaluate using numpy.
         if type(inputs[0]) == tvm.relay.expr.Var and type(inputs[1]) == tvm.relay.expr.Var:
             params = args[0]
@@ -264,8 +265,8 @@ def _elemwise(name):
                 np_op = _get_numpy_op(name)
                 output = np_op(in0, in1)
                 return output
-        else:
-            return _get_relay_op(name)(*inputs)
+
+        return _get_relay_op(name)(*inputs)
     return _impl
 
 def _pooling(name):
@@ -1933,7 +1934,7 @@ class GraphProto(object):
                 else:
                     op = self._convert_operator(node.op, inputs, attr, graph)
 
-                # Check if op is converted to param Why convert to param? Shouldnt it just be a constant?
+                # Check if op is converted to param
                 if isinstance(op, np.ndarray):
                     self._params[node.name] = tvm.nd.array(op)
                     op = [_expr.var(node.name,

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -841,12 +841,13 @@ def _stridedSlice():
         # There are certain cases where a stridedslice is actually just picking out a constant.
         # In these cases we treat the output as a constant rather than a function.
         # This is important for the shape inference of other functions.
-        if (inputs[0].name_hint in params.keys() and
-                len(begin) == 1 and len(end) == 1 and len(stride) == 1):
+        if isinstance(inputs[0], tvm.relay.expr.Var):
+            if (inputs[0].name_hint in params.keys() and
+                    len(begin) == 1 and len(end) == 1 and len(stride) == 1):
 
-            input_data = params[inputs[0].name_hint].asnumpy()
-            output_data = input_data[begin[0]:end[0]:stride[0]]
-            return output_data
+                input_data = params[inputs[0].name_hint].asnumpy()
+                output_data = input_data[begin[0]:end[0]:stride[0]]
+                return output_data
 
         def _transform_mask(stride_dim, ellipsis_mask):
             """Handle mask inputs to create new begin, end, stride and output shape"""

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -608,8 +608,8 @@ def _depth_to_space():
             # Finally reshape to proper output.
             new_h = in_h * block_size
             new_w = in_w * block_size
-            out = _op.reshape(transposed, newshape=(in_n, new_h, new_w, new_c))
-            return out
+            newshape = (in_n, new_h, new_w, new_c)
+
         else: # Handle NCHW layout
             in_n, in_c, in_h, in_w = input_shape
             new_c = int(in_c / (block_size * block_size))
@@ -618,8 +618,12 @@ def _depth_to_space():
             transposed = _op.transpose(expanded, axes=(0, 3, 4, 1, 5, 2))
             new_h = in_h * block_size
             new_w = in_w * block_size
-            out = _op.reshape(transposed, newshape=(in_n, new_c, new_h, new_w))
-            return out
+            newshape = (in_n, new_c, new_h, new_w)
+
+        return AttrCvt(
+            op_name="reshape",
+            extras={'newshape': newshape},
+            ignores=['data_format', 'block_size'])([transposed], attr)
 
     return _impl
 


### PR DESCRIPTION
Added DepthToConv operator to tensorflow frontend.

In some cases where a tensors shape was based on input values such as Resize or Full ops, Relay was unable to correctly determine the proper output shape. To address this, I added better constant detection to many operations. This allows more unusual architectures to be directly imported.

Also made keras import script work with tensorflow.keras if standalone keras not found.

I've confirmed that frontend tests pass after these changes.