### PR TITLE
[Relay] Option to select which convolution layers are quantized.

### DIFF
--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -154,18 +154,12 @@ def conv2d_rewrite(ref_call, new_args, ctx):
     input field, and rhs of conv will be quantized to weight field.
     Output would be in activation field"""
     cnt = _conv_counter()
-    print(cnt)
     if cnt < current_qconfig().skip_k_conv:
         _set_conv_counter(cnt + 1)
         return None
-    print(cnt)
 
-    boundary_node = False
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt not in leave_alone_indices and (cnt + 1) in leave_alone_indices:
-            # If this node is quantized and the next node isn't, we need to handle the boundary.
-            boundary_node = True
         if cnt in leave_alone_indices:
             _set_conv_counter(cnt + 1)
             return None
@@ -183,16 +177,6 @@ def conv2d_rewrite(ref_call, new_args, ctx):
 
     expr = _forward_op(ref_call, [lhs_expr, rhs_expr])
 
-    # If this is a boundary node, also need to attach dequantization.
-    #if boundary_node:
-        # first transpose extra channel back into main channel.
-        #expr = relay.transpose(expr, [0, 1, 4, 2, 3])
-        # Next we reshape to fuse channel and subchannel. Then convert to float.
-        #expr = relay.reshape(expr, [0, -3, 0, 0]).astype('float32')
-
-        # just see if this even works.
-        #expr = relay.add(expr, expr)
-
     return QAnnotateExpr(expr, QAnnotateKind.ACTIVATION)
 
 
@@ -205,7 +189,7 @@ def dense_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt + 1) in leave_alone_indices:
+        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -229,7 +213,7 @@ def multiply_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt + 1) in leave_alone_indices:
+        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -256,7 +240,7 @@ def add_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt + 1) in leave_alone_indices:
+        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -289,7 +273,7 @@ def identity_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt + 1) in leave_alone_indices:
+        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
             return None
 
     x_expr, x_kind = _get_expr_kind(new_args[0])
@@ -312,7 +296,7 @@ def pool2d_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt + 1) in leave_alone_indices:
+        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
             return None
 
     expr, x_kind = _get_expr_kind(new_args[0])
@@ -336,7 +320,7 @@ def concatenate_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices:
+        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
             return None
 
     input_tuple = new_args[0]

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -189,7 +189,7 @@ def dense_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
+        if (cnt - 1) in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -213,7 +213,7 @@ def multiply_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
+        if (cnt - 1) in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -240,7 +240,7 @@ def add_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
+        if (cnt - 1) in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -273,7 +273,7 @@ def identity_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
+        if (cnt - 1) in leave_alone_indices:
             return None
 
     x_expr, x_kind = _get_expr_kind(new_args[0])
@@ -296,7 +296,7 @@ def pool2d_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
+        if (cnt - 1) in leave_alone_indices:
             return None
 
     expr, x_kind = _get_expr_kind(new_args[0])
@@ -320,7 +320,7 @@ def concatenate_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if cnt in leave_alone_indices or (cnt - 1) in leave_alone_indices:
+        if (cnt - 1) in leave_alone_indices:
             return None
 
     input_tuple = new_args[0]

--- a/python/tvm/relay/quantize/_annotate.py
+++ b/python/tvm/relay/quantize/_annotate.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 import warnings
 
 import topi
-from tvm import relay
 from . import _quantize
 from .quantize import QAnnotateKind, current_qconfig
 from .quantize import _conv_counter, _set_conv_counter
@@ -189,7 +188,7 @@ def dense_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if (cnt - 1) in leave_alone_indices:
+        if cnt - 1 in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -213,7 +212,7 @@ def multiply_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if (cnt - 1) in leave_alone_indices:
+        if cnt - 1 in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -240,7 +239,7 @@ def add_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if (cnt - 1) in leave_alone_indices:
+        if cnt - 1 in leave_alone_indices:
             return None
 
     lhs_expr, lhs_kind = _get_expr_kind(new_args[0])
@@ -273,7 +272,7 @@ def identity_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if (cnt - 1) in leave_alone_indices:
+        if cnt - 1 in leave_alone_indices:
             return None
 
     x_expr, x_kind = _get_expr_kind(new_args[0])
@@ -296,7 +295,7 @@ def pool2d_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if (cnt - 1) in leave_alone_indices:
+        if cnt - 1 in leave_alone_indices:
             return None
 
     expr, x_kind = _get_expr_kind(new_args[0])
@@ -320,7 +319,7 @@ def concatenate_rewrite(ref_call, new_args, ctx):
         return None
     if current_qconfig().skip_conv_layers is not None:
         leave_alone_indices = [int(x) for x in current_qconfig().skip_conv_layers]
-        if (cnt - 1) in leave_alone_indices:
+        if cnt - 1 in leave_alone_indices:
             return None
 
     input_tuple = new_args[0]

--- a/python/tvm/relay/quantize/quantize.py
+++ b/python/tvm/relay/quantize/quantize.py
@@ -71,6 +71,7 @@ class QConfig(NodeBase):
         "dtype_activation": "int32",
         "global_scale": 8.0,
         "skip_k_conv": 1,
+        "skip_conv_layers": None,
         "round_for_shift": True,
         "store_lowbit_output": True,
         "debug_enabled_ops": None,
@@ -138,6 +139,10 @@ def qconfig(**kwargs):
 
     skip_k_conv: int
         The number of skipped conv2d.
+
+    skip_conv_layers: list
+        Different way of specifying which layers to avoid. Provide a list of indices
+        that indicate which conv2d layers to leave untouched.
 
     round_for_shift: boolean
         Whether to add bias for rounding during shift.

--- a/src/relay/pass/quantize.cc
+++ b/src/relay/pass/quantize.cc
@@ -439,7 +439,7 @@ Expr AddRealize(const Call& ref_call,
     Expr ret = ForwardOp(ref_call, ret_args);
     return QRealizeIntExprNode::make(ret, dom_scale, dtype);
   }
-  //CHECK(!new_args[0]->derived_from<TempExprNode>() && !new_args[1]->derived_from<TempExprNode>());
+  CHECK(!new_args[0]->derived_from<TempExprNode>() && !new_args[1]->derived_from<TempExprNode>());
   return Expr(nullptr);
 }
 

--- a/src/relay/pass/quantize.cc
+++ b/src/relay/pass/quantize.cc
@@ -439,7 +439,7 @@ Expr AddRealize(const Call& ref_call,
     Expr ret = ForwardOp(ref_call, ret_args);
     return QRealizeIntExprNode::make(ret, dom_scale, dtype);
   }
-  CHECK(!new_args[0]->derived_from<TempExprNode>() && !new_args[1]->derived_from<TempExprNode>());
+  //CHECK(!new_args[0]->derived_from<TempExprNode>() && !new_args[1]->derived_from<TempExprNode>());
   return Expr(nullptr);
 }
 
@@ -596,6 +596,7 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
   p->stream << "nbit_activation=" << op->nbit_activation << ", ";
   p->stream << "global_scale=" << op->global_scale << ", ";
   p->stream << "skip_k_conv==" << op->skip_k_conv << ", ";
+  p->stream << "skip_conv_layers==" << op->skip_conv_layers << ", ";
   p->stream << "round_for_shift==" << op->round_for_shift << ", ";
   p->stream << "store_lowbit_output==" << op->store_lowbit_output << ", ";
   p->stream << "debug_enabled_ops==" << op->debug_enabled_ops << ", ";

--- a/src/relay/pass/quantize.h
+++ b/src/relay/pass/quantize.h
@@ -126,6 +126,7 @@ class QConfigNode : public Node {
   DataType dtype_activation = Int(32);
   double global_scale = 8.0;
   int skip_k_conv = 1;
+  Array<Expr> skip_conv_layers = Array<Expr>(NodePtr<Node>(nullptr));
   bool round_for_shift = true;
   bool store_lowbit_output = true;
   Array<Expr> debug_enabled_ops = Array<Expr>(NodePtr<Node>(nullptr));
@@ -140,6 +141,7 @@ class QConfigNode : public Node {
     v->Visit("dtype_activation", &dtype_activation);
     v->Visit("global_scale", &global_scale);
     v->Visit("skip_k_conv", &skip_k_conv);
+	v->Visit("skip_conv_layers", &skip_conv_layers);
     v->Visit("round_for_shift", &round_for_shift);
     v->Visit("store_lowbit_output", &store_lowbit_output);
     v->Visit("debug_enabled_ops", &debug_enabled_ops);

--- a/src/relay/pass/quantize.h
+++ b/src/relay/pass/quantize.h
@@ -141,7 +141,7 @@ class QConfigNode : public Node {
     v->Visit("dtype_activation", &dtype_activation);
     v->Visit("global_scale", &global_scale);
     v->Visit("skip_k_conv", &skip_k_conv);
-	v->Visit("skip_conv_layers", &skip_conv_layers);
+    v->Visit("skip_conv_layers", &skip_conv_layers);
     v->Visit("round_for_shift", &round_for_shift);
     v->Visit("store_lowbit_output", &store_lowbit_output);
     v->Visit("debug_enabled_ops", &debug_enabled_ops);

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -104,9 +104,10 @@ def conv2d_cuda(cfg, data, kernel, strides, padding, dilation, layout='NCHW', ou
     if cfg.template_key == 'winograd':
         return winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dtype,
                              pre_computed=False)
-    if cfg.template_key == 'int8' :
-        if (data.dtype=='int8' or data.dtype=='uint8'):
-            return conv2d_NCHWc_int8(cfg, data, kernel, strides, padding, dilation, layout, out_dtype)
+    if cfg.template_key == 'int8':
+        if (data.dtype == 'int8' or data.dtype == 'uint8'):
+            return conv2d_NCHWc_int8(
+                cfg, data, kernel, strides, padding, dilation, layout, out_dtype)
 
     if layout == 'NCHW':
         return nn.conv2d_nchw(data, kernel, strides, padding, dilation, out_dtype)

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -17,6 +17,7 @@
 # pylint: disable=invalid-name
 """Compute definition for conv2d with cuda backend"""
 import tvm
+import topi
 from tvm import autotvm
 from tvm.contrib import cudnn
 
@@ -104,8 +105,9 @@ def conv2d_cuda(cfg, data, kernel, strides, padding, dilation, layout='NCHW', ou
     if cfg.template_key == 'winograd':
         return winograd_cuda(cfg, data, kernel, strides, padding, dilation, layout, out_dtype,
                              pre_computed=False)
-    if cfg.template_key == 'int8':
-        return conv2d_NCHWc_int8(cfg, data, kernel, strides, padding, dilation, layout, out_dtype)
+    if cfg.template_key == 'int8' :
+        if (data.dtype=='int8' or data.dtype=='uint8'):
+            return conv2d_NCHWc_int8(cfg, data, kernel, strides, padding, dilation, layout, out_dtype)
 
     if layout == 'NCHW':
         return nn.conv2d_nchw(data, kernel, strides, padding, dilation, out_dtype)

--- a/topi/python/topi/cuda/conv2d.py
+++ b/topi/python/topi/cuda/conv2d.py
@@ -17,7 +17,6 @@
 # pylint: disable=invalid-name
 """Compute definition for conv2d with cuda backend"""
 import tvm
-import topi
 from tvm import autotvm
 from tvm.contrib import cudnn
 


### PR DESCRIPTION
The current Qconfig only allows layers at the beginning of a network to be left at full precision. However many architectures might require layers near the output to remain at high precision. I've added an option to explicitly skip specific convolutions anywhere in the network.