### PR TITLE
[Bugfix] Check file exists before removing it

### DIFF
--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -111,7 +111,8 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
         except Exception as err:
             retries -= 1
             if retries == 0:
-                os.remove(tempfile)
+                if os.path.exists(tempfile):
+                    os.remove(tempfile)
                 raise err
             else:
                 print("download failed due to {}, retrying, {} attempt{} left"


### PR DESCRIPTION
`FileNotFoundError: [Errno 2] No such file or directory` is raised when trying to remove tmpfile that does not exist. This occurs when there is no network connection and there is no tophub cache.