### PR TITLE
[BugFix][VTA] Fix bug in vta runtime DepPop function.

### DIFF
--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -514,7 +514,7 @@ class InsnQueue : public BaseQueue {
     }
     // Impossible condition
     CHECK(from != kLoadStage || to != kStoreStage);
-    CHECK(to != kLoadStage || to != kComputeStage);
+    CHECK(from != kStoreStage || to != kLoadStage);
   }
   // Insert dependency push of load
   void DepPush(int from, int to) {


### PR DESCRIPTION
Issue:
    One of existing dependency check used a always true condition,
    and the intend logic actually should be a check for such illegal
    scenario of store and load.

Solution:
    Fix the said logic issue.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
