### PR TITLE
[BugFix][VTA] Fix vta_conv2d crash issue after change vta_config.json

### DIFF
--- a/vta/python/vta/top/vta_conv2d.py
+++ b/vta/python/vta/top/vta_conv2d.py
@@ -165,7 +165,7 @@ def find_schedules(layer, vt_only=False, best_only=False):
                     fil_sched.append(schedule)
                     xfer_size.append(_get_data_movement_byte(schedule, layer))
 
-    if best_only:
+    if best_only and xfer_size:
         return [fil_sched[xfer_size.index(min(xfer_size))]]
     return fil_sched
 
@@ -501,5 +501,10 @@ RESNET = {
 }
 
 for idx in RESNET:
-    scheds = find_schedules(RESNET[idx], vt_only=True, best_only=True)[0]
-    _WL2PLAN[RESNET[idx]] = scheds
+    f_schedules = find_schedules(RESNET[idx], vt_only=True, best_only=True)
+    if f_schedules:
+        scheds = f_schedules[0]
+        _WL2PLAN[RESNET[idx]] = scheds
+    else:
+        logging.warning("No valid schedule was found for the workload on current vta configuration")
+        break


### PR DESCRIPTION
configuration.

Issue:
Once change LOG_BLOCK_IN or LOG_BLOCK_OUT into > 4 value, when run vta
“Simple Matrix Multiply” or load vta, vta would crash at vta_conv2d.py.

Analysis:
This issue caused by resnet18 logic of vta_conv2d.py which have
in_filter minmum size that is 16. > 4 value would cause such in_filter
check failed then make xfer_size be empty and find_schedules function
return a empty list finally cause crash.

Solution:
add the empty list check.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
