### PR TITLE
[GraphRuntime] Layerwise timing in debug graph runtime

### DIFF
--- a/python/tvm/contrib/debugger/debug_result.py
+++ b/python/tvm/contrib/debugger/debug_result.py
@@ -207,10 +207,8 @@ class DebugResult(object):
     def display_debug_result(self):
         """Displays the debugger result"
         """
-        header = ["Node Name", "Ops", "Time(us)", "Time(%)", "Start Time", \
-                    "End Time", "Shape", "Inputs", "Outputs"]
-        lines = ["---------", "---", "--------", "-------", "----------", \
-                    "--------", "-----", "------", "-------"]
+        header = ["Node Name", "Ops", "Time(us)", "Time(%)", "Shape", "Inputs", "Outputs"]
+        lines = ["---------", "---", "--------", "-------", "-----", "------", "-------"]
         eid = 0
         data = []
         total_time = sum(time[0] for time in self._time_list)
@@ -223,12 +221,11 @@ class DebugResult(object):
                     continue
                 name = node['name']
                 shape = str(self._output_tensor_list[eid].shape)
-                time_us = round(time[0] * 1000000, 2)
-                time_percent = round(((time[0] / total_time) * 100), 2)
+                time_us = round(time[0] * 1000000, 3)
+                time_percent = round(((time[0] / total_time) * 100), 3)
                 inputs = str(node['attrs']['num_inputs'])
                 outputs = str(node['attrs']['num_outputs'])
-                node_data = [name, op, time_us, time_percent, str(time[1]), str(time[2]), \
-                             shape, inputs, outputs]
+                node_data = [name, op, time_us, time_percent, shape, inputs, outputs]
                 data.append(node_data)
                 eid += 1
         fmt = ""

--- a/tests/python/unittest/test_runtime_graph_debug.py
+++ b/tests/python/unittest/test_runtime_graph_debug.py
@@ -100,9 +100,6 @@ def test_graph_simple():
         out = mod.get_output(0, tvm.nd.empty((n,)))
         np.testing.assert_equal(out.asnumpy(), a + 1)
 
-        #test individual run
-        mod.run_individual(20, 2, 1)
-
         mod.exit()
         #verify dump root delete after cleanup
         assert(not os.path.exists(directory))
@@ -129,7 +126,6 @@ def test_graph_simple():
         mod.run(x=tvm.nd.array(a, ctx))
         out = tvm.nd.empty((n,), ctx=ctx)
         out = mod.get_output(0, out)
-        mod.run_individual(20, 2, 1)
         np.testing.assert_equal(out.asnumpy(), a + 1)
 
     check_verify()


### PR DESCRIPTION
The debug_run in the debug graph runtime runs each layer individually and only once, which is not the best way to get the layerwise timing.  The PR replaces debug_run with the more accurate run_individual (implemented in https://github.com/dmlc/tvm/pull/2569) in the python debug graph runtime. 

Before:
```
Node Name  Ops    Time(us)  Time(%)  Start Time       End Time         Shape  Inputs  Outputs  
---------  ---    --------  -------  ----------       --------         -----  ------  -------  
add        myadd  4.54      83.5     21:16:40.659529  21:16:40.659548  (4,)   1       1        
Node Name  Ops    Time(us)  Time(%)  Start Time       End Time         Shape  Inputs  Outputs  
---------  ---    --------  -------  ----------       --------         -----  ------  -------  
add        myadd  1.15      78.68    21:16:40.794619  21:16:40.794770  (4,)   1       1        
```
After:
```
Node Name  Ops    Time(us)  Time(%)  Shape  Inputs  Outputs  
---------  ---    --------  -------  -----  ------  -------  
add        myadd  0.071     100.0    (4,)   1       1        
Node Name  Ops    Time(us)  Time(%)  Shape  Inputs  Outputs  
---------  ---    --------  -------  -----  ------  -------  
add        myadd  0.06      100.0    (4,)   1       1        
```
Note myadd actually only takes about 0.06 - 0.07 us to run, if you warm the cache up first. In the case of a full model, the right way to get layerwise timing is to let the model run continuously with minimal interruptions for a fixed amount of time, and then take the average to get the runtime of individual layers.

@icemelon9 and @antinucleon  please review