### PR TITLE
[Relay][Transform] merge PassContext and BuildConfig

### DIFF
--- a/docs/api/python/relay/transform.rst
+++ b/docs/api/python/relay/transform.rst
@@ -15,16 +15,33 @@
     specific language governing permissions and limitations
     under the License.
 
-tvm.relay.build_module
+tvm.relay.transform
 ----------------------
 
-.. automodule:: tvm.relay.build_module
+.. automodule:: tvm.relay.transform
 
-.. autofunction:: tvm.relay.build_module.build
+.. autofunction:: tvm.relay.transform.build_config
 
-.. autofunction:: tvm.relay.build_module.optimize
+.. autofunction:: tvm.relay.transform.module_pass
 
-.. autofunction:: tvm.relay.build_module.create_executor
+.. autofunction:: tvm.relay.transform.function_pass
 
-.. autoclass:: tvm.relay.build_module.GraphExecutor
+.. autofunction:: tvm.relay.transform.current_pass_context
+
+.. autoclass:: tvm.relay.transform.Pass
+    :members:
+
+.. autoclass:: tvm.relay.transform.PassInfo
+    :members:
+
+.. autoclass:: tvm.relay.transform.PassContext
+    :members:
+
+.. autoclass:: tvm.relay.transform.ModulePass
+    :members:
+
+.. autoclass:: tvm.relay.transform.FunctionPass
+    :members:
+
+.. autoclass:: tvm.relay.transform.Sequential
     :members:

--- a/docs/api/python/relay/transform.rst
+++ b/docs/api/python/relay/transform.rst
@@ -26,8 +26,6 @@ tvm.relay.transform
 
 .. autofunction:: tvm.relay.transform.function_pass
 
-.. autofunction:: tvm.relay.transform.current_pass_context
-
 .. autoclass:: tvm.relay.transform.Pass
     :members:
 

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -61,6 +61,7 @@
 #include <tvm/relay/expr.h>
 #include <tvm/relay/module.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace tvm {

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -71,20 +71,8 @@ namespace transform {
  * \brief A data structure to map the names of specific optimizations to
  *        numeric optimization levels
  */
-struct OptPassLevel {
-  static const std::unordered_map<std::string, int> CreateMap() {
-    const std::unordered_map<std::string, int> m = {
-      {"SimplifyInference", 0},
-      {"OpFusion", 1},
-      {"FoldConstant", 2},
-      {"CombineParallelConv2D", 3},
-      {"FoldScaleAxis", 3},
-      {"AlterOpLayout", 3},
-      {"CanonicalizeOps", 3},
-      {"EliminateCommonSubexpr", 3}
-    };
-    return m;
-  }
+class OptPassLevel {
+ public:
   /*!
    * \brief Get level for an optimization pass
    *
@@ -98,6 +86,21 @@ struct OptPassLevel {
       return -1;
     }
     return it->second;
+  }
+
+ private:
+  static const std::unordered_map<std::string, int> CreateMap() {
+    const std::unordered_map<std::string, int> m = {
+      {"SimplifyInference", 0},
+      {"OpFusion", 1},
+      {"FoldConstant", 2},
+      {"CombineParallelConv2D", 3},
+      {"FoldScaleAxis", 3},
+      {"AlterOpLayout", 3},
+      {"CanonicalizeOps", 3},
+      {"EliminateCommonSubexpr", 3}
+    };
+    return m;
   }
 };
 
@@ -128,31 +131,6 @@ class PassContextNode : public RelayNode {
   /*! \brief The list of disabled passes. */
   tvm::Array<tvm::Expr> disabled_pass;
 
-  /*! 
-   * \brief A helper struct to get the optimization pass name to opt level
-   * mapping.
-   */
-  OptPassLevel OPT_PASS_LEVEL;
-
-  /*!
-   * \brief Convert a list of tvm StringImm to a `std::string` set.
-   *
-   * \param input. The input StringImm array.
-   *
-   * \return The coverted `std::strin`g set.
-   */
-  std::unordered_set<std::string> ToStringSet(
-      const tvm::Array<tvm::Expr>& input) const;
-
-  /*!
-   * \brief Check if a pass is enabled.
-   *
-   * \param pass_name The name of an optimization/analysis pass.
-   *
-   * \return true if the pass is enabled. Otherwise, false.
-   */
-  bool pass_enabled(const std::string& pass_name) const;
-
   PassContextNode() = default;
 
   void VisitAttrs(tvm::AttrVisitor* v) final {
@@ -175,6 +153,7 @@ class PassContext : public NodeRef {
                       tvm::Array<tvm::Expr> required_pass,
                       tvm::Array<tvm::Expr> disabled_pass);
 
+  // Move exter/exit to private once #3231 is merged.
   // The entry of a pass context scope.
   TVM_DLL static void EnterWithScope(const PassContext& pass_ctx);
   // The exit of a pass context scope.
@@ -185,7 +164,7 @@ class PassContext : public NodeRef {
   const PassContextNode* operator->() const;
 
   using ContainerType = PassContextNode;
-  class Internal;
+  // class Internal;
 
  private:
   // Classes to get the Python `with` like syntax. Enabled after #3231 is merged
@@ -255,8 +234,8 @@ class PassNode : public RelayNode {
    */
   virtual Module operator()(const Module& mod) const = 0;
 
-  virtual Module Apply(const Module& mod,
-                       const PassContext& pass_ctx) const = 0;
+  virtual Module operator()(const Module& mod,
+                            const PassContext& pass_ctx) const = 0;
 
   void VisitAttrs(tvm::AttrVisitor* v) override {}
 

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -56,6 +56,7 @@
 #ifndef TVM_RELAY_TRANSFORM_H_
 #define TVM_RELAY_TRANSFORM_H_
 
+#include <tvm/base.h>
 #include <tvm/packed_func_ext.h>
 #include <tvm/relay/error.h>
 #include <tvm/relay/expr.h>
@@ -117,23 +118,23 @@ class PassContext : public NodeRef {
                       tvm::Array<tvm::Expr> required_pass,
                       tvm::Array<tvm::Expr> disabled_pass);
 
-  // Move exter/exit to private once #3231 is merged.
-  // The entry of a pass context scope.
-  TVM_DLL static void EnterWithScope(const PassContext& pass_ctx);
-  // The exit of a pass context scope.
-  TVM_DLL static void ExitWithScope();
   // Get the currently used pass context.
   TVM_DLL static PassContext Current();
 
   const PassContextNode* operator->() const;
 
   using ContainerType = PassContextNode;
-  // class Internal;
+  class Internal;
 
  private:
-  // Classes to get the Python `with` like syntax. Enabled after #3231 is merged
-  // friend class Internal;
-  // friend class With<PassContext>;
+  // The entry of a pass context scope.
+  TVM_DLL void EnterWithScope();
+  // The exit of a pass context scope.
+  TVM_DLL void ExitWithScope();
+
+  // Classes to get the Python `with` like syntax.
+  friend class Internal;
+  friend class tvm::With<PassContext>;
 };
 
 /*

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -68,43 +68,6 @@ namespace tvm {
 namespace relay {
 namespace transform {
 
-/*!
- * \brief A data structure to map the names of specific optimizations to
- *        numeric optimization levels
- */
-class OptPassLevel {
- public:
-  /*!
-   * \brief Get level for an optimization pass
-   *
-   * \param key pass name
-   * \return int level
-   */
-  int operator[](const std::string& key) const {
-    const auto data = CreateMap();
-    auto it = data.find(key);
-    if (it == data.end()) {
-      return -1;
-    }
-    return it->second;
-  }
-
- private:
-  static const std::unordered_map<std::string, int> CreateMap() {
-    const std::unordered_map<std::string, int> m = {
-      {"SimplifyInference", 0},
-      {"OpFusion", 1},
-      {"FoldConstant", 2},
-      {"CombineParallelConv2D", 3},
-      {"FoldScaleAxis", 3},
-      {"AlterOpLayout", 3},
-      {"CanonicalizeOps", 3},
-      {"EliminateCommonSubexpr", 3}
-    };
-    return m;
-  }
-};
-
 /*
  * \brief The context of pass.
  */
@@ -233,7 +196,9 @@ class PassNode : public RelayNode {
    *
    * \return The updated module.
    */
-  virtual Module operator()(const Module& mod) const = 0;
+  Module operator()(const Module& mod) const {
+    return this->operator()(mod, PassContext::Current());
+  }
 
   virtual Module operator()(const Module& mod,
                             const PassContext& pass_ctx) const = 0;

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -26,7 +26,8 @@ from . import module
 from . import adt
 from . import ir_pass
 from . import transform
-from .build_module import build, build_config, create_executor
+from .build_module import build, create_executor
+from .transform import build_config
 from . import prelude
 from . import parser
 from . import debug

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -118,7 +118,7 @@ class BuildModule(object):
         return graph_json, mod, params
 
     def _setup_build_config(self, params):
-        cfg = _transform.current_pass_context()
+        cfg = _transform.PassContext.current()
 
         # Set opt_level.
         self.set_opt_level(cfg.opt_level)

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -28,80 +28,9 @@ from . import _build_module
 from . import ir_pass
 from . import ty as _ty
 from . import expr as _expr
+from . import transform as _transform
 from .backend import interpreter as _interpreter
 from .backend.vm import VMExecutor
-
-class BuildConfig(object):
-    """Configuration scope to set a build config option.
-
-    Parameters
-    ----------
-    kwargs
-        Keyword arguments of configurations to set.
-    """
-    current = None
-    defaults = {
-        "opt_level": 2,
-        "add_pass": None,
-        "disable_pass": None,
-        "fallback_device": None,
-    }
-
-    def __init__(self, **kwargs):
-        self._old_scope = None
-        for k, _ in kwargs.items():
-            if k not in BuildConfig.defaults:
-                raise ValueError("invalid argument %s, candidates are %s" %
-                                 (k, BuildConfig.defaults.keys()))
-        self._attr = kwargs
-
-    def __getattr__(self, name):
-        if name not in self._attr:
-            return BuildConfig.defaults[name]
-        return self._attr[name]
-
-    def __enter__(self):
-        # pylint: disable=protected-access
-        self._old_scope = BuildConfig.current
-        attr = BuildConfig.current._attr.copy()
-        attr.update(self._attr)
-        self._attr = attr
-        BuildConfig.current = self
-        return self
-
-    def __exit__(self, ptype, value, trace):
-        assert self._old_scope
-        BuildConfig.current = self._old_scope
-
-
-BuildConfig.current = BuildConfig()
-
-
-def build_config(**kwargs):
-    """Configure the build behavior by setting config variables.
-
-    Parameters
-    ----------
-    opt_level: int, default=2
-        Optimization level. See OPT_PASS_LEVEL for level of each pass.
-
-    add_pass: set of str
-        Optimization pass to be added regardless of optimization level.
-
-    disable_pass: set of str
-        Optimization pass to be disabled during optimization.
-
-    fallback_device : str or tvm.TVMContext
-        The fallback device. It is also used as the default device for
-        operators without specified device during heterogeneous execution.
-
-    Returns
-    -------
-    config: BuildConfig
-        The build configuration
-    """
-    return BuildConfig(**kwargs)
-
 
 def _update_target(target):
     target = target if target else _target.current_target()
@@ -189,7 +118,7 @@ class BuildModule(object):
         return graph_json, mod, params
 
     def _setup_build_config(self, params):
-        cfg = BuildConfig.current
+        cfg = _transform.current_pass_context()
 
         # Set opt_level.
         self.set_opt_level(cfg.opt_level)
@@ -199,24 +128,24 @@ class BuildModule(object):
             self.set_fallback_device(cfg.fallback_device)
 
         # Add required passes.
-        if cfg.add_pass:
+        if cfg.required_pass:
             passes = set()
-            if isinstance(cfg.add_pass, (list, tuple, set)):
-                passes = set(cfg.add_pass)
+            if isinstance(cfg.required_pass, (list, tuple, set)):
+                passes = set(cfg.required_pass)
             else:
                 raise TypeError("add_pass must be list, tuple, or set, but " +
-                                "got {}".format(type(cfg.add_pass)))
+                                "got {}".format(type(cfg.required_pass)))
             for pass_name in passes:
                 self.add_pass(pass_name)
 
         # Add disabled passes.
-        if cfg.disable_pass:
+        if cfg.disabled_pass:
             passes = set()
-            if isinstance(cfg.disable_pass, (list, tuple, set)):
-                passes = set(cfg.disable_pass)
+            if isinstance(cfg.disabled_pass, (list, tuple, set)):
+                passes = set(cfg.disabled_pass)
             else:
                 raise TypeError("disable_pass must be list, tuple, or set, " +
-                                "but got {}".format(type(cfg.disable_pass)))
+                                "but got {}".format(type(cfg.disabled_pass)))
             for pass_name in passes:
                 self.disable_pass(pass_name)
 
@@ -287,12 +216,11 @@ class BuildModule(object):
         fallback_device : str or tvm.TVMContext
             The fallback device used for heterogeneous execution.
         """
-        if isinstance(fallback_device, str):
+        if isinstance(fallback_device, (int, str)):
             fallback_device = _nd.context(fallback_device)
         if not isinstance(fallback_device, TVMContext):
-            raise TypeError("fallback_device is expected to be str " +
-                            "TVMContext, or dict of device name to target, " +
-                            "but received: {}".format(type(fallback_device)))
+            raise TypeError("fallback_device is expected to be str, int, or " +
+                            "TVMContext but received: {}".format(type(fallback_device)))
 
         self._set_fallback_device(fallback_device.device_type)
 

--- a/python/tvm/relay/quantize/quantize.py
+++ b/python/tvm/relay/quantize/quantize.py
@@ -22,7 +22,7 @@ import numpy as np
 from . import _quantize
 from .. import expr as _expr
 from .. import ir_pass as _ir_pass
-from .. import build_module as _build
+from .. import transform as _transform
 from .. import op as _op
 from ... import make as _make
 from ..base import NodeBase, register_relay_node
@@ -301,7 +301,7 @@ def optimize(func, params=None):
                   "FoldConstant",
                   "CanonicalizeOps"]
 
-    cfg = _build.build_config(add_pass=opt_passes)
+    cfg = _transform.build_config(required_pass=opt_passes)
 
     if params:
         name_dict = {}
@@ -321,25 +321,25 @@ def optimize(func, params=None):
             bind_dict[arg] = _expr.const(v)
         func = _expr.bind(func, bind_dict)
 
-    if "SimplifyInference" in cfg.add_pass:
+    if "SimplifyInference" in cfg.required_pass:
         func = _ir_pass.infer_type(func)
         func = _ir_pass.simplify_inference(func)
 
-    if "FoldConstant" in cfg.add_pass:
+    if "FoldConstant" in cfg.required_pass:
         func = _ir_pass.fold_constant(func)
 
-    if "FoldScaleAxis" in cfg.add_pass:
+    if "FoldScaleAxis" in cfg.required_pass:
         func = _ir_pass.infer_type(func)
         func = _ir_pass.backward_fold_scale_axis(func)
         func = _ir_pass.infer_type(func)
         func = _ir_pass.forward_fold_scale_axis(func)
         func = _ir_pass.fold_constant(func)
 
-    if "CanonicalizeOps" in cfg.add_pass:
+    if "CanonicalizeOps" in cfg.required_pass:
         func = _ir_pass.infer_type(func)
         func = _ir_pass.canonicalize_ops(func)
 
-    if "FoldConstant" in cfg.add_pass:
+    if "FoldConstant" in cfg.required_pass:
         func = _ir_pass.fold_constant(func)
 
     return func

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -63,14 +63,14 @@ class PassContext(RelayNode):
     opt_level : Optional[int]
         The optimization level of this pass.
 
-    fallback_device : Optional[int]
+    fallback_device : Optional[Union[int, str, TVMContext]]
         The fallback device type. It is also used as the default device for
         operators that are not annotated during heterogeneous execution.
 
-    required_pass : Optional[List[str]]
+    required_pass : Optional[Union[List[str], Set[str], Tuple[str]]]
         The list of passes that are required by a certain pass.
 
-    disabled_pass : Optional[List[str]]
+    disabled_pass : Optional[Union[List[str], Set[str], Tuple[str]]]
         The list of passes that are disabled.
     """
     def __init__(self,
@@ -107,10 +107,10 @@ class PassContext(RelayNode):
     def __exit__(self, ptype, value, trace):
         _transform.ExitPassContext(self)
 
-
-def current_pass_context():
-    """Return the current pass context."""
-    return _transform.GetCurrentPassContext()
+    @staticmethod
+    def current():
+        """Return the current pass context."""
+        return _transform.GetCurrentPassContext()
 
 
 def build_config(opt_level=2,

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -118,25 +118,39 @@ def build_config(opt_level=2,
                  required_pass=None,
                  disabled_pass=None):
     """Configure the build behavior by setting config variables.
+
     Parameters
     ----------
-    opt_level: int, default=2
-        Optimization level. See include/tvm/relay/transform.h for level of each
-        pass.
+    opt_level: int, optional
+        Optimization level. The optimization pass name and level are as the
+        following:
 
-    fallback_device : int or tvm.TVMContext
+        .. code-block:: python
+
+            OPT_PASS_LEVEL = {
+                "SimplifyInference": 0,
+                "OpFusion": 1,
+                "FoldConstant": 2,
+                "CombineParallelConv2D": 3,
+                "FoldScaleAxis": 3,
+                "AlterOpLayout": 3,
+                "CanonicalizeOps": 3,
+                "EliminateCommonSubexpr": 3,
+            }
+
+    fallback_device : int, str, or tvm.TVMContext, optional
         The fallback device. It is also used as the default device for
         operators without specified device during heterogeneous execution.
 
-    required_pass: set of str
+    required_pass: set of str, optional
         Optimization passes that are required regardless of optimization level.
 
-    disabled_pass: set of str
+    disabled_pass: set of str, optional
         Optimization passes to be disabled during optimization.
 
     Returns
     -------
-    config: PassContext
+    pass_context: PassContext
         The pass context for optimizations.
     """
     return PassContext(opt_level, fallback_device, required_pass,

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -23,8 +23,10 @@ conveniently.
 """
 import types
 
+from tvm._ffi.runtime_ctypes import TVMContext
 from . import _transform
 from .base import RelayNode, register_relay_node
+from .. import nd as _nd
 
 
 @register_relay_node
@@ -57,10 +59,99 @@ class PassContext(RelayNode):
     Each pass context contains a number of auxiliary information that is used
     to help an optimization pass. Such information includes the error reporter
     to record the errors of during the optimization, etc.
-    """
 
-    def __init__(self):
-        self.__init_handle_by_constructor__(_transform.PassContext)
+    opt_level : Optional[int]
+        The optimization level of this pass.
+
+    fallback_device : Optional[int]
+        The fallback device type. It is also used as the default device for
+        operators that are not annotated during heterogeneous execution.
+
+    required_pass : Optional[List[str]]
+        The list of passes that are required by a certain pass.
+
+    disabled_pass : Optional[List[str]]
+        The list of passes that are disabled.
+    """
+    defaults = {
+        "opt_level": 2,
+        "required_pass": None,
+        "disabled_pass": None,
+        "fallback_device": _nd.cpu(),
+    }
+
+    def __init__(self, **kwargs):
+        for k, _ in kwargs.items():
+            if k not in PassContext.defaults:
+                raise ValueError("invalid argument %s, candidates are %s" %
+                                 (k, PassContext.defaults.keys()))
+
+        fallback_device = kwargs["fallback_device"] if "fallback_device" in \
+                            kwargs else PassContext.defaults["fallback_device"]
+        if isinstance(fallback_device, str):
+            fallback_device = _nd.context(fallback_device).device_type
+        elif isinstance(fallback_device, TVMContext):
+            fallback_device = fallback_device.device_type
+        if not isinstance(fallback_device, int):
+            raise TypeError("required_pass is expected to be the type of " +
+                            "int/str/TVMContext.")
+
+        required = kwargs["required_pass"] if "required_pass" in kwargs \
+                    else PassContext.defaults["required_pass"]
+        required = required if required else []
+        if not isinstance(required, (list, tuple)):
+            raise TypeError("required_pass is expected to be the type of " +
+                            "list/tuple/set.")
+
+        disabled = kwargs["disabled_pass"] if "disabled_pass" in kwargs \
+                    else PassContext.defaults["disabled_pass"]
+        disabled = disabled if disabled else []
+        if not isinstance(disabled, (list, tuple)):
+            raise TypeError("disabled_pass is expected to be the type of " +
+                            "list/tuple/set.")
+
+        opt_level = kwargs["opt_level"] if "opt_level" in kwargs \
+                    else PassContext.defaults["opt_level"]
+
+        self.__init_handle_by_constructor__(_transform.PassContext, opt_level,
+                                            fallback_device, required,
+                                            disabled)
+
+    def __enter__(self):
+        _transform.EnterPassContext(self)
+        return self
+
+    def __exit__(self, ptype, value, trace):
+        _transform.ExitPassContext(self)
+
+
+def current_pass_context():
+    """Return the current pass context."""
+    return _transform.GetCurrentPassContext()
+
+
+def build_config(**kwargs):
+    """Configure the build behavior by setting config variables.
+    Parameters
+    ----------
+    opt_level: int, default=2
+        Optimization level. See OPT_PASS_LEVEL for level of each pass.
+
+    required_pass: set of str
+        Optimization passes that are required regardless of optimization level.
+
+    disabled_pass: set of str
+        Optimization passes to be disabled during optimization.
+
+    fallback_device : int or tvm.TVMContext
+        The fallback device. It is also used as the default device for
+        operators without specified device during heterogeneous execution.
+    Returns
+    -------
+    config: PassContext
+        The pass context for optimizations.
+    """
+    return PassContext(**kwargs)
 
 
 @register_relay_node
@@ -69,20 +160,6 @@ class Pass(RelayNode):
     that are implemented in the backend. They are defined for users to
     conveniently interact with the base class.
     """
-
-    def set_pass_context(self, pass_ctx):
-        """Setup the pass context for analysis and optimizations. This context
-        could be shared by different passes for sequential passes.
-
-        Parameters
-        ----------
-        pass_ctx : PassContext
-            The context that is used to help perform a certain pass or a series
-            of passes.
-        """
-        if not isinstance(pass_ctx, PassContext):
-            raise TypeError("pass_ctx is expected to be the PassContext type")
-        _transform.SetContext(self, pass_ctx)
 
     @property
     def info(self):
@@ -150,32 +227,23 @@ class Sequential(Pass):
 
     required : Optional[List[str]]
         The list of passes that the sequential pass is dependent on.
-
-    disabled : Optional[List[str]]
-        A list of disabled passes.
     """
 
     def __init__(self,
                  passes=None,
                  opt_level=2,
                  name="sequential",
-                 required=None,
-                 disabled=None):
+                 required=None):
         passes = passes if passes else []
         if not isinstance(passes, (list, tuple)):
             raise TypeError("passes must be a list of Pass objects.")
-
-        disabled = disabled if disabled else []
-        if not isinstance(disabled, (list, tuple)):
-            raise TypeError("disabled must be a list or tuple of pass names")
 
         required = required if required else []
         if not isinstance(required, (list, tuple)):
             raise TypeError("Required is expected to be the type of list/tuple.")
 
         self.__init_handle_by_constructor__(_transform.Sequential,
-                                            passes, opt_level, name, required,
-                                            disabled)
+                                            passes, opt_level, name, required)
 
 
 def module_pass(pass_func=None, opt_level=None, name=None, required=None):

--- a/src/relay/pass/pass_manager.cc
+++ b/src/relay/pass/pass_manager.cc
@@ -406,6 +406,14 @@ Sequential::Sequential(tvm::Array<Pass> passes, PassInfo pass_info) {
   node_ = std::move(n);
 }
 
+Sequential::Sequential(tvm::Array<Pass> passes, std::string name) {
+  auto n = make_node<SequentialNode>();
+  n->passes = std::move(passes);
+  PassInfo pass_info = PassInfoNode::make(2, std::move(name), {});
+  n->pass_info = std::move(pass_info);
+  node_ = std::move(n);
+}
+
 const SequentialNode* Sequential::operator->() const {
   return static_cast<const SequentialNode*>(this->node_.get());
 }

--- a/tests/python/frontend/coreml/test_forward.py
+++ b/tests/python/frontend/coreml/test_forward.py
@@ -31,7 +31,7 @@ import model_zoo
 
 def get_tvm_output(func, x, params, target, ctx,
                    out_shape=(1, 1000), input_name='image', dtype='float32'):
-    with relay.build_module.build_config(opt_level=3):
+    with relay.transform.build_config(opt_level=3):
         graph, lib, params = relay.build(func, target, params=params)
     m = graph_runtime.create(graph, lib, ctx)
     # set inputs
@@ -72,7 +72,7 @@ def run_tvm_graph(coreml_model, target, ctx, input_data, input_name, output_shap
         dtype_dict = {input_name: input_data.dtype}
 
     func, params = relay.frontend.from_coreml(coreml_model, shape_dict)
-    with relay.build_module.build_config(opt_level=3):
+    with relay.transform.build_config(opt_level=3):
         graph, lib, params = relay.build(func, target, params=params)
 
     from tvm.contrib import graph_runtime

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -43,7 +43,7 @@ def verify_keras_frontend(keras_model, need_transpose=True):
     def get_tvm_output(xs, target, ctx, dtype='float32'):
         shape_dict = {name: x.shape for (name, x) in zip(keras_model.input_names, xs)}
         func, params = relay.frontend.from_keras(keras_model, shape_dict)
-        with relay.build_module.build_config(opt_level=2):
+        with relay.transform.build_config(opt_level=2):
             graph, lib, params = relay.build(func, target, params=params)
         m = graph_runtime.create(graph, lib, ctx)
         for name, x in zip(keras_model.input_names, xs):

--- a/tutorials/frontend/from_tflite.py
+++ b/tutorials/frontend/from_tflite.py
@@ -144,7 +144,7 @@ func, params = relay.frontend.from_tflite(tflite_model,
 
 # target x86 CPU
 target = "llvm"
-with relay.build_module.build_config(opt_level=3):
+with relay.transform.build_config(opt_level=3):
     graph, lib, params = relay.build(func, target, params=params)
 
 ######################################################################


### PR DESCRIPTION
This is a draft PR to:

- [x] Merge `BuildConfig` and `PassContext` in both Python and C++ as `BuildConfig` is mainly used for managing pass configs. Python side is done. C++ `BuildConfig` will be replaced by `PassContext` when we start migrating `optimize` in `build_module` which is the next task.
- [x] Make pass manager be able to execute passes using `with` statement where configs like `opt_level` and `disabled_passes` are specified, as pointed out in #3202 
- [x] Alter `Sequential` API to support `with` syntax.

After this change, we should be able to test the given example once the passes are registered with `Pass MyPass(xxx)`.

cc @tqchen @jroesch, @MarisaKirisame @wweic 
