### PR TITLE
[Bugfix] Fix a memory leak in OpManager

### DIFF
--- a/src/relay/ir/op.cc
+++ b/src/relay/ir/op.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -56,6 +56,13 @@ struct OpManager {
   static OpManager* Global() {
     static OpManager inst;
     return &inst;
+  }
+  ~OpManager() {
+    for (PackedFunc* func : frontend_funcs) {
+      if (func) {
+        delete func;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Add destructor in OpManager to delete `frontend_funcs`.

Memory leak caught by LeakSanitizer:
```
==2522658==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x48f130 in operator new(unsigned long) (/data/users/hlu/tvm/sparse/tvm_sparse_benchmark.cc+0x48f130)
    #1 0x7efd36d620dd in tvm::relay::$_2::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const tvm/tvm/src/relay/ir/op.cc:152
    #2 0x7efd36d613e8 in std::_Function_handler<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*), tvm::relay::$_2>::_M_invoke(std::_Any_data const&, tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) third-party-buck/platform007/build/libgcc/include/c++/7.3.0/bits/std_function.h:316
    #3 0x7efd37fa4d08 in std::function<void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*) const third-party-buck/platform007/build/libgcc/include/c++/7.3.0/bits/std_function.h:706
    #4 0x7efd37f9d022 in tvm::runtime::TVMRetValue tvm::runtime::PackedFunc::operator()<char const (&) [4], char const (&) [13], tvm::runtime::TypedPackedFunc<tvm::Schedule (tvm::Attrs const&, tvm::Array<tvm::Tensor, void> const&, tvm::Target const&)>&, int>(char const (&) [4], char const (&) [13], tvm::runtime::TypedPackedFunc<tvm::Schedule (tvm::Attrs const&, tvm::Array<tvm::Tensor, void> const&, tvm::Target const&)>&, int&&) const tvm/tvm/include/tvm/runtime/packed_func.h:1205
    #5 0x7efd37f9acf4 in tvm::registerTopiSchedules()::$_0::operator()() const caffe2/caffe2/fb/tvm/topi/topi_init.cc:53
    #6 0x7efd37f99abc in void std::__invoke_impl<void, tvm::registerTopiSchedules()::$_0>(std::__invoke_other, tvm::registerTopiSchedules()::$_0&&) third-party-buck/platform007/build/libgcc/include/c++/7.3.0/bits/invoke.h:60
    #7 0x7efd37f99a8c in std::__invoke_result<tvm::registerTopiSchedules()::$_0>::type std::__invoke<tvm::registerTopiSchedules()::$_0>(tvm::registerTopiSchedules()::$_0&&) third-party-buck/platform007/build/libgcc/include/c++/7.3.0/bits/invoke.h:95
    #8 0x7efd37f9972c in std::invoke_result<tvm::registerTopiSchedules()::$_0>::type std::invoke<tvm::registerTopiSchedules()::$_0>(tvm::registerTopiSchedules()::$_0&&) third-party-buck/platform007/build/libgcc/include/c++/7.3.0/functional:80
    #9 0x7efd37f9957a in void folly::basic_once_flag<folly::SharedMutexImpl<false, void, std::atomic, false, false>, std::atomic>::call_once_slow<tvm::registerTopiSchedules()::$_0>(tvm::registerTopiSchedules()::$_0&&) buck-out/dev/gen/folly/synchronization/call_once#header-mode-symlink-tree-with-header-map,headers/folly/synchronization/CallOnce.h:110
    #10 0x7efd37f99165 in void folly::basic_once_flag<folly::SharedMutexImpl<false, void, std::atomic, false, false>, std::atomic>::call_once<tvm::registerTopiSchedules()::$_0>(tvm::registerTopiSchedules()::$_0&&) buck-out/dev/gen/folly/synchronization/call_once#header-mode-symlink-tree-with-header-map,headers/folly/synchronization/CallOnce.h:101
    #11 0x7efd37f99165 in void folly::call_once<folly::SharedMutexImpl<false, void, std::atomic, false, false>, std::atomic, tvm::registerTopiSchedules()::$_0>(folly::basic_once_flag<folly::SharedMutexImpl<false, void, std::atomic, false, false>, std::atomic>&, tvm::registerTopiSchedules()::$_0&&) buck-out/dev/gen/folly/synchronization/call_once#header-mode-symlink-tree-with-header-map,headers/folly/synchronization/CallOnce.h:57
    #12 0x7efd37f99165 in tvm::registerTopiSchedules() caffe2/caffe2/fb/tvm/topi/topi_init.cc:26
    #13 0x4369e4 in main tvm/sparse/tvm_sparse_benchmark.cc:125
    #14 0x7efd1c7c81a5 in __libc_start_main /home/engshare/third-party2/glibc/2.26/src/glibc-2.26/csu/libc-start.c:308:16
    #15 0x432ce9 in _start /home/engshare/third-party2/glibc/2.26/src/glibc-2.26/sysdeps/x86_64/start.S:120
```
@tqchen, @jroesch, please review. 