### PR TITLE
[VTA][TSIM] Use Module instead of RawModule for testbench by creating an empty bundle for the IO

### DIFF
--- a/vta/apps/tsim_example/config/config.json
+++ b/vta/apps/tsim_example/config/config.json
@@ -1,5 +1,5 @@
 {
-  "TARGET" : "verilog",
+  "TARGET" : "chisel",
   "TOP_NAME" : "TestAccel",
   "BUILD_NAME" : "build",
   "USE_TRACE" : "OFF",

--- a/vta/apps/tsim_example/config/config.json
+++ b/vta/apps/tsim_example/config/config.json
@@ -1,5 +1,5 @@
 {
-  "TARGET" : "chisel",
+  "TARGET" : "verilog",
   "TOP_NAME" : "TestAccel",
   "BUILD_NAME" : "build",
   "USE_TRACE" : "OFF",


### PR DESCRIPTION
RawModule is an experimental feature in Chisel, this PR eliminates the need for that feature.
