### PR TITLE
[RELAY][PASS] Move CombineParallelConv2D to opt level 4

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -65,7 +65,7 @@ const std::unordered_map<std::string, int> OptPassLevel::_data = {
   {"SimplifyInference", 0},
   {"OpFusion", 1},
   {"FoldConstant", 2},
-  {"CombineParallelConv2D", 3},
+  {"CombineParallelConv2D", 4},
   {"FoldScaleAxis", 3},
   {"AlterOpLayout", 3},
   {"CanonicalizeOps", 3},


### PR DESCRIPTION
As discussed in #2827 , `CombineParallelConv2d` doesn't always give better performance. We disabled this pass and will integrate it with graph tuner in the future.