### PR TITLE
kCustomBegin overlapped with kExtEnd; incr by 1

### DIFF
--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -115,7 +115,7 @@ typedef enum {
   kExtReserveEnd = 64U,
   kExtEnd = 128U,
   // The rest of the space is used for custom, user-supplied datatypes
-  kCustomBegin = 128U,
+  kCustomBegin = 129U,
 } TVMTypeCode;
 
 /*!


### PR DESCRIPTION
This was a typo in the original custom datatypes PR.