### PR TITLE
[TOPI] Fast tanh

### DIFF
--- a/topi/tests/python/test_topi_math.py
+++ b/topi/tests/python/test_topi_math.py
@@ -29,13 +29,21 @@ def test_util():
 
 
 def test_ewise():
-    m = tvm.var('m')
-    l = tvm.var('l')
-    A = tvm.placeholder((m, l), name='A')
+    def test_apply(
+        func,
+        name,
+        f_numpy,
+        low,
+        high,
+        shape=(20, 3),
+        dtype=tvm.float32,
+        check_round=False,
+        skip_name_check=False,
+    ):
+        m = tvm.var("m")
+        l = tvm.var("l")
+        A = tvm.placeholder((m, l), dtype=dtype, name="A")
 
-    shape = (20, 3)
-
-    def test_apply(func, name, f_numpy, low, high, check_round=False, skip_name_check=False):
         B = func(A)
         assert tuple(B.shape) == tuple(A.shape)
         if not skip_name_check:
@@ -63,7 +71,6 @@ def test_ewise():
         for device in get_all_backend():
             check_device(device)
 
-
     test_apply(topi.floor, "floor", np.floor, -100, 100)
     test_apply(topi.ceil, "ceil", np.ceil, -100, 100)
     test_apply(topi.sign, "sign", np.sign, -100, 100, skip_name_check=True)
@@ -71,11 +78,12 @@ def test_ewise():
     test_apply(topi.abs, "fabs", np.abs, -100, 100)
     test_apply(topi.round, "round", np.round, -100, 100, check_round=True)
     test_apply(topi.exp, "exp", np.exp, -1, 1)
-    test_apply(topi.tanh, "tanh", np.tanh, -10, 10)
-    test_apply(topi.sigmoid, "sigmoid", lambda x:1/(1+np.exp(-x)), -1, 1)
+    test_apply(topi.tanh, "tanh", np.tanh, -10, 10, shape=(128, 128))
+    test_apply(topi.tanh, "tanh", np.tanh, -10, 10, shape=(128, 128), dtype="float64")
+    test_apply(topi.sigmoid, "sigmoid", lambda x: 1 / (1 + np.exp(-x)), -1, 1)
     test_apply(topi.log, "log", np.log, 0, 100)
     test_apply(topi.sqrt, "sqrt", np.sqrt, 0, 100)
-    test_apply(topi.rsqrt, "rsqrt", lambda x:np.ones_like(x)/np.sqrt(x), 0, 100, skip_name_check=True)
+    test_apply(topi.rsqrt, "rsqrt", lambda x: np.ones_like(x) / np.sqrt(x), 0, 100, skip_name_check=True)
 
 
 def test_cast():
@@ -93,7 +101,7 @@ def test_cast():
         b_np = a_np.astype(to_dtype)
 
         for device in get_all_backend():
-            ctx = tvm.context(device,  0)
+            ctx = tvm.context(device, 0)
             if not ctx.exist:
                 print("Skip because %s is not enabled" % device)
                 continue


### PR DESCRIPTION
Borrowing the fast_tanh_float implementation from Eigen (https://github.com/eigenteam/eigen-git-mirror/blob/80f488a7bc9b7c64c9d0c0e8fb301fd905ad1b95/Eigen/src/Core/MathFunctionsImpl.h#L26) can bring about 28x speedup to tanh. 

benchmark:
```
target = "llvm -mcpu=core-avx2"
num_iter = 1000
num_cycles = 5
dtype = "float32"

def bench_tanh(func, m, n):
    a = relay.var("a", shape=(m, n))
    out = func(a)
    f = relay.ir_pass.infer_type(relay.Function([a], out))
    opt_level = 3

    with relay.build_config(opt_level=opt_level):
        graph, lib, params = relay.build(f, target, params={})
    print(graph)

    remote = tvm.rpc.LocalSession()
    tmp = tvm.contrib.util.tempdir()
    lib_fname = tmp.relpath("net.tar")
    with tvm.target.create(target):
        lib.export_library(lib_fname)

    remote.upload(lib_fname)
    lib = remote.load_module("net.tar")
    ctx = remote.cpu(0)

    module = graph_runtime.create(graph, lib, ctx)

    logging.debug(graph)

    input = {'a': np.random.uniform(low=-10, high=10, size=(m, n)).astype(np.float32)}
    module.set_input(**input)

    ftimer = module.module.time_evaluator("run", ctx, num_iter)
    for _ in range(num_cycles):
        prof_res = ftimer()
        print("TVM time: ", prof_res.mean * 1e6, " us")
        time.sleep(1)

bench_tanh(relay.tanh, 1024, 128)
```
Results:
```
before:
TVM time:  1512.9183090000001  us
TVM time:  1406.613658  us
TVM time:  1444.041799  us
TVM time:  1445.61708  us
TVM time:  1407.4704649999999  us

after:
TVM time:  49.699045999999996  us
TVM time:  57.133776999999995  us
TVM time:  57.434446  us
TVM time:  59.131979  us
TVM time:  57.127435999999996  us

speedup = 28x
```
The speedup is about the same on intel skylakes.