### PR TITLE
[Bugfix][VTA] PkgConfig cause crash in PYNQ board due to link library

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -55,7 +55,7 @@ elseif(PYTHON)
     set_target_properties(vta PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
   endif(APPLE)
 
-  # PYNQ rules for Pynq v2.3
+  # PYNQ rules for Pynq v2.4
   if(${VTA_TARGET} STREQUAL "pynq")
     find_library(__cma_lib NAMES cma PATH /usr/lib)
     target_link_libraries(vta ${__cma_lib})

--- a/docs/vta/install.md
+++ b/docs/vta/install.md
@@ -84,7 +84,7 @@ This guide covers the following themes:
 
 Setup your Pynq board based on the [Pynq board getting started tutorial](http://pynq.readthedocs.io/en/latest/getting_started.html).
 You should follow the instructions up to and including the *Turning On the PYNQ-Z1* step (no need to pursue the tutorial beyond this point).
-* Make sure that you've downloaded the latest Pynq image, [PYNQ-Z1 v2.3](http://www.pynq.io/board.html) (released October 3rd 2018), and have imaged your SD card with it (we recommend the free [Etcher](https://etcher.io/) program).
+* Make sure that you've downloaded the latest Pynq image, [PYNQ-Z1 v2.4](http://www.pynq.io/board.html)(released February 22rd 2019), and have imaged your SD card with it (we recommend the free [Etcher](https://etcher.io/) program).
 * For this test setup, follow the ["Connect to a Computer"](http://pynq.readthedocs.io/en/latest/getting_started.html#connect-to-a-computer) Ethernet setup instructions. To be able to talk to the board, make sure to [assign your computer a static IP address](http://pynq.readthedocs.io/en/latest/appendix.html#assign-your-computer-a-static-ip)
 
 Once the board is powered on and connected to your development machine, try connecting to it to make sure you've properly set up your Pynq board:

--- a/vta/python/vta/pkg_config.py
+++ b/vta/python/vta/pkg_config.py
@@ -77,10 +77,9 @@ class PkgConfig(object):
         if self.target == "pynq":
             self.ldflags = [
                 "-L/usr/lib",
-                "-lsds_lib",
                 "-L/opt/python3.6/lib/python3.6/site-packages/pynq/drivers/",
                 "-L/opt/python3.6/lib/python3.6/site-packages/pynq/lib/",
-                "-l:libdma.so"]
+                "-l:libcma.so"]
         else:
             self.ldflags = []
 


### PR DESCRIPTION
not exist.

Symptom:
When run vta_get_started.py with pynq board, host crash and
complain "cannot find -lsds_lib" and "cannot find -l:libdma.so"

Reproduce:
At pynq board, delete the ./build/vta_config.json, then run rpc
server.
In host machine run vta_get_started.py, issue would reproduce.

Analysis:
This issue caused by 'PkgConfig' function  still using pynq2.1
library which not exist in pynq2.3 anymore, when a "reconfig_runtime"
logic of rpc_server.py get triggered , the compile would failed due to
link library not exist.

Solution:
change the link library to libcma.so.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
