### PR TITLE
[Redo] Memory leak in OpManager

### DIFF
--- a/src/relay/ir/op.cc
+++ b/src/relay/ir/op.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -54,8 +54,8 @@ struct OpManager {
   std::vector<PackedFunc*> frontend_funcs;
   // get singleton of the op manager
   static OpManager* Global() {
-    static OpManager inst;
-    return &inst;
+    static OpManager* inst = new OpManager();
+    return inst;
   }
 };
 


### PR DESCRIPTION
Changing `OpManager inst` to a pointer avoids the leak sanitizer from complaining about memory leak at exit time. The idea comes from @ajtulloch.

@tqchen, please review.