### PR TITLE
Improve error message for custom tflite operators

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -112,7 +112,7 @@ class OperatorConverter(object):
         op_code_str = self.builtin_op_code[op_code_id]
         if op_code_id == BuiltinOperator.CUSTOM:
             # Custom operator
-            raise NotImplementedError("Not Support Custom Operator Now")
+            raise NotImplementedError("Custom operators are currently not supported")
         return op_code_str
 
     def get_input_tensors(self, op):


### PR DESCRIPTION
Improve error message for custom tflite operators
before: "Not Support Custom Operator Now"
after: "Custom operators are currently not supported"