### PR TITLE
[ARITH] Bugfix: int bound analysis for mod

### DIFF
--- a/src/arithmetic/const_int_bound.cc
+++ b/src/arithmetic/const_int_bound.cc
@@ -190,7 +190,7 @@ class ConstIntBoundAnalyzer::Impl :
                          std::min(a.max_value, b_max_cap));
       } else {
         return MakeBound(std::max(a.min_value, -b_max_cap),
-                         std::min(a.max_value, b_max_cap));
+                         std::min(std::max(a.max_value, (int64_t)0), b_max_cap));
       }
     } else {
       CHECK(!b.is_const(0)) << "mod by zero";

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -564,6 +564,7 @@ def test_cmp_simplify():
     ck.verify((x + 1)*(y - 1) < 0, tvm.const(1, "bool"))
     ck.verify(y*y >= 0, tvm.const(1, "bool"))
     ck.verify(x*6 <= -3, tvm.const(0, "bool"))
+    ck.verify((y - 1) % 3 == 0, (y + (-1)) % 3 == 0)
 
 
 def test_logical_simplify():


### PR DESCRIPTION
Fix bound analysis of `a % b` when `a` has a negative upper bound.
@tqchen @derisavi please review