### PR TITLE
[Relay][Transform] quantize opt passes to pass manager

### DIFF
--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -532,22 +532,6 @@ TVM_DLL Pass CanonicalizeOps();
  */
 TVM_DLL Pass AlterOpLayout();
 
-/*!
- * \brief Rewrite a graph and return a graph that simulates the error introduced
- * by the current quantization scheme.
- *
- * \return The pass.
- */
-TVM_DLL Pass QuantizeAnnotate();
-
-/*!
- * \brief This pass transforms the simulated quantized graph to a low-bit
- * integer graph.
- *
- * \return The pass.
- */
-TVM_DLL Pass QuantizeRealize();
-
 }  // namespace transform
 }  // namespace relay
 }  // namespace tvm

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -532,6 +532,22 @@ TVM_DLL Pass CanonicalizeOps();
  */
 TVM_DLL Pass AlterOpLayout();
 
+/*!
+ * \brief Rewrite a graph and return a graph that simulates the error introduced
+ * by the current quantization scheme.
+ *
+ * \return The pass.
+ */
+TVM_DLL Pass QuantizeAnnotate();
+
+/*!
+ * \brief This pass transforms the simulated quantized graph to a low-bit
+ * integer graph.
+ *
+ * \return The pass.
+ */
+TVM_DLL Pass QuantizeRealize();
+
 }  // namespace transform
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/pass/pass_manager.cc
+++ b/src/relay/pass/pass_manager.cc
@@ -285,7 +285,7 @@ ModulePass ModulePassNode::make(
 Module ModulePassNode::operator()(const Module& mod,
                                   const PassContext& pass_ctx) const {
   const PassInfo& pass_info = Info();
-  DLOG(INFO) << "Executing module pass : "
+DLOG(INFO) << "Executing module pass : "
              << pass_info->name
              << " with opt level: "
              << pass_info->opt_level;
@@ -313,6 +313,7 @@ Module FunctionPassNode::operator()(const Module& mod,
              << pass_info->name
              << " with opt level: "
              << pass_info->opt_level;
+
   Module updated_mod = mod;
   // Execute the pass function and return a new module.
   std::vector<std::pair<GlobalVar, Function> > updates;

--- a/src/relay/pass/pass_manager.cc
+++ b/src/relay/pass/pass_manager.cc
@@ -285,7 +285,7 @@ ModulePass ModulePassNode::make(
 Module ModulePassNode::operator()(const Module& mod,
                                   const PassContext& pass_ctx) const {
   const PassInfo& pass_info = Info();
-DLOG(INFO) << "Executing module pass : "
+  DLOG(INFO) << "Executing module pass : "
              << pass_info->name
              << " with opt level: "
              << pass_info->opt_level;

--- a/src/relay/pass/quantize.cc
+++ b/src/relay/pass/quantize.cc
@@ -43,6 +43,8 @@ namespace tvm {
 namespace relay {
 namespace quantize {
 
+using namespace relay::transform;
+
 /*! \brief Attribute for simulated quantize operator */
 struct SimulatedQuantizeAttrs : public tvm::AttrsNode<SimulatedQuantizeAttrs> {
   int kind;
@@ -588,12 +590,6 @@ TVM_REGISTER_API("relay._quantize._EnterQConfigScope")
 TVM_REGISTER_API("relay._quantize._ExitQConfigScope")
 .set_body_typed(QConfig::ExitQConfigScope);
 
-}  // namespace quantize
-
-namespace transform {
-
-using namespace relay::quantize;
-
 Pass QuantizeAnnotate() {
   std::function<Expr(const Expr&)> fmulti_ref = [](const Expr& e) {
     if (e->derived_from<TempExprNode>()) {
@@ -615,10 +611,10 @@ Pass QuantizeAnnotate() {
   return CreateFunctionPass(pass_func, 1, "QuantizeAnnotate", {});
 }
 
-TVM_REGISTER_API("relay._transform.QuantizeAnnotate")
+TVM_REGISTER_API("relay._quantize.QuantizeAnnotate")
 .set_body_typed(QuantizeAnnotate);
 
-Pass QuantizeRealize() {
+Pass QuantizeRealizePass() {
   runtime::TypedPackedFunc<Function(Function, Module, PassContext)> pass_func =
     [=](Function f, Module m, PassContext pc) {
       return Downcast<Function>(
@@ -627,10 +623,9 @@ Pass QuantizeRealize() {
   return CreateFunctionPass(pass_func, 1, "QuantizeRealize", {});
 }
 
-TVM_REGISTER_API("relay._transform.QuantizeRealize")
-.set_body_typed(QuantizeRealize);
+TVM_REGISTER_API("relay._quantize.QuantizeRealize")
+.set_body_typed(QuantizeRealizePass);
 
-}  // namespace transform
-
+}  // namespace quantize
 }  // namespace relay
 }  // namespace tvm

--- a/src/relay/pass/quantize.cc
+++ b/src/relay/pass/quantize.cc
@@ -131,23 +131,6 @@ TVM_REGISTER_API("relay._quantize.make_annotate_expr")
       static_cast<QAnnotateKind>(args[1].operator int()));
   });
 
-
-TVM_REGISTER_API("relay._quantize.annotate")
-.set_body_typed<Expr(Expr)>([] (const Expr& expr) {
-  std::function<Expr(const Expr&)> fmulti_ref = [](const Expr& e) {
-      if (e->derived_from<TempExprNode>()) {
-        const auto* n = e.as<QAnnotateExprNode>();
-        CHECK(n);
-        const PackedFunc* f = runtime::Registry::Get("relay.quantize.attach_simulated_quantize");
-        Expr ret = (*f)(n->expr, static_cast<int>(kQInput));
-        return static_cast<Expr>(QAnnotateExprNode::make(ret, kQInput));
-      }
-      return e;
-    };
-  return ForwardRewrite(expr, "FQAnnotateRewrite", nullptr, fmulti_ref);
-});
-
-
 // =============
 // realize pass
 
@@ -535,14 +518,6 @@ Expr AvgPoolRealize(const Call& ref_call,
 
 RELAY_REGISTER_OP("nn.avg_pool2d")
 .set_attr<FForwardRewrite>("FQRealizeRewrite", AvgPoolRealize);
-
-
-TVM_REGISTER_API("relay._quantize.realize")
-.set_body_typed<Expr(Expr)>([](const Expr& e) {
-  Expr ret = ForwardRewrite(e, "FQRealizeRewrite", nullptr, nullptr);
-  return ret;
-});
-
 
 // =============
 // qconfig


### PR DESCRIPTION
#3273

This PR moves optimizations in `quantize.py` to the pass manager, i.e. the sequence of passes are moved to `Sequential`.

cc @tqchen @vinx13 @ZihengJiang @jroesch @MarisaKirisame 