### PR TITLE
[Arithmetic] Fix compare logic issue.

### DIFF
--- a/src/arithmetic/rewrite_simplify.cc
+++ b/src/arithmetic/rewrite_simplify.cc
@@ -87,10 +87,10 @@ TryCompare(const Expr& x, int64_t val) {
   if (dbound->max_value < val) {
     return kLT;
   }
-  if (dbound->min_value >= val) {
+  if (dbound->min_value == val) {
     return kGE;
   }
-  if (dbound->max_value <= val) {
+  if (dbound->max_value == val) {
     return kLE;
   }
   if (val == 0) {


### PR DESCRIPTION
Issue:
In function TryCompare, when input parameter 'x' is type ConstIntBound, there
are couple logic to compare the min_value and max_value with target
value 'val', current logic did redundant logic check that do '>=' check
after a '>' check, and do '<=' check after a '<' for same variables.

Solution:
change '>=' into '=='and change '<=' into '=='.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
