### PR TITLE
Add PAD operator to relay tflite frontend

### DIFF
--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -394,6 +394,35 @@ def test_forward_squeeze():
     _test_squeeze(np.arange(6).reshape((1, 2, 1, 3)), [0, 2])
     _test_squeeze(np.arange(6).reshape((2, 1, 3, 1)), [1, 3])
 
+
+#######################################################################
+# Pad
+# ---
+
+def _test_pad(data):
+    """ One iteration of PAD """
+
+    assert len(data) == 2
+
+    # Test with tensor and constant
+    with tf.Graph().as_default():
+        in_data = [array_ops.placeholder(shape=data[0].shape, dtype=data[0].dtype, name='in')]
+        out = array_ops.pad(in_data[0], ops.convert_to_tensor(data[1], dtype=data[1].dtype))
+        compare_tflite_with_tvm([data[0]], ['in:0'], in_data, [out])
+
+
+def test_forward_pad():
+    """ Pad """
+    _test_pad([np.arange(1.0, 7.0, dtype=np.float32).reshape((2, 1, 1, 3)),
+               np.array([[1, 1], [2, 2], [1, 1], [2, 2]], dtype=np.int32)])
+    _test_pad([np.arange(1.0, 7.0, dtype=np.float32).reshape((2, 1, 3)),
+               np.array([[2, 2], [1, 1], [1, 1]], dtype=np.int32)])
+    _test_pad([np.arange(1.0, 7.0, dtype=np.float32).reshape((2, 3)),
+               np.array([[1, 1], [2, 2]], dtype=np.int32)])
+    _test_pad([np.arange(1.0, 4.0, dtype=np.float32).reshape((1, 3)),
+               np.array([[1, 1], [2, 2]], dtype=np.int32)])
+
+
 #######################################################################
 # Softmax
 # -------
@@ -528,6 +557,7 @@ def test_forward_inception_v4_net():
 if __name__ == '__main__':
     # Transforms
     test_forward_concatenation()
+    test_forward_pad()
     test_forward_reshape()
     test_forward_squeeze()
 


### PR DESCRIPTION
PAD operator is used in TFLite SSD Resnet 50 model (ssd_resnet_50_fpn_coco).
Model graph: [ssd_resnet_50_fpn_coco.tflite.pdf](https://www.dropbox.com/s/l2pirsrmq86gxau/ssd_resnet_50_fpn_coco.tflite.pdf?dl=0)
```
### ssd_resnet_50_fpn_coco summary:
# op_id: op_name - count
 0: ADD - 58
 2: CONCATENATION - 2
 3: CONV_2D - 110
14: LOGISTIC - 1
17: MAX_POOL_2D - 4
18: MUL - 42
22: RESHAPE - 14
32: CUSTOM - 1
34: PAD - 1
```

This PR adds PAD operator support to relay tflite frontend.