### PR TITLE
Add LOGISTIC operator to relay tflite frontend

### DIFF
--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -67,6 +67,7 @@ class OperatorConverter(object):
             'MUL': self.convert_mul,
             'FULLY_CONNECTED': self.convert_fully_connected,
             'PAD': self.convert_pad,
+            'LOGISTIC': self.convert_logistic,
         }
 
     def check_unsupported_ops(self):
@@ -216,6 +217,23 @@ class OperatorConverter(object):
         in_expr = self.get_expr(input_tensor_idx)
         out = _op.reshape(in_expr, newshape=tuple(target_shape))
 
+        return out
+
+    def convert_logistic(self, op):
+        """Convert TFLite LOGISTIC"""
+        try:
+            from tflite.Operator import Operator
+        except ImportError:
+            raise ImportError("The tflite package must be installed")
+
+        assert isinstance(op, Operator)
+        input_tensors = self.get_input_tensors(op)
+        assert len(input_tensors) == 1, "input tensors length should be 1"
+
+        input_tensor = input_tensors[0]
+        in_expr = self.get_expr(input_tensor.tensor_idx)
+
+        out = _op.sigmoid(in_expr)
         return out
 
     def convert_softmax(self, op):

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -424,6 +424,22 @@ def test_forward_pad():
 
 
 #######################################################################
+# Logistic
+# --------
+
+def _test_logistic(data):
+    """ One iteration of LOGISTIC """
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        out = math_ops.sigmoid(in_data)
+        compare_tflite_with_tvm(data, 'Placeholder:0', [in_data], [out])
+
+def test_forward_logistic():
+    """ LOGISTIC """
+    _test_logistic(np.arange(6.0, dtype=np.float32).reshape((1, 6)))
+
+
+#######################################################################
 # Softmax
 # -------
 
@@ -563,6 +579,7 @@ if __name__ == '__main__':
 
     # NN
     test_forward_convolution()
+    test_forward_logistic()
     test_forward_pooling()
     test_forward_softmax()
     test_forward_fully_connected()


### PR DESCRIPTION
LOGISTIC operator is used in TFLite SSD Resnet50 and Mobilenet models.
Model graph: [ssd_resnet_50_fpn_coco_nopp.tflite.pdf](https://www.dropbox.com/s/wuxm1v4g7bkj7uq/ssd_resnet_50_fpn_coco_nopp.tflite.pdf?dl=0)
```
### ssd_resnet_50_fpn_coco summary:
# op_id: op_name - count
 0: ADD - 58
 2: CONCATENATION - 2
 3: CONV_2D - 110
14: LOGISTIC - 1
17: MAX_POOL_2D - 4
18: MUL - 42
22: RESHAPE - 14
34: PAD - 1
```

This PR adds LOGISTIC operator support to relay tflite frontend.