### PR TITLE
[LINT] Improve robustness in task_lint.sh logic

### DIFF
--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -31,7 +31,7 @@ echo "Check file types..."
 python3 tests/lint/check_file_type.py
 
 echo "Check ASF license header..."
-java -jar /bin/apache-rat.jar -E tests/lint/rat-excludes  -d . |grep "== File" > /tmp/$$.apache-rat.txt || true
+java -jar /bin/apache-rat.jar -E tests/lint/rat-excludes  -d . | (grep "== File" > /tmp/$$.apache-rat.txt || true)
 if grep --quiet -E "File" /tmp/$$.apache-rat.txt; then
     echo "Need to add ASF header to the following files."
     echo "----------------File List----------------"


### PR DESCRIPTION
The existing RAT ASF license auditing logic ignores any failure in the
shell pipeline rather than just the exit code of the final grep.
Adjust the logic such that failure of the various tools in the
pipeline are not elided away.