### PR TITLE
[Relay] Make the behavior of data nullptr check of pooling layer same as others.

### DIFF
--- a/src/relay/op/nn/pooling.cc
+++ b/src/relay/op/nn/pooling.cc
@@ -70,7 +70,8 @@ bool Pool2DRel(const Array<Type>& types,
   CHECK_EQ(types.size(), 2);
   const auto* data = types[0].as<TensorTypeNode>();
 
-  CHECK(data != nullptr);
+  if (data == nullptr) return false;
+
   const auto dshape = data->shape;
   CHECK_GE(dshape.size(), 2U)
       << "Pool2D only support input >= 2-D: input must have height and width";


### PR DESCRIPTION
 In current [relay.nn.conv](https://github.com/dmlc/tvm/blob/master/src/relay/op/nn/convolution.cc#L45) and [relay.nn.nn](https://github.com/dmlc/tvm/blob/master/src/relay/op/nn/nn.cc#L51), if `data` is `nullptr` it will return `False`. But for [relay.nn.pooling](https://github.com/dmlc/tvm/blob/master/src/relay/op/nn/pooling.cc#L73), it will abort and raise error.

As discussed in https://discuss.tvm.ai/t/fail-to-load-onnx-resnet-50/2869/7, it is better to have the same behavior when checking whether `data` is `nullptr` or not. 