### PR TITLE
[CI] Clarify RAT exclude patterns.

### DIFF
--- a/tests/lint/rat-excludes
+++ b/tests/lint/rat-excludes
@@ -38,6 +38,7 @@ _static
 _build
 .*~
 \#..*\#
+\.#.*
 
 # Relay parser
 RelayLexer.py

--- a/tests/lint/rat-excludes
+++ b/tests/lint/rat-excludes
@@ -1,6 +1,8 @@
 # subdirectories
 3rdparty
 .github
+jvm
+tutorials
 
 # Binary or data files
 .*\.css

--- a/tests/lint/rat-excludes
+++ b/tests/lint/rat-excludes
@@ -1,6 +1,6 @@
 # subdirectories
-3rdparty/*
-.github/*
+3rdparty
+.github
 
 # Binary or data files
 .*\.css
@@ -28,7 +28,7 @@
 
 # Generated modules
 .*\.egg-info
-.*gen_modules/*
+.*gen_modules
 .*doxygen
 core.cpp
 build


### PR DESCRIPTION
RAT exclude patterns are not matched across path separators.  Patterns
of the form xyz/* will match files and directories named xyz anywhere
in the tree because the regexp /* contracts to "".  Adjust the
existing rat exclude patterns that appear to contain matches with path
separators to be explicit about the pattern they actually match.