### PR TITLE
Cache original functions in module

### DIFF
--- a/src/relay/pass/pass_manager.cc
+++ b/src/relay/pass/pass_manager.cc
@@ -315,8 +315,12 @@ Module FunctionPassNode::operator()(const Module& mod,
              << pass_info->opt_level;
   Module updated_mod = mod;
   // Execute the pass function and return a new module.
+  std::vector<std::pair<GlobalVar, Function> > original;
   std::vector<std::pair<GlobalVar, Function> > updates;
   for (const auto& it : mod->functions) {
+    original.push_back({it.first, it.second});
+  }
+  for (const auto& it : original) {
     auto updated_func = SkipFunction(it.second)
                             ? it.second
                             : pass_func(it.second, updated_mod, pass_ctx);


### PR DESCRIPTION
The test `test_vm.py:test_count_loop` is failing in `master` branch. I guess `FuseOps` somehow alters the module in some way, thus impacted iterators. I added the fix to prevent such passes. But we should still figure out which part of `FuseOps` is violating the invariant cause it might lead to subtle errors in the future.

````
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
  * frame #0: 0x0000000112342e2f libtvm.dylib`tvm::IterAdapter<tvm::Map<tvm::relay::GlobalVar, tvm::relay::Function, void, void>::Ptr2NodeRef, std::__1::__hash_map_const_iterator<std::__1::__hash_const_iterator<std::__1::__hash_node<std::__1::__hash_value_type<tvm::NodePtr<tvm::Node>, tvm::NodePtr<tvm::Node> >, void*>*> > >::operator*() const + 15
    frame #1: 0x00000001126b907b libtvm.dylib`tvm::relay::transform::FunctionPassNode::operator()(tvm::relay::Module const&, tvm::relay::transform::PassContext const&) const + 475
    frame #2: 0x00000001126bad5f libtvm.dylib`tvm::relay::transform::Pass::operator()(tvm::relay::Module const&, tvm::relay::transform::PassContext const&) const + 159
    frame #3: 0x00000001126ba9d7 libtvm.dylib`tvm::relay::transform::SequentialNode::operator()(tvm::relay::Module const&, tvm::relay::transform::PassContext const&) const + 1015
    frame #4: 0x0000000112342929 libtvm.dylib`tvm::relay::transform::PassNode::operator()(tvm::relay::Module const&) const + 57
    frame #5: 0x0000000112340d86 libtvm.dylib`tvm::relay::transform::Pass::operator()(tvm::relay::Module const&) const + 150
    frame #6: 0x00000001126c0fef libtvm.dylib`std::__1::__function::__func<tvm::relay::transform::$_4, std::__1::allocator<tvm::relay::transform::$_4>, void (tvm::runtime::TVMArgs, tvm::runtime::TVMRetValue*)>::operator()(tvm::runtime::TVMArgs&&, tvm::runtime::TVMRetValue*&&) + 159
    frame #7: 0x0000000112930956 libtvm.dylib`TVMFuncCall + 70
    frame #8: 0x0000000106fe2f57 _ctypes.cpython-36m-darwin.so`ffi_call_unix64 + 79
    frame #9: 0x0000000106fe37f8 _ctypes.cpython-36m-darwin.so`ffi_call + 904
    frame #10: 0x0000000106fde8bd _ctypes.cpython-36m-darwin.so`_ctypes_callproc + 829
    frame #11: 0x0000000106fd7f4a _ctypes.cpython-36m-darwin.so`PyCFuncPtr_call + 1210
    frame #12: 0x0000000105c20191 python`_PyObject_FastCallDict + 321
````

cc: @zhiics @tqchen @jroesch 