### PR TITLE
[RUNTIME] specifying number of threads by compiler definition

### DIFF
--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -216,6 +216,9 @@ void Yield() {
 }
 
 int MaxConcurrency() {
+#ifdef TVM_NUM_THREADS
+  return std::max(TVM_NUM_THREADS, 1);
+#else
   int max_concurrency = 1;
   const char *val = getenv("TVM_NUM_THREADS");
   if (val == nullptr) {
@@ -230,6 +233,7 @@ int MaxConcurrency() {
 #endif
   }
   return std::max(max_concurrency, 1);
+#endif
 }
 
 


### PR DESCRIPTION
For certain circumstances, it's difficult to set environment variable
for applications (like Android apps), providing a macro definition to
specify the number of threads.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
