### PR TITLE
[VTA] add support to event counters

### DIFF
--- a/vta/apps/tsim_example/src/driver.cc
+++ b/vta/apps/tsim_example/src/driver.cc
@@ -54,23 +54,20 @@ class Device {
  private:
   void Launch(uint32_t c, uint32_t length, void* inp, void* out) {
     dpi_->Launch(wait_cycles_);
-    // set counter to zero
-    dpi_->WriteReg(0x04, 0);
     dpi_->WriteReg(0x08, c);
     dpi_->WriteReg(0x0c, length);
     dpi_->WriteReg(0x10, get_half_addr(inp, false));
     dpi_->WriteReg(0x14, get_half_addr(inp, true));
     dpi_->WriteReg(0x18, get_half_addr(out, false));
     dpi_->WriteReg(0x1c, get_half_addr(out, true));
-    // launch
-    dpi_->WriteReg(0x00, 0x1);
+    dpi_->WriteReg(0x00, 0x1); // launch
   }
 
   uint32_t WaitForCompletion() {
     uint32_t i, val;
     for (i = 0; i < wait_cycles_; i++) {
       val = dpi_->ReadReg(0x00);
-      if (val == 2) break;  // finish
+      if (val == 2) break; // finish
     }
     val = dpi_->ReadReg(0x04);
     return val;

--- a/vta/config/vta_config.json
+++ b/vta/config/vta_config.json
@@ -1,5 +1,5 @@
 {
-  "TARGET" : "tsim",
+  "TARGET" : "sim",
   "HW_FREQ" : 100,
   "HW_CLK_TARGET" : 7,
   "HW_VER" : "0.0.0",

--- a/vta/config/vta_config.json
+++ b/vta/config/vta_config.json
@@ -1,5 +1,5 @@
 {
-  "TARGET" : "sim",
+  "TARGET" : "tsim",
   "HW_FREQ" : 100,
   "HW_CLK_TARGET" : 7,
   "HW_VER" : "0.0.0",

--- a/vta/hardware/chisel/src/main/scala/core/Core.scala
+++ b/vta/hardware/chisel/src/main/scala/core/Core.scala
@@ -64,6 +64,7 @@ class Core(implicit p: Parameters) extends Module {
   val load = Module(new Load)
   val compute = Module(new Compute)
   val store = Module(new Store)
+  val ecounters = Module(new EventCounters)
 
   // Read(rd) and write(wr) from/to memory (i.e. DRAM)
   io.vme.rd(0) <> fetch.io.vme_rd
@@ -102,6 +103,11 @@ class Core(implicit p: Parameters) extends Module {
   store.io.inst <> fetch.io.inst.st
   store.io.out_baddr := io.vcr.ptrs(5)
   store.io.out <> compute.io.out
+
+  // Event counters
+  ecounters.io.launch := io.vcr.launch
+  ecounters.io.finish := compute.io.finish
+  io.vcr.ecnt <> ecounters.io.ecnt
 
   // Finish instruction is executed and asserts the VCR finish flag
   val finish = RegNext(compute.io.finish)

--- a/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
+++ b/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
@@ -24,6 +24,15 @@ import chisel3.util._
 import vta.util.config._
 import vta.shell._
 
+/** EventCounters.
+  *
+  * This unit contains all the event counting logic. For example, launch and
+  * finish can be used to count all the clock cycles spent by VTA on a run until
+  * it executes the FINISH instruction.
+  *
+  * The ecnt port is used to bulk (<>) connect to the VCR, so these values can be
+  * accessed by the host.
+  */
 class EventCounters(debug: Boolean = false)(implicit p: Parameters) extends Module {
   val vp = p(ShellKey).vcrParams
   val io = IO(new Bundle{

--- a/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
+++ b/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
@@ -29,7 +29,7 @@ class EventCounters(debug: Boolean = false)(implicit p: Parameters) extends Modu
   val io = IO(new Bundle{
     val launch = Input(Bool())
     val finish = Input(Bool())
-    val ecnt = Vec(vp.nVals, ValidIO(UInt(vp.regBits.W)))
+    val ecnt = Vec(vp.nECnt, ValidIO(UInt(vp.regBits.W)))
   })
   val cycle_cnt = RegInit(0.U(vp.regBits.W))
   when (io.launch && !io.finish) {

--- a/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
+++ b/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package vta.core
+
+import chisel3._
+import chisel3.util._
+import vta.util.config._
+import vta.shell._
+
+class EventCounters(debug: Boolean = false)(implicit p: Parameters) extends Module {
+  val vp = p(ShellKey).vcrParams
+  val io = IO(new Bundle{
+    val launch = Input(Bool())
+    val finish = Input(Bool())
+    val ecnt = Vec(vp.nVals, ValidIO(UInt(vp.regBits.W)))
+  })
+  val cycle_cnt = RegInit(0.U(vp.regBits.W))
+  when (io.launch && !io.finish) {
+    cycle_cnt := cycle_cnt + 1.U
+  } .otherwise {
+    cycle_cnt := 0.U
+  }
+  io.ecnt(0).valid := io.finish
+  io.ecnt(0).bits := cycle_cnt
+}

--- a/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
+++ b/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
@@ -32,7 +32,11 @@ import vta.shell._
   * launch and finish signals.
   *
   * The event counter value is passed to the VCR module via the ecnt port, so
-  * they can be accessed by the host.
+  * they can be accessed by the host. The number of event counters (nECnt) is
+  * defined in the Shell VCR module as a parameter, see VCRParams.
+  *
+  * If one would like to add an event counter, then the value of nECnt must be
+  * changed in VCRParams together with the corresponding counting logic here.
   */
 class EventCounters(debug: Boolean = false)(implicit p: Parameters) extends Module {
   val vp = p(ShellKey).vcrParams

--- a/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
+++ b/vta/hardware/chisel/src/main/scala/core/EventCounters.scala
@@ -26,12 +26,13 @@ import vta.shell._
 
 /** EventCounters.
   *
-  * This unit contains all the event counting logic. For example, launch and
-  * finish can be used to count all the clock cycles spent by VTA on a run until
-  * it executes the FINISH instruction.
+  * This unit contains all the event counting logic. One common event tracked in
+  * hardware is the number of clock cycles taken to achieve certain task. We
+  * can count the total number of clock cycles spent in a VTA run by checking
+  * launch and finish signals.
   *
-  * The ecnt port is used to bulk (<>) connect to the VCR, so these values can be
-  * accessed by the host.
+  * The event counter value is passed to the VCR module via the ecnt port, so
+  * they can be accessed by the host.
   */
 class EventCounters(debug: Boolean = false)(implicit p: Parameters) extends Module {
   val vp = p(ShellKey).vcrParams

--- a/vta/hardware/chisel/src/main/scala/shell/VCR.scala
+++ b/vta/hardware/chisel/src/main/scala/shell/VCR.scala
@@ -23,8 +23,6 @@ import chisel3._
 import chisel3.util._
 import vta.util.config._
 import vta.util.genericbundle._
-import scala.collection.mutable.ListBuffer
-import scala.collection.mutable.LinkedHashMap
 import vta.interface.axi._
 
 /** VCR parameters.

--- a/vta/hardware/chisel/src/main/scala/shell/VCR.scala
+++ b/vta/hardware/chisel/src/main/scala/shell/VCR.scala
@@ -54,7 +54,7 @@ class VCRMaster(implicit p: Parameters) extends VCRBase {
   val mp = p(ShellKey).memParams
   val launch = Output(Bool())
   val finish = Input(Bool())
-  val ecnt = Vec(vp.nVals, Flipped(ValidIO(UInt(vp.regBits.W))))
+  val ecnt = Vec(vp.nECnt, Flipped(ValidIO(UInt(vp.regBits.W))))
   val vals = Output(Vec(vp.nVals, UInt(vp.regBits.W)))
   val ptrs = Output(Vec(vp.nPtrs, UInt(mp.addrBits.W)))
 }
@@ -69,7 +69,7 @@ class VCRClient(implicit p: Parameters) extends VCRBase {
   val mp = p(ShellKey).memParams
   val launch = Input(Bool())
   val finish = Output(Bool())
-  val ecnt = Vec(vp.nVals, ValidIO(UInt(vp.regBits.W)))
+  val ecnt = Vec(vp.nECnt, ValidIO(UInt(vp.regBits.W)))
   val vals = Input(Vec(vp.nVals, UInt(vp.regBits.W)))
   val ptrs = Input(Vec(vp.nPtrs, UInt(mp.addrBits.W)))
 }

--- a/vta/hardware/chisel/src/main/scala/shell/VCR.scala
+++ b/vta/hardware/chisel/src/main/scala/shell/VCR.scala
@@ -33,14 +33,11 @@ import vta.interface.axi._
   */
 case class VCRParams()
 {
-  val nValsReg: Int = 1
-  val nPtrsReg: Int = 6
-  val regBits: Int = 32
-  val nCtrlReg: Int = 4
-  val ctrlBaseAddr: Int = 0
-
-  require (nValsReg > 0)
-  require (nPtrsReg > 0)
+  val nCtrl = 1
+  val nECnt = 1
+  val nVals = 1
+  val nPtrs = 6
+  val regBits = 32
 }
 
 /** VCRBase. Parametrize base class. */
@@ -57,9 +54,9 @@ class VCRMaster(implicit p: Parameters) extends VCRBase {
   val mp = p(ShellKey).memParams
   val launch = Output(Bool())
   val finish = Input(Bool())
-  val irq = Output(Bool())
-  val ptrs = Output(Vec(vp.nPtrsReg, UInt(mp.addrBits.W)))
-  val vals = Output(Vec(vp.nValsReg, UInt(vp.regBits.W)))
+  val ecnt = Vec(vp.nVals, Flipped(ValidIO(UInt(vp.regBits.W))))
+  val vals = Output(Vec(vp.nVals, UInt(vp.regBits.W)))
+  val ptrs = Output(Vec(vp.nPtrs, UInt(mp.addrBits.W)))
 }
 
 /** VCRClient.
@@ -72,9 +69,9 @@ class VCRClient(implicit p: Parameters) extends VCRBase {
   val mp = p(ShellKey).memParams
   val launch = Input(Bool())
   val finish = Output(Bool())
-  val irq = Input(Bool())
-  val ptrs = Input(Vec(vp.nPtrsReg, UInt(mp.addrBits.W)))
-  val vals = Input(Vec(vp.nValsReg, UInt(vp.regBits.W)))
+  val ecnt = Vec(vp.nVals, ValidIO(UInt(vp.regBits.W)))
+  val vals = Input(Vec(vp.nVals, UInt(vp.regBits.W)))
+  val ptrs = Input(Vec(vp.nPtrs, UInt(mp.addrBits.W)))
 }
 
 /** VTA Control Registers (VCR).
@@ -97,10 +94,23 @@ class VCR(implicit p: Parameters) extends Module {
   // Write control (AW, W, B)
   val waddr = RegInit("h_ffff".U(hp.addrBits.W)) // init with invalid address
   val wdata = io.host.w.bits.data
-  val wstrb = io.host.w.bits.strb
-  val wmask = Cat(Fill(8, wstrb(3)), Fill(8, wstrb(2)), Fill(8, wstrb(1)), Fill(8, wstrb(0)))
   val sWriteAddress :: sWriteData :: sWriteResponse :: Nil = Enum(3)
   val wstate = RegInit(sWriteAddress)
+
+  // read control (AR, R)
+  val sReadAddress :: sReadData :: Nil = Enum(2)
+  val rstate = RegInit(sReadAddress)
+  val rdata = RegInit(0.U(vp.regBits.W))
+
+  // registers
+  val nTotal = vp.nCtrl + vp.nECnt + vp.nVals + (2*vp.nPtrs)
+  val reg = Seq.fill(nTotal)(RegInit(0.U(vp.regBits.W)))
+  val addr = Seq.tabulate(nTotal)(_ * 4)
+  val reg_map = (addr zip reg)  map { case (a, r) => a.U -> r }
+  val eo = vp.nCtrl
+  val vo = eo + vp.nECnt
+  val po = vo + vp.nVals
+
   switch (wstate) {
     is (sWriteAddress) {
       when (io.host.aw.valid) {
@@ -124,11 +134,8 @@ class VCR(implicit p: Parameters) extends Module {
   io.host.aw.ready := wstate === sWriteAddress
   io.host.w.ready := wstate === sWriteData
   io.host.b.valid := wstate === sWriteResponse
-  io.host.b.bits.resp := "h_0".U
+  io.host.b.bits.resp := 0.U
 
-  // read control (AR, R)
-  val sReadAddress :: sReadData :: Nil = Enum(2)
-  val rstate = RegInit(sReadAddress)
 
   switch (rstate) {
     is (sReadAddress) {
@@ -145,98 +152,40 @@ class VCR(implicit p: Parameters) extends Module {
 
   io.host.ar.ready := rstate === sReadAddress
   io.host.r.valid := rstate === sReadData
+  io.host.r.bits.data := rdata
+  io.host.r.bits.resp := 0.U
 
-  val nPtrsReg = vp.nPtrsReg
-  val nValsReg = vp.nValsReg
-  val regBits = vp.regBits
-  val ptrsBits = mp.addrBits
-  val nCtrlReg = vp.nCtrlReg
-  val rStride = regBits/8
-  val pStride = ptrsBits/8
-  val ctrlBaseAddr = vp.ctrlBaseAddr
-  val valsBaseAddr = ctrlBaseAddr + nCtrlReg*rStride
-  val ptrsBaseAddr = valsBaseAddr + nValsReg*rStride
-
-  val ctrlAddr = Seq.tabulate(nCtrlReg)(i => i*rStride + ctrlBaseAddr)
-  val valsAddr = Seq.tabulate(nValsReg)(i => i*rStride + valsBaseAddr)
-
-  val ptrsAddr = new ListBuffer[Int]()
-  for (i <- 0 until nPtrsReg) {
-    ptrsAddr += i*pStride + ptrsBaseAddr
-    if (ptrsBits == 64) {
-      ptrsAddr += i*pStride + rStride + ptrsBaseAddr
-    }
-  }
-
-  // AP register
-  val c0 = RegInit(VecInit(Seq.fill(regBits)(false.B)))
-
-  // ap start
-  when (io.host.w.fire() && waddr === ctrlAddr(0).asUInt && wstrb(0) && wdata(0)) {
-    c0(0) := true.B
-  } .elsewhen (io.vcr.finish) {
-    c0(0) := false.B
-  }
-
-  // ap done = finish
   when (io.vcr.finish) {
-    c0(1) := true.B
-  } .elsewhen (io.host.ar.fire() && io.host.ar.bits.addr === ctrlAddr(0).asUInt) {
-    c0(1) := false.B
+    reg(0) := "b_10".U
+  } .elsewhen (io.host.w.fire() && addr(0).U === waddr) {
+    reg(0) := wdata
   }
 
-  val c1 = 0.U
-  val c2 = 0.U
-  val c3 = 0.U
-
-  val ctrlRegList = List(c0, c1, c2, c3)
-
-  io.vcr.launch := c0(0)
-
-  // interrupts not supported atm
-  io.vcr.irq := false.B
-
-  // Write pointer and value registers
-  val pvAddr = valsAddr ++ ptrsAddr
-  val pvNumReg =  if (ptrsBits == 64) nValsReg + nPtrsReg*2 else nValsReg + nPtrsReg
-  val pvReg = RegInit(VecInit(Seq.fill(pvNumReg)(0.U(regBits.W))))
-  val pvRegList = new ListBuffer[UInt]()
-
-  for (i <- 0 until pvNumReg) {
-    when (io.host.w.fire() && (waddr === pvAddr(i).U)) {
-      pvReg(i) := (wdata & wmask) | (pvReg(i) & ~wmask)
-    }
-    pvRegList += pvReg(i)
-  }
-
-  for (i <- 0 until nValsReg) {
-    io.vcr.vals(i) := pvReg(i)
-  }
-
-  for (i <- 0 until nPtrsReg) {
-    if (ptrsBits == 64) {
-      io.vcr.ptrs(i) := Cat(pvReg(nValsReg + i*2 + 1), pvReg(nValsReg + i*2))
-    } else {
-      io.vcr.ptrs(i) := pvReg(nValsReg + i)
+  for (i <- 0 until vp.nECnt) {
+    when (io.vcr.ecnt(i).valid) {
+      reg(eo + i) := io.vcr.ecnt(i).bits
+    } .elsewhen (io.host.w.fire() && addr(eo + i).U === waddr) {
+      reg(eo + i) := wdata
     }
   }
 
-  // Read pointer and value registers
-  val mapAddr = ctrlAddr ++ valsAddr ++ ptrsAddr
-  val mapRegList = ctrlRegList ++ pvRegList
-
-  val rdata = RegInit(0.U(regBits.W))
-  val rmap = LinkedHashMap[Int,UInt]()
-
-  val totalReg = mapRegList.length
-  for (i <- 0 until totalReg) { rmap += mapAddr(i) -> mapRegList(i).asUInt }
-
-  val decodeAddr = rmap map { case (k, _) => k -> (io.host.ar.bits.addr === k.asUInt) }
+  for (i <- 0 until (vp.nVals + (2*vp.nPtrs))) {
+    when (io.host.w.fire() && addr(vo + i).U === waddr) {
+      reg(vo + i) := wdata
+    }
+  }
 
   when (io.host.ar.fire()) {
-    rdata := Mux1H(for ((k, v) <- rmap) yield decodeAddr(k) -> v)
+    rdata := MuxLookup(io.host.ar.bits.addr, 0.U, reg_map)
   }
 
-  io.host.r.bits.resp := 0.U
-  io.host.r.bits.data := rdata
+  io.vcr.launch := reg(0)(0)
+
+  for (i <- 0 until vp.nVals) {
+    io.vcr.vals(i) := reg(vo + i)
+  }
+
+  for (i <- 0 until vp.nPtrs) {
+    io.vcr.ptrs(i) := Cat(reg(po + 2*i + 1), reg(po + 2*i))
+  }
 }

--- a/vta/include/vta/dpi/module.h
+++ b/vta/include/vta/dpi/module.h
@@ -35,7 +35,7 @@ namespace dpi {
 class DPIModuleNode : public tvm::runtime::ModuleNode {
  public:
 /*!
- * \brief Launch accelerator until it finishes or reach max_cycles
+ * \brief Launch hardware simulation until accelerator finishes or reach max_cycles
  * \param max_cycles The maximum of cycles to wait
  */
   virtual void Launch(uint64_t max_cycles) = 0;
@@ -53,7 +53,7 @@ class DPIModuleNode : public tvm::runtime::ModuleNode {
  */
   virtual uint32_t ReadReg(int addr) = 0;
 
-/*! \brief Kill or Exit() the accelerator */
+/*! \brief Finish hardware simulation */
   virtual void Finish() = 0;
 
   static tvm::runtime::Module Load(std::string dll_name);

--- a/vta/python/vta/testing/simulator.py
+++ b/vta/python/vta/testing/simulator.py
@@ -75,12 +75,12 @@ def tsim_init(hw_lib):
     f(m)
 
 def tsim_cycles():
-    """Clear profiler statistics
+    """Get tsim clock cycles
 
     Returns
     -------
-    stats : dict
-        Current profiler statistics
+    stats : int
+        tsim clock cycles
     """
     return tvm.get_global_func("tvm.vta.tsim.cycles")()
 

--- a/vta/python/vta/testing/simulator.py
+++ b/vta/python/vta/testing/simulator.py
@@ -74,5 +74,14 @@ def tsim_init(hw_lib):
     m = tvm.module.load(lib, "vta-tsim")
     f(m)
 
+def tsim_cycles():
+    """Clear profiler statistics
+
+    Returns
+    -------
+    stats : dict
+        Current profiler statistics
+    """
+    return tvm.get_global_func("tvm.vta.tsim.cycles")()
 
 LIBS = _load_lib()


### PR DESCRIPTION
This PR adds infrastructure (software and hardware) to support event counters in the VTA Chisel implementation. Only counting cycles at the moment.

This is how cycles are now displayed on vta unittest (`test_vta_insn.py`)

```
$ python3 test_vta_insn.py
Initialize VTACommandHandle...
Load/store test took 619 clock cycles
Padded load test took 8579 clock cycles
GEMM schedule:default test took 648 clock cycles
GEMM schedule:smt test took 755 clock cycles
ALU SHL imm:True test took 1067 clock cycles
ALU MAX imm:True test took 1067 clock cycles
ALU MAX imm:False test took 1654 clock cycles
ALU ADD imm:True test took 1067 clock cycles
ALU ADD imm:False test took 1654 clock cycles
ALU SHR imm:True test took 1067 clock cycles
Relu test took 1738 clock cycles
Shift/scale test took 386 clock cycles
Close VTACommandhandle...
```