### PR TITLE
Add test_forward_ssd_mobilenet_v1 to tflite/test_forward

### DIFF
--- a/python/tvm/relay/testing/tf.py
+++ b/python/tvm/relay/testing/tf.py
@@ -163,13 +163,10 @@ def get_workload_official(model_url, model_sub_path):
     model_sub_path:
         Sub path in extracted tar for the ftozen protobuf file.
 
-    temp_dir: TempDirectory
-        The temporary directory object to download the content.
-
     Returns
     -------
-    graph_def: graphdef
-        graph_def is the tensorflow workload for mobilenet.
+    model_path: str
+        Full path to saved model file
 
     """
 
@@ -200,7 +197,7 @@ def get_workload(model_path, model_sub_path=None):
     Returns
     -------
     graph_def: graphdef
-        graph_def is the tensorflow workload for mobilenet.
+        graph_def is the tensorflow workload.
 
     """
 

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -599,6 +599,24 @@ def test_forward_inception_v4_net():
                                 rtol=1e-5, atol=1e-5)
 
 #######################################################################
+# SSD Mobilenet
+# -------------
+
+def test_forward_ssd_mobilenet_v1():
+    """Test the SSD Mobilenet V1 TF Lite model."""
+    # SSD MobilenetV1
+    tflite_model_file = tf_testing.get_workload_official(
+        "https://raw.githubusercontent.com/dmlc/web-data/master/tensorflow/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28_nopp.tgz",
+        "ssd_mobilenet_v1_coco_2018_01_28_nopp.tflite")
+    with open(tflite_model_file, "rb") as f:
+        tflite_model_buf = f.read()
+    data = np.random.uniform(size=(1, 300, 300, 3)).astype('float32')
+    tflite_output = run_tflite_graph(tflite_model_buf, data)
+    tvm_output = run_tvm_graph(tflite_model_buf, data, 'normalized_input_image_tensor')
+    tvm.testing.assert_allclose(np.squeeze(tvm_output[0]), np.squeeze(tflite_output[0]),
+                                rtol=1e-5, atol=1e-5)
+
+#######################################################################
 # Main
 # ----
 if __name__ == '__main__':
@@ -623,3 +641,4 @@ if __name__ == '__main__':
     test_forward_mobilenet_v2()
     test_forward_inception_v3_net()
     test_forward_inception_v4_net()
+    test_forward_ssd_mobilenet_v1()


### PR DESCRIPTION
This tests uses official non-quantized model `ssd_mobilenet_v1_coco` downloaded from https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md

`ssd_mobilenet_v1_coco_2018_01_28.tar.gz` contains checkpoint.
To generate tflite file I exported the checkpoint to `tflite_graph.pb` file using `object_detection/export_tflite_ssd_graph.py` form `tensorflow/models' repo.

Then I converted `tflite_graph.pb` file to `TFLITE` format using the command below. 
Because TFLite frontend does not support custom operators I did not include custom operator `TFLite_Detection_PostProcess` which are the last operator in the graph. 
I did that by specifying `--output_arrays` as `raw_outputs/class_predictions,raw_outputs/box_encodings` which are inputs for `TFLite_Detection_PostProcess` op.
Users can do PostProcessing outside of TVM.
[post-processing code is here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/detection_postprocess.cc)
```
# FLOAT no Post Processing
export TFM_PATH=<path_to_dir_containing_tflite_graph.pb>
export FMT=TFLITE
tflite_convert \
--graph_def_file=$TFM_PATH/tflite_graph.pb \
--output_file=$TFM_PATH/model_nopp.tflite \
--output_format=$FMT \
--input_arrays=normalized_input_image_tensor \
--input_shapes=1,300,300,3 \
--inference_type=FLOAT \
--output_arrays="raw_outputs/class_predictions,raw_outputs/box_encodings"
```
[Graph visualization](https://www.dropbox.com/s/7xhjei1412d1gi1/ssd_mobilenet_v1_coco_2018_01_28_nopp.pdf?dl=0)

I uploaded resulting `model_nopp.tflite` file to s3 bucket belonging to [neo-ai organization](https://github.com/neo-ai)