### PR TITLE
Update tflite schema version to 1.13

### DIFF
--- a/docker/install/ubuntu_install_tflite.sh
+++ b/docker/install/ubuntu_install_tflite.sh
@@ -35,7 +35,7 @@ pip2 install flatbuffers
 # Setup tflite from schema
 mkdir tflite
 cd tflite
-wget -q https://raw.githubusercontent.com/tensorflow/tensorflow/r1.12/tensorflow/contrib/lite/schema/schema.fbs
+wget -q https://raw.githubusercontent.com/tensorflow/tensorflow/r1.13/tensorflow/lite/schema/schema.fbs
 flatc --python schema.fbs
 
 cat <<EOM >setup.py

--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -31,7 +31,7 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import variables
-from tensorflow.contrib import lite as interpreter_wrapper
+from tensorflow import lite as interpreter_wrapper
 
 import tvm.relay.testing.tf as tf_testing
 


### PR DESCRIPTION
In order to parse tflite flatbuffers files tflite frontend needs `tensorflow/lite/schema/schema.fbs`
Currently we use schema from version r1.12

when we run `pip3 install tensorflow` in Ubuntu 16.04 docker container pip3 installs tensorflow 1.13.1.
Better to update tflite schema to r1.13 as well

`lite` module was moved from `tensorflow/contrib/` to just `tensorflow/` in version 1.13
This PR changes
1. update schema.fbs version to r1.13
2. updates `lite` module location (drops "contrib")