### PR TITLE
[Relay][Module] Make tags for ADT constructors and ConstructorValues more robust

### DIFF
--- a/include/tvm/relay/adt.h
+++ b/include/tvm/relay/adt.h
@@ -114,7 +114,7 @@ class ConstructorNode : public ExprNode {
   /*! \brief The datatype the constructor will construct. */
   GlobalTypeVar belong_to;
   /*! \brief Index in the table of constructors (set when the type is registered). */
-  mutable int64_t tag = -1;
+  mutable int32_t tag = -1;
 
   ConstructorNode() {}
 

--- a/include/tvm/relay/adt.h
+++ b/include/tvm/relay/adt.h
@@ -114,7 +114,7 @@ class ConstructorNode : public ExprNode {
   /*! \brief The datatype the constructor will construct. */
   GlobalTypeVar belong_to;
   /*! \brief Index in the table of constructors (set when the type is registered). */
-  mutable int tag = -1;
+  mutable int64_t tag = -1;
 
   ConstructorNode() {}
 

--- a/include/tvm/relay/interpreter.h
+++ b/include/tvm/relay/interpreter.h
@@ -182,7 +182,7 @@ RELAY_DEFINE_NODE_REF(RefValue, RefValueNode, Value);
 class ConstructorValue;
 
 struct ConstructorValueNode : ValueNode {
-  int64_t tag;
+  int32_t tag;
 
   tvm::Array<Value> fields;
 
@@ -195,7 +195,7 @@ struct ConstructorValueNode : ValueNode {
     v->Visit("constructor", &constructor);
   }
 
-  TVM_DLL static ConstructorValue make(int64_t tag,
+  TVM_DLL static ConstructorValue make(int32_t tag,
                                        tvm::Array<Value> fields,
                                        Constructor construtor = {});
 

--- a/include/tvm/relay/interpreter.h
+++ b/include/tvm/relay/interpreter.h
@@ -182,7 +182,7 @@ RELAY_DEFINE_NODE_REF(RefValue, RefValueNode, Value);
 class ConstructorValue;
 
 struct ConstructorValueNode : ValueNode {
-  int tag;
+  int64_t tag;
 
   tvm::Array<Value> fields;
 
@@ -195,7 +195,7 @@ struct ConstructorValueNode : ValueNode {
     v->Visit("constructor", &constructor);
   }
 
-  TVM_DLL static ConstructorValue make(int tag,
+  TVM_DLL static ConstructorValue make(int64_t tag,
                                        tvm::Array<Value> fields,
                                        Constructor construtor = {});
 

--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -166,7 +166,7 @@ class ModuleNode : public RelayNode {
    * \param tag The tag for the constructor.
    * \return The constructor object.
    */
-  TVM_DLL Constructor LookupTag(const int64_t tag);
+  TVM_DLL Constructor LookupTag(const int32_t tag);
 
   /*!
    * \brief Update the functions inside this environment by
@@ -209,7 +209,7 @@ class ModuleNode : public RelayNode {
   /*! \brief A map from constructor tags to constructor objects
    * for convenient access
    */
-  std::unordered_map<int64_t, Constructor> constructor_tag_map_;
+  std::unordered_map<int32_t, Constructor> constructor_tag_map_;
 };
 
 struct Module : public NodeRef {

--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -32,6 +32,7 @@
 #include <tvm/relay/type.h>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace tvm {
 namespace relay {

--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -166,7 +166,7 @@ class ModuleNode : public RelayNode {
    * \param tag The tag for the constructor.
    * \return The constructor object.
    */
-  TVM_DLL Constructor LookupTag(const size_t tag);
+  TVM_DLL Constructor LookupTag(const int64_t tag);
 
   /*!
    * \brief Update the functions inside this environment by

--- a/include/tvm/relay/module.h
+++ b/include/tvm/relay/module.h
@@ -133,32 +133,39 @@ class ModuleNode : public RelayNode {
   TVM_DLL GlobalTypeVar GetGlobalTypeVar(const std::string& str);
 
   /*!
-   * \brief Lookup a global function by its variable.
+   * \brief Look up a global function by its variable.
    * \param var The global var to lookup.
    * \returns The function named by the variable argument.
    */
   TVM_DLL Function Lookup(const GlobalVar& var);
 
   /*!
-   * \brief Lookup a global function by its string name
+   * \brief Look up a global function by its string name
    * \param name The name of the function.
    * \returns The function named by the argument.
    */
   TVM_DLL Function Lookup(const std::string& name);
 
   /*!
-   * \brief Lookup a global type definition by its variable.
+   * \brief Look up a global type definition by its variable.
    * \param var The var of the global type definition.
    * \return The type definition.
    */
   TVM_DLL TypeData LookupDef(const GlobalTypeVar& var);
 
   /*!
-   * \brief Lookup a global type definition by its name.
+   * \brief Look up a global type definition by its name.
    * \param var The name of the global type definition.
    * \return The type definition.
    */
   TVM_DLL TypeData LookupDef(const std::string& var);
+
+  /*!
+   * \brief Look up a constructor by its tag.
+   * \param tag The tag for the constructor.
+   * \return The constructor object.
+   */
+  TVM_DLL Constructor LookupTag(const size_t tag);
 
   /*!
    * \brief Update the functions inside this environment by
@@ -185,6 +192,9 @@ class ModuleNode : public RelayNode {
   TVM_DECLARE_NODE_TYPE_INFO(ModuleNode, Node);
 
  private:
+  /*! \brief Helper function for registering a typedef's constructors */
+  void RegisterConstructors(const GlobalTypeVar& var, const TypeData& type);
+
   /*! \brief A map from string names to global variables that
    * ensures global uniqueness.
    */
@@ -194,6 +204,11 @@ class ModuleNode : public RelayNode {
    * that ensures global uniqueness.
    */
   tvm::Map<std::string, GlobalTypeVar> global_type_var_map_;
+
+  /*! \brief A map from constructor tags to constructor objects
+   * for convenient access
+   */
+  std::unordered_map<int64_t, Constructor> constructor_tag_map_;
 };
 
 struct Module : public NodeRef {

--- a/python/tvm/relay/backend/interpreter.py
+++ b/python/tvm/relay/backend/interpreter.py
@@ -112,6 +112,27 @@ class RefValue(Value):
         self.__init_handle_by_constructor__(
             _make.RefValue, value)
 
+
+def _arg_to_ast(mod, arg):
+    if isinstance(arg, TensorValue):
+        return Constant(arg.data.copyto(nd.cpu(0)))
+    elif isinstance(arg, TupleValue):
+        return Tuple([_arg_to_ast(mod, field) for field in arg.fields])
+    elif isinstance(arg, tuple):
+        return Tuple([_arg_to_ast(mod, field) for field in arg])
+    elif isinstance(arg, RefValue):
+        return RefCreate(_arg_to_ast(mod, arg.value))
+    elif isinstance(arg, ConstructorValue):
+        return Call(mod.get_constructor(arg.tag),
+                    [_arg_to_ast(mod, field) for field in arg.fields])
+    elif isinstance(arg, np.ndarray):
+        return Constant(nd.array(arg))
+    elif isinstance(arg, Constant):
+        return arg
+    else:
+        return const(arg)
+
+
 class Executor(object):
     """An abstract interface for executing Relay programs."""
 
@@ -208,7 +229,7 @@ class Executor(object):
         if binds:
             scope_builder = ScopeBuilder()
             for key, value in binds.items():
-                scope_builder.let(key, self._arg_to_ast(value))
+                scope_builder.let(key, _arg_to_ast(self.mod, value))
             scope_builder.ret(expr)
             expr = scope_builder.get()
 
@@ -244,26 +265,6 @@ class Interpreter(Executor):
         self.target = target
         self._intrp = _backend.CreateInterpreter(mod, ctx, target)
 
-    def _arg_to_ast(self, arg):
-        if isinstance(arg, TensorValue):
-            return Constant(arg.data.copyto(nd.cpu(0)))
-        elif isinstance(arg, TupleValue):
-            return Tuple([self._arg_to_ast(field) for field in arg.fields])
-        elif isinstance(arg, tuple):
-            return Tuple([self._arg_to_ast(field) for field in arg])
-        elif isinstance(arg, RefValue):
-            return RefCreate(self._arg_to_ast(arg.value))
-        elif isinstance(arg, ConstructorValue):
-            return Call(self.mod.get_constructor(arg.tag),
-                        [self._arg_to_ast(field) for field in arg.fields])
-        elif isinstance(arg, np.ndarray):
-            return Constant(nd.array(arg))
-        elif isinstance(arg, Constant):
-            return arg
-        else:
-            return const(arg)
-
-
     def optimize(self, expr):
         """Optimize an expr.
 
@@ -294,7 +295,7 @@ class Interpreter(Executor):
 
             relay_args = []
             for arg in args:
-                relay_args.append(self._arg_to_ast(arg))
+                relay_args.append(_arg_to_ast(self.mod, arg))
 
             if isinstance(expr, GlobalVar):
                 func = self.mod[expr]

--- a/python/tvm/relay/module.py
+++ b/python/tvm/relay/module.py
@@ -165,6 +165,25 @@ class Module(RelayNode):
         """
         return _module.Module_GetGlobalTypeVar(self, name)
 
+    def get_constructor(self, tag):
+        """Look up an ADT constructor by tag.
+
+        Parameters
+        ----------
+        tag: int
+            The tag for a constructor.
+
+        Returns
+        -------
+        constructor: Constructor
+           The constructor associated with the given tag,
+
+        Raises
+        ------
+        tvm.TVMError if the corresponding constructor cannot be found.
+        """
+        return _module.Module_LookupTag(self, tag)
+
     @staticmethod
     def from_expr(expr):
         return _module.Module_FromExpr(expr)

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -103,7 +103,7 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
                               p->stream << "RefValueNode(" << node->value << ")";
                             });
 
-ConstructorValue ConstructorValueNode::make(int64_t tag,
+ConstructorValue ConstructorValueNode::make(int32_t tag,
                                             tvm::Array<Value> fields,
                                             Constructor constructor) {
   NodePtr<ConstructorValueNode> n = make_node<ConstructorValueNode>();

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -103,7 +103,7 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
                               p->stream << "RefValueNode(" << node->value << ")";
                             });
 
-ConstructorValue ConstructorValueNode::make(int tag,
+ConstructorValue ConstructorValueNode::make(int64_t tag,
                                             tvm::Array<Value> fields,
                                             Constructor constructor) {
   NodePtr<ConstructorValueNode> n = make_node<ConstructorValueNode>();

--- a/src/relay/ir/module.cc
+++ b/src/relay/ir/module.cc
@@ -116,9 +116,9 @@ void ModuleNode::RegisterConstructors(const GlobalTypeVar& var, const TypeData& 
   // The hash will be used as the most significant byte of the tag, with the index of
   // the constructor in the less significant bytes
   size_t hash = std::hash<std::string>()(var->var->name_hint);
-  int64_t prefix = static_cast<int64_t>(hash & 0xff) << 56;
+  int32_t prefix = static_cast<int32_t>(hash & 0xff) << 24;
   for (size_t i = 0; i < type->constructors.size(); ++i) {
-    type->constructors[i]->tag = prefix | static_cast<int64_t>(i);
+    type->constructors[i]->tag = prefix | static_cast<int32_t>(i);
     constructor_tag_map_[type->constructors[i]->tag] = type->constructors[i];
   }
 }
@@ -172,7 +172,7 @@ TypeData ModuleNode::LookupDef(const std::string& name) {
   return this->LookupDef(id);
 }
 
-Constructor ModuleNode::LookupTag(const int64_t tag) {
+Constructor ModuleNode::LookupTag(const int32_t tag) {
   auto it = constructor_tag_map_.find(tag);
   CHECK(it != constructor_tag_map_.end())
     << "There is no constructor with the tag " << tag;
@@ -238,7 +238,7 @@ TVM_REGISTER_API("relay._module.Module_LookupDef_str")
   });
 
 TVM_REGISTER_API("relay._module.Module_LookupTag")
-.set_body_typed<Constructor(Module, int64_t)>([](Module mod, int64_t tag) {
+.set_body_typed<Constructor(Module, int32_t)>([](Module mod, int32_t tag) {
     return mod->LookupTag(tag);
   });
 

--- a/src/relay/ir/module.cc
+++ b/src/relay/ir/module.cc
@@ -112,10 +112,13 @@ void ModuleNode::Add(const GlobalVar& var,
 }
 
 void ModuleNode::RegisterConstructors(const GlobalTypeVar& var, const TypeData& type) {
+  // We hash the global type var name to use as a globally unique prefix for tags.
+  // The hash will be used as the most significant byte of the tag, with the index of
+  // the constructor in the less significant bytes
+  size_t hash = std::hash<std::string>()(var->var->name_hint);
+  int64_t prefix = static_cast<int64_t>(hash & 0xff) << 56;
   for (size_t i = 0; i < type->constructors.size(); ++i) {
-    size_t hash = dmlc::HashCombine(std::hash<std::string>()(var->var->name_hint),
-                                    std::hash<size_t>()(i));
-    type->constructors[i]->tag = static_cast<int64_t>(hash);
+    type->constructors[i]->tag = prefix | static_cast<int64_t>(i);
     constructor_tag_map_[type->constructors[i]->tag] = type->constructors[i];
   }
 }

--- a/src/relay/ir/module.cc
+++ b/src/relay/ir/module.cc
@@ -169,7 +169,7 @@ TypeData ModuleNode::LookupDef(const std::string& name) {
   return this->LookupDef(id);
 }
 
-Constructor ModuleNode::LookupTag(const size_t tag) {
+Constructor ModuleNode::LookupTag(const int64_t tag) {
   auto it = constructor_tag_map_.find(tag);
   CHECK(it != constructor_tag_map_.end())
     << "There is no constructor with the tag " << tag;
@@ -235,7 +235,7 @@ TVM_REGISTER_API("relay._module.Module_LookupDef_str")
   });
 
 TVM_REGISTER_API("relay._module.Module_LookupTag")
-.set_body_typed<Constructor(Module, size_t)>([](Module mod, size_t tag) {
+.set_body_typed<Constructor(Module, int64_t)>([](Module mod, int64_t tag) {
     return mod->LookupTag(tag);
   });
 

--- a/src/relay/ir/module.cc
+++ b/src/relay/ir/module.cc
@@ -113,8 +113,9 @@ void ModuleNode::Add(const GlobalVar& var,
 
 void ModuleNode::RegisterConstructors(const GlobalTypeVar& var, const TypeData& type) {
   for (size_t i = 0; i < type->constructors.size(); ++i) {
-    type->constructors[i]->tag = static_cast<int64_t>(dmlc::HashCombine(std::hash<std::string>()(var->var->name_hint),
-                                                                         std::hash<size_t>()(i)));
+    size_t hash = dmlc::HashCombine(std::hash<std::string>()(var->var->name_hint),
+                                    std::hash<size_t>()(i));
+    type->constructors[i]->tag = static_cast<int64_t>(hash);
     constructor_tag_map_[type->constructors[i]->tag] = type->constructors[i];
   }
 }

--- a/tests/python/relay/test_ir_module.py
+++ b/tests/python/relay/test_ir_module.py
@@ -25,6 +25,10 @@ def constructor_list(p):
     return [p.nil, p.cons, p.rose, p.some, p.none, p.z, p.s]
 
 
+def adt_list(p):
+    return [p.nat, p.l, p.optional, p.tree]
+
+
 def test_constructor_tag_round_trip():
     mod1 = Module()
     p1 = Prelude(mod1)
@@ -42,3 +46,23 @@ def test_constructor_tag_round_trip():
         ctor = mod2.get_constructor(tag)
         assert ctor == ctors2[i]
         assert ctor.name_hint == ctors1[i].name_hint
+
+
+def test_constructor_tag_differences():
+    # ensure that if we have the type data for a given ADT, the tags
+    # for the constructors of the *same ADT* are simple offsets from
+    # each other
+    mod = Module()
+    p = Prelude(mod)
+    add_nat_definitions(p)
+
+    adts = adt_list(p)
+    for adt in adts:
+        data = mod[adt]
+        for i in range(len(data.constructors) - 1):
+            ctor1 = data.constructors[i]
+            ctor2 = data.constructors[i + 1]
+            assert ctor2.tag - ctor1.tag == 1
+            # make sure there is something present at the MSB
+            assert ctor1.tag - i != 0
+            assert ctor2.tag - (i + 1) != 0

--- a/tests/python/relay/test_ir_module.py
+++ b/tests/python/relay/test_ir_module.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for module functionality."""
+import tvm
+from tvm import relay
+from tvm.relay import Module
+from tvm.relay.prelude import Prelude
+from tvm.relay.testing import add_nat_definitions
+
+def constructor_list(p):
+    return [p.nil, p.cons, p.rose, p.some, p.none, p.z, p.s]
+
+
+def test_constructor_tag_round_trip():
+    mod1 = Module()
+    p1 = Prelude(mod1)
+    add_nat_definitions(p1)
+    mod2 = Module()
+    p2 = Prelude(mod2)
+    add_nat_definitions(p2)
+
+    # ensure hashes match across modules
+    ctors1 = constructor_list(p1)
+    ctors2 = constructor_list(p2)
+
+    for i in range(len(ctors1)):
+        tag = ctors1[i].tag
+        ctor = mod2.get_constructor(tag)
+        assert ctor.name_hint == ctors1[i].name_hint

--- a/tests/python/relay/test_ir_module.py
+++ b/tests/python/relay/test_ir_module.py
@@ -40,4 +40,5 @@ def test_constructor_tag_round_trip():
     for i in range(len(ctors1)):
         tag = ctors1[i].tag
         ctor = mod2.get_constructor(tag)
+        assert ctor == ctors2[i]
         assert ctor.name_hint == ctors1[i].name_hint


### PR DESCRIPTION
Since #3299 changed the representation of `ConstructorValue` to rely on the ADT tag rather than a constructor object, I wrote this change to ensure that
1. it would be easy to get back a constructor given the tag and
2. tags could be reasonably guaranteed to be globally unique

Previously tags simply consisted of the constructor's index in the typedata array, but this means that constructors for different ADTs could have clashing tags. Here I use the hash of the ADT name (guaranteed to be globally unique by the module) and the index to produce the tag for the constructor. The module also keeps a reverse mapping of tags to constructors to make it easy to retrieve.

I followed the example of the structural hash in passing around the hashed values and I hope I have done so correctly. I have added some round-trip tests to ensure that hashes map back to the same constructors each time. Please review @jroesch, @wweic, @icemelon9, @MarisaKirisame (reviewers on #3299)  