### PR TITLE
[VTA] OSX fixes and bugfix tsim-example-RegFile

### DIFF
--- a/vta/apps/tsim_example/Makefile
+++ b/vta/apps/tsim_example/Makefile
@@ -20,12 +20,11 @@ export PYTHONPATH:=$(PWD)/python:$(PYTHONPATH)
 BUILD_NAME = build
 build_dir = $(abspath .)/$(BUILD_NAME)
 
-default: verilog driver run_verilog
+default: verilog driver
+	python3 tests/python/verilog_accel.py
 
-run_chisel: chisel driver 
+run_chisel: chisel driver
 	python3 tests/python/chisel_accel.py
-	
-.PHONY: cmake
 
 driver: | $(build_dir)
 	cd $(build_dir) && cmake .. && make
@@ -38,9 +37,6 @@ verilog:
 
 chisel:
 	make -C hardware/chisel
-
-run_verilog:
-	python3 tests/python/verilog_accel.py
 
 clean:
 	-rm -rf $(build_dir)

--- a/vta/apps/tsim_example/hardware/chisel/Makefile
+++ b/vta/apps/tsim_example/hardware/chisel/Makefile
@@ -84,11 +84,17 @@ else
   cxx_flags += -DVM_TRACE=0
 endif
 
+# The following is to be consistent with cmake
+ifeq ($(shell uname), Darwin)
+  lib_path = $(build_dir)/$(LIBNAME).dylib
+else
+  lib_path = $(build_dir)/$(LIBNAME).so
+endif
+
 default: lib
 
-lib: $(build_dir)/$(LIBNAME).so
-$(build_dir)/$(LIBNAME).so: $(verilator_build_dir)/V$(TOP).cpp
-	echo $(cxx_files)
+lib: $(lib_path)
+$(lib_path): $(verilator_build_dir)/V$(TOP).cpp
 	g++ $(cxx_flags) $(cxx_files) -o $@
 
 verilator: $(verilator_build_dir)/V$(TOP).cpp

--- a/vta/apps/tsim_example/hardware/chisel/src/main/scala/accel/RegFile.scala
+++ b/vta/apps/tsim_example/hardware/chisel/src/main/scala/accel/RegFile.scala
@@ -53,7 +53,7 @@ class RegFile(implicit config: AccelConfig) extends Module {
     val finish = Input(Bool())
     val ecnt = Vec(config.nECnt, Flipped(ValidIO(UInt(config.regBits.W))))
     val vals = Output(Vec(config.nVals, UInt(config.regBits.W)))
-    val ptrs = Output(Vec(config.nPtrs, UInt(config.regBits.W)))
+    val ptrs = Output(Vec(config.nPtrs, UInt(config.ptrBits.W)))
     val host = new VTAHostDPIClient
   })
   val sIdle :: sRead :: Nil = Enum(2)

--- a/vta/apps/tsim_example/hardware/verilog/Makefile
+++ b/vta/apps/tsim_example/hardware/verilog/Makefile
@@ -83,10 +83,17 @@ else
   cxx_flags += -DVM_TRACE=0
 endif
 
+# The following is to be consistent with cmake
+ifeq ($(shell uname), Darwin)
+  lib_path = $(build_dir)/$(LIBNAME).dylib
+else
+  lib_path = $(build_dir)/$(LIBNAME).so
+endif
+
 default: lib
 
-lib: $(build_dir)/$(LIBNAME).so
-$(build_dir)/$(LIBNAME).so: $(build_dir)/V$(TOP).cpp
+lib: $(lib_path)
+$(lib_path): $(build_dir)/V$(TOP).cpp
 	g++ $(cxx_flags) $(cxx_files) -o $@
 
 verilator: $(build_dir)/V$(TOP).cpp

--- a/vta/apps/tsim_example/python/__init__.py
+++ b/vta/apps/tsim_example/python/__init__.py
@@ -1,0 +1,1 @@
+from . import tsim

--- a/vta/apps/tsim_example/python/tsim.py
+++ b/vta/apps/tsim_example/python/tsim.py
@@ -34,8 +34,8 @@ def driver(hw_backend):
     _sw_libname = "libsw" + _ext
     _cur_path = osp.dirname(osp.abspath(osp.expanduser(__file__)))
     if hw_backend in ("verilog", "chisel"):
-        _hw_lib = osp.join(_cur_path, "..", "..", "hardware", hw_backend, "build", _hw_libname)
-    _sw_lib = osp.join(_cur_path, "..", "..", "build", _sw_libname)
+        _hw_lib = osp.join(_cur_path, "..", "hardware", hw_backend, "build", _hw_libname)
+    _sw_lib = osp.join(_cur_path, "..", "build", _sw_libname)
 
     def load_dll(dll):
         try:

--- a/vta/apps/tsim_example/tests/python/chisel_accel.py
+++ b/vta/apps/tsim_example/tests/python/chisel_accel.py
@@ -17,8 +17,7 @@
 
 import tvm
 import numpy as np
-
-from accel.driver import driver
+import tsim
 
 def test_accel():
     rmax = 64
@@ -27,7 +26,7 @@ def test_accel():
     ctx = tvm.cpu(0)
     a = tvm.nd.array(np.random.randint(rmax, size=n).astype("uint64"), ctx)
     b = tvm.nd.array(np.zeros(n).astype("uint64"), ctx)
-    f = driver("chisel")
+    f = tsim.driver("chisel")
     cycles = f(a, b, c)
     msg = "cycles:{0:4} n:{1:2} c:{2:2}".format(cycles, n, c)
     np.testing.assert_equal(b.asnumpy(), a.asnumpy() + c, err_msg = "[FAIL] " + msg)

--- a/vta/apps/tsim_example/tests/python/verilog_accel.py
+++ b/vta/apps/tsim_example/tests/python/verilog_accel.py
@@ -17,8 +17,7 @@
 
 import tvm
 import numpy as np
-
-from accel.driver import driver
+import tsim
 
 def test_accel():
     rmax = 64
@@ -27,7 +26,7 @@ def test_accel():
     ctx = tvm.cpu(0)
     a = tvm.nd.array(np.random.randint(rmax, size=n).astype("uint64"), ctx)
     b = tvm.nd.array(np.zeros(n).astype("uint64"), ctx)
-    f = driver("verilog")
+    f = tsim.driver("verilog")
     cycles = f(a, b, c)
     msg = "cycles:{0:4} n:{1:2} c:{2:2}".format(cycles, n, c)
     np.testing.assert_equal(b.asnumpy(), a.asnumpy() + c, err_msg = "[FAIL] " + msg)

--- a/vta/hardware/chisel/Makefile
+++ b/vta/hardware/chisel/Makefile
@@ -86,10 +86,17 @@ else
   cxx_flags += -DVM_TRACE=0
 endif
 
+# The following is to be consistent with cmake
+ifeq ($(shell uname), Darwin)
+  lib_path = $(vta_dir)/$(BUILD_NAME)/$(VTA_LIBNAME).dylib
+else
+  lib_path = $(vta_dir)/$(BUILD_NAME)/$(VTA_LIBNAME).so
+endif
+
 default: lib
 
-lib: $(vta_dir)/$(BUILD_NAME)/$(VTA_LIBNAME).so
-$(vta_dir)/$(BUILD_NAME)/$(VTA_LIBNAME).so: $(verilator_build_dir)/V$(TOP_TEST).cpp
+lib: $(lib_path)
+$(lib_path): $(verilator_build_dir)/V$(TOP_TEST).cpp
 	g++ $(cxx_flags) $(cxx_files) -o $@
 
 verilator: $(verilator_build_dir)/V$(TOP_TEST).cpp


### PR DESCRIPTION
The following PR fixes the following:

1. Makefiles (hardware) for OSX (.so and .dylib)
2. RegFile bug in tsim-example
3. Rename and move python files to better explain things in the upcoming tutorial