### PR TITLE
[VTA] Fix VTA function Vivado Compile Error.

### DIFF
--- a/vta/hardware/xilinx/src/vta.cc
+++ b/vta/hardware/xilinx/src/vta.cc
@@ -586,19 +586,29 @@ void vta(
 
   // Instantiate temporary instruction queues (used for peeking)
   hls::stream<insn_T> tmp_load_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=tmp_load_queue)
   hls::stream<insn_T> tmp_gemm_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=tmp_gemm_queue)
   hls::stream<insn_T> tmp_store_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=tmp_store_queue)
 
   // Instatiate physical instruction queues
   hls::stream<insn_T> load_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=load_queue)
   hls::stream<insn_T> gemm_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=gemm_queue)
   hls::stream<insn_T> store_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=store_queue)
 
   // Dependence queues
   hls::stream<bool> l2g_dep_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=l2g_dep_queue)
   hls::stream<bool> s2g_dep_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=s2g_dep_queue)
   hls::stream<bool> g2l_dep_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=g2s_dep_queue)
   hls::stream<bool> g2s_dep_queue;
+  PRAGMA_HLS(HLS stream depth=STREAM_IN_DEPTH variable=g2s_dep_queue)
 
   // Instantiate memories
   inp_vec_T inp_mem[VTA_INP_BUFF_DEPTH][VTA_BATCH];

--- a/vta/hardware/xilinx/src/vta.h
+++ b/vta/hardware/xilinx/src/vta.h
@@ -114,6 +114,13 @@ typedef ap_int<VTA_ALUOP_IMM_BIT_WIDTH> aluop_imm_T;
 typedef ap_int<VTA_LOG_ACC_WIDTH> aluop_sh_imm_T;
 
 /*!
+* Define HLS stream depth 
+*/
+#define PRAGMA_SUB(x) _Pragma (#x)
+#define PRAGMA_HLS(x) PRAGMA_SUB(x)
+#define STREAM_IN_DEPTH 8
+
+/*!
 * \brief Fetch module.
 *   Reads in \a insn_count instructions via DMA and pushes them to the
 *   appropriate load, gemm or store queue.


### PR DESCRIPTION
Issue:
when using vivado compile vta.cc with top function 'vta', vivado
report deadlock error like '...with default size is used in a non -dataflow
region, which may result in deadlock Please consider to resize the
stream using the directive ‘set_directive_stream’ or the ‘HL S stream’
pragma.'

Solution:
give the queue a default size as 8. after fix, compile error gone, we can run test bench with this 'vta' function and get correct result.

