### PR TITLE
[nnvm] fix nnvm compiler build module error

### DIFF
--- a/nnvm/python/nnvm/compiler/build_module.py
+++ b/nnvm/python/nnvm/compiler/build_module.py
@@ -148,7 +148,7 @@ def _update_shape_dtype(shape, dtype, params):
     shape.update({k : v.shape for k, v in params.items()})
     if isinstance(dtype, str):
         for k, v in params.items():
-            if v.dtype != dtype:
+            if v.dtype != dtype and v.shape:
                 raise ValueError(
                     "%s: dtype not expected %s vs %s" % (k, dtype, v.dtype))
     else:


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).

fix error as bellow:
nnvm/python/nnvm/compiler/build_module.py", line 153, in _update_shape_dtype
    "%s: dtype not expected %s vs %s" % (k, dtype, v.dtype))
ValueError: 6: dtype not expected float32 vs int64

I have model imported from onnx and one of the shape in the params is None, the params will be pruned later.
(64, 3, 3, 3)
(64,)
(64,)
(64,)
(64,)
()
...

@tqchen 