### PR TITLE
[Bugfix] Missing headers

### DIFF
--- a/include/tvm/relay/attrs/algorithm.h
+++ b/include/tvm/relay/attrs/algorithm.h
@@ -25,6 +25,7 @@
 #define TVM_RELAY_ATTRS_ALGORITHM_H_
 
 #include <tvm/attrs.h>
+#include <tvm/relay/base.h>
 #include <string>
 
 namespace tvm {

--- a/include/tvm/relay/attrs/image.h
+++ b/include/tvm/relay/attrs/image.h
@@ -25,6 +25,7 @@
 #define TVM_RELAY_ATTRS_IMAGE_H_
 
 #include <tvm/attrs.h>
+#include <tvm/relay/base.h>
 #include <string>
 
 namespace tvm {

--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -25,6 +25,7 @@
 #define TVM_RELAY_ATTRS_NN_H_
 
 #include <tvm/attrs.h>
+#include <tvm/relay/base.h>
 #include <string>
 
 namespace tvm {

--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -25,6 +25,7 @@
 #define TVM_RELAY_ATTRS_TRANSFORM_H_
 
 #include <tvm/attrs.h>
+#include <tvm/relay/base.h>
 #include <string>
 
 namespace tvm {

--- a/include/tvm/relay/attrs/vision.h
+++ b/include/tvm/relay/attrs/vision.h
@@ -25,6 +25,7 @@
 #define TVM_RELAY_ATTRS_VISION_H_
 
 #include <tvm/attrs.h>
+#include <tvm/relay/base.h>
 #include <string>
 
 namespace tvm {


### PR DESCRIPTION
I'm hitting `use of undeclared identifier` errors when using tvm as an external library because the header file `<tvm/relay/base.h>` was not included.

```
tvm/tvm/include/tvm/relay/attrs/nn.h:52:9: error: use of undeclared identifier 'IndexExpr'
  Array<IndexExpr> strides;
        ^
tvm/tvm/include/tvm/relay/attrs/nn.h:53:9: error: use of undeclared identifier 'IndexExpr'
  Array<IndexExpr> padding;
        ^
tvm/tvm/include/tvm/relay/attrs/nn.h:54:9: error: use of undeclared identifier 'IndexExpr'
  Array<IndexExpr> dilation;
        ^
tvm/tvm/include/tvm/relay/attrs/nn.h:56:3: error: unknown type name 'IndexExpr'
  IndexExpr channels;
  ^
tvm/tvm/include/tvm/relay/attrs/nn.h:57:9: error: use of undeclared identifier 'IndexExpr'
  Array<IndexExpr> kernel_size;
        ^
tvm/tvm/include/tvm/relay/attrs/nn.h:61:3: error: unknown type name 'DataType'; did you mean 'DLDataType'?
  DataType out_dtype;
  ^~~~~~~~
  DLDataType
tvm/tvm/3rdparty/dlpack/include/dlpack/dlpack.h:106:3: note: 'DLDataType' declared here
} DLDataType;
```