### PR TITLE
to fix issue Target llvm is not enabled

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -92,7 +92,7 @@ set(USE_GRAPH_RUNTIME_DEBUG OFF)
 # - ON: enable llvm with cmake's find search
 # - OFF: disable llvm
 # - /path/to/llvm-config: enable specific LLVM when multiple llvm-dev is available.
-set(USE_LLVM OFF)
+set(USE_LLVM ON)
 
 #---------------------------------------------
 # Contrib libraries


### PR DESCRIPTION
Issue:
I was building TVM4J and got error `bf != nullptr Target llvm is not enabled` when generating shared library. The issue is similar to https://github.com/dmlc/tvm/issues/1020

Solution:
enable LLVM in config.cmake


Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
