### PR TITLE
Don't replace reduction init axis with new axis if bound to a thread.

### DIFF
--- a/src/op/op_util.cc
+++ b/src/op/op_util.cc
@@ -72,10 +72,9 @@ MakeLoopNest(const Stage& stage,
 
     // Mark the iter var in the IR, to remember the point
     if (bind_iv->thread_tag.length() == 0) {
-
-      //Onlyl generate new loop if we're not bound to a thread.
+      // Only generate new loop if we're not bound to a thread.
       if (new_loop_var) {
-	var = Var(iv->var->name_hint + ".init", bind_iv->var.type());
+        var = Var(iv->var->name_hint + ".init", bind_iv->var.type());
       }
 
       ForType for_type = ForType::Serial;

--- a/src/op/op_util.cc
+++ b/src/op/op_util.cc
@@ -69,11 +69,15 @@ MakeLoopNest(const Stage& stage,
 
     // initialize the offset and loop_level
     Var var = bind_iv->var;
-    if (new_loop_var) {
-      var = Var(iv->var->name_hint + ".init", bind_iv->var.type());
-    }
+
     // Mark the iter var in the IR, to remember the point
     if (bind_iv->thread_tag.length() == 0) {
+
+      //Onlyl generate new loop if we're not bound to a thread.
+      if (new_loop_var) {
+	var = Var(iv->var->name_hint + ".init", bind_iv->var.type());
+      }
+
       ForType for_type = ForType::Serial;
       IterVarAttr it_attr;
       if (stage->iter_var_attrs.count(iv)) {

--- a/tests/python/unittest/test_codegen_cuda.py
+++ b/tests/python/unittest/test_codegen_cuda.py
@@ -1,3 +1,4 @@
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_codegen_cuda.py
+++ b/tests/python/unittest/test_codegen_cuda.py
@@ -199,6 +199,10 @@ def test_cuda_shuffle():
 
 
 def test_cuda_reducition_binding():
+    if not tvm.gpu(0).exist or not tvm.module.enabled("cuda"):
+        print("skip because cuda is not enabled..")
+        return
+
     k = tvm.reduce_axis((0, 32), 'k')
     A = tvm.placeholder((96, 32), name='A')
     B = tvm.compute( (96,), lambda m:
@@ -210,6 +214,7 @@ def test_cuda_reducition_binding():
 
     mo, _ = s[B].split(B.op.axis[0], 32)
     s[B].bind(mo, tvm.thread_axis("blockIdx.x"))
+
     fcuda = tvm.build(s, [A, B], "cuda")
 
 


### PR DESCRIPTION
Fixes https://github.com/dmlc/tvm/issues/3407
