### PR TITLE
[Relay][Frontend] Fix tensorflow frontend lstm forget bias adding order

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -1372,9 +1372,8 @@ def _LSTMBlockCell():
         gate_list = _op.split(gates_bias, indices_or_sections=4, axis=1)
         in_gate = _op.sigmoid(gate_list[0])
         in_transform = _op.tanh(gate_list[1])
-        forget_gate = _op.sigmoid(gate_list[2])
-        forget_gate = _op.add(forget_gate,
-                              tvm.relay.const(forget_bias, attr['T'].name))
+        forget_gate = _op.add(gate_list[2], tvm.relay.const(forget_bias, attr['T'].name))
+        forget_gate = _op.sigmoid(forget_gate)
         out_gate = _op.sigmoid(gate_list[3])
         next_c = _op.add(_op.multiply(forget_gate, in_state_c),
                          _op.multiply(in_gate, in_transform))

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1132,7 +1132,7 @@ def _test_lstm_cell(batch_size, num_hidden, num_layers, forget_bias, dtype):
 
 def test_forward_lstm():
     '''test LSTM block cell'''
-    _test_lstm_cell(1, 2, 1, 0.0, 'float32')
+    _test_lstm_cell(1, 2, 1, 0.5, 'float32')
 
 
 


### PR DESCRIPTION
Recently, I tried to convert my own RNN model trained with TF into TVM.

I found out the TF frontend code with LSTMBlockCell conversion have a bug.

According to TF's implementation, (line 59 - line 76) 
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/rnn/python/ops/lstm_ops.py

forget_gate f should adding forget_bias first, then doing the sigmoid operation. However, in the relay's frontend conversion code, the forget_gate is doing sigmoid first then add with forget_bias.

I have checked with TF_forward test case, since in the LSTM and PTB test case, the forget_bias is set to 0.0,  so the test case couldn't detect this bug.

I changed the order on my own, and get the correct prediction on my own model.





