### PR TITLE
[Relay][VM]Create closure object for GlobalVar

### DIFF
--- a/python/tvm/relay/prelude.py
+++ b/python/tvm/relay/prelude.py
@@ -482,8 +482,8 @@ class Prelude:
         with open(prelude_file) as prelude:
             prelude = fromtext(prelude.read())
             self.mod.update(prelude)
-            self.id = self.mod["id"]
-            self.compose = self.mod["compose"]
+            self.id = self.mod.get_global_var("id")
+            self.compose = self.mod.get_global_var("compose")
 
 
     def __init__(self, mod):

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -231,8 +231,12 @@ struct VMCompiler : ExprFunctor<void(const Expr& expr)> {
   }
 
   void VisitExpr_(const GlobalVarNode* gvar) {
-    // TODO(wweic): Support Load GlobalVar into a register
-    LOG(FATAL) << "Loading GlobalVar into register is not yet supported";
+    auto var = GetRef<GlobalVar>(gvar);
+    auto func = this->context->module->Lookup(var);
+    auto it = this->context->global_map.find(var);
+    CHECK(it != this->context->global_map.end());
+    // Allocate closure with zero free vars
+    Emit(Instruction::AllocClosure(it->second, 0, {}, NewRegister()));
   }
 
   void VisitExpr_(const IfNode* if_node) {


### PR DESCRIPTION
For function like:
````
fn (%y: float32) -> float32 {
  let %x: float32 = let %x1: fn (float32) -> float32 = @lifted_name12481580008527263117
  let %add_two: fn (float32) -> float32 = @compose(%x1, %x1) /* ty=fn (float32) -> float32 */
  let %x2: float32 = %add_two(%y) /* ty=float32 */
  %x2
}
````

We should create a closure object for `lifted_name12481580008527263117`.

cc @icemelon9 @jroesch @zhiics @MarisaKirisame @slyubomirsky 