### PR TITLE
[codegen/llvm] Emit DWARF debug information for LoweredFunc instances

### DIFF
--- a/src/codegen/llvm/codegen_cpu.h
+++ b/src/codegen/llvm/codegen_cpu.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -139,6 +139,13 @@ class CodeGenCPU : public CodeGenLLVM {
   std::unordered_map<std::string, llvm::GlobalVariable*> func_handle_map_;
   // List of symbols to be exported to TVM system lib.
   std::vector<std::pair<std::string, llvm::Value*> > export_system_symbols_;
+
+  // Get the DWARF type corresponding to the LLVM type |ty|. The current API in practice only
+  // generates |int32|, and |int8*|.
+  static llvm::DIType* getDebugType(IRBuilder* builder, llvm::DIBuilder* di_builder,
+                                    llvm::Type* ty);
+  // Adds the DWARF debug information for |function| to |dbg_info_|.
+  void AddDebugInformation(llvm::Function* function);
 };
 
 }  // namespace codegen

--- a/src/codegen/llvm/codegen_llvm.cc
+++ b/src/codegen/llvm/codegen_llvm.cc
@@ -73,6 +73,7 @@ void CodeGenLLVM::Init(const std::string& module_name,
   md_tbaa_root_ = md_builder_->createTBAARoot("tvm-tbaa");
   md_tbaa_alias_set_ = md_builder_->createTBAANode("tvm-alias", md_tbaa_root_);
   this->InitTarget(tm);
+  dbg_info_ = CreateDebugInfo(module_.get());
 }
 
 void CodeGenLLVM::InitTarget(llvm::TargetMachine* tm) {
@@ -108,6 +109,7 @@ void CodeGenLLVM::InitFuncState() {
   volatile_buf_.clear();
   analyzer_.reset(new arith::Analyzer());
 }
+
 
 void CodeGenLLVM::AddFunctionInternal(const LoweredFunc& f, bool ret_void) {
   this->InitFuncState();
@@ -166,9 +168,11 @@ void CodeGenLLVM::AddFunctionInternal(const LoweredFunc& f, bool ret_void) {
   }
 }
 
+
 std::unique_ptr<llvm::Module> CodeGenLLVM::Finish() {
   this->AddStartupFunction();
   // link modules
+  dbg_info_->di_builder_->finalize();
   for (size_t i = 0; i < link_modules_.size(); ++i) {
     CHECK(!llvm::Linker::linkModules(*module_, std::move(link_modules_[i])))
         << "Failed to link modules";
@@ -417,6 +421,19 @@ void CodeGenLLVM::GetAlignment(Type t,
     align_bits = 8;
   }
   *p_alignment = align_bits / 8;
+}
+
+std::unique_ptr<CodeGenLLVM::DebugInfo> CodeGenLLVM::CreateDebugInfo(llvm::Module* module) {
+  auto debug_info = llvm::make_unique<CodeGenLLVM::DebugInfo>();
+  debug_info->di_builder_ = llvm::make_unique<llvm::DIBuilder>(*module);
+  // TODO(tulloch): pass this information through relay::Span classes to the LoweredFunc instance?
+  debug_info->file_ = debug_info->di_builder_->createFile("model.tvm", "/tmp/");
+  debug_info->compilation_unit_ = debug_info->di_builder_->createCompileUnit(
+      llvm::dwarf::DW_LANG_C, debug_info->file_, "TVM", 0, "", 0, "",
+      llvm::DICompileUnit::DebugEmissionKind::FullDebug,
+      /* SplitDebugInlining */ true,
+      /* DebugInfoForProfiling */ true);
+  return debug_info;
 }
 
 llvm::Value* CodeGenLLVM::CreateBroadcast(llvm::Value* value, int lanes) {

--- a/src/codegen/llvm/codegen_llvm.h
+++ b/src/codegen/llvm/codegen_llvm.h
@@ -293,6 +293,17 @@ class CodeGenLLVM :
   std::unordered_set<const Variable*> alias_var_set_;
   // set of volatile buffer.
   std::unordered_set<const Variable*> volatile_buf_;
+
+  struct DebugInfo {
+    std::unique_ptr<llvm::DIBuilder> di_builder_;
+    llvm::DICompileUnit* compilation_unit_{nullptr};
+    llvm::DIFile* file_{nullptr};
+  };
+  std::unique_ptr<DebugInfo> dbg_info_;
+
+  // Create a new DebugInfo struct from the given Module that initializes the |file_| and
+  // |compilation_unit_| to TVM defaults.
+  static std::unique_ptr<DebugInfo> CreateDebugInfo(llvm::Module* module);
 };
 }  // namespace codegen
 }  // namespace tvm

--- a/src/codegen/llvm/llvm_common.h
+++ b/src/codegen/llvm/llvm_common.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -38,6 +38,7 @@
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Instructions.h>

--- a/tests/python/unittest/test_codegen_llvm.py
+++ b/tests/python/unittest/test_codegen_llvm.py
@@ -471,6 +471,78 @@ def test_llvm_fp_math():
     check_llvm_sigmoid(8)
     check_llvm_sigmoid(16)
 
+
+def test_dwarf_debug_information():
+    nn = 1024
+    n = tvm.convert(nn)
+    A = tvm.placeholder((n,), name='A')
+    B = tvm.placeholder((n,), name='B')
+    C = tvm.compute(A.shape, lambda *i: A(*i) + B(*i), name='C')
+    s = tvm.create_schedule(C.op)
+    xo, xi = s[C].split(C.op.axis[0], factor=4)
+    s[C].parallel(xo)
+    s[C].vectorize(xi)
+    def check_llvm_object():
+        if not tvm.module.enabled("llvm"):
+            return
+        if tvm.codegen.llvm_version_major() < 5:
+            return
+        # build two functions
+        f2 = tvm.lower(s, [A, B, C], name="fadd1")
+        f1 = tvm.lower(s, [A, B, C], name="fadd2")
+        m = tvm.build([f1, f2], "llvm")
+        temp = util.tempdir()
+        o_path = temp.relpath("temp.o")
+        m.save(o_path)
+        import re
+        import shutil
+        import subprocess
+        import sys
+
+        # Try the dwarfdump utility (OS X)
+        if shutil.which("dwarfdump"):
+            output = subprocess.check_output(["dwarfdump", o_path])
+            assert re.search(r"""DW_AT_name\\t\("fadd1"\)""", str(output))
+            assert re.search(r"""DW_AT_name\\t\("fadd2"\)""", str(output))
+
+        # Try gobjdump (OS X)
+        if shutil.which("gobjdump"):
+            output = subprocess.check_output(["gobjdump", "--dwarf", o_path])
+            assert re.search(r"""DW_AT_name.*fadd1""", str(output))
+            assert re.search(r"""DW_AT_name.*fadd2""", str(output))
+
+        # Try objdump (Linux) - Darwin objdump has different DWARF syntax.
+        if shutil.which("objdump") and sys.platform != 'darwin':
+            output = subprocess.check_output(["objdump", "--dwarf", o_path])
+            assert re.search(r"""DW_AT_name.*fadd1""", str(output))
+            assert re.search(r"""DW_AT_name.*fadd2""", str(output))
+
+    def check_llvm_ir():
+        if not tvm.module.enabled("llvm"):
+            return
+        if tvm.codegen.llvm_version_major() < 5:
+            return
+        # build two functions
+        f2 = tvm.lower(s, [A, B, C], name="fadd1")
+        f1 = tvm.lower(s, [A, B, C], name="fadd2")
+        m = tvm.build([f1, f2], target="llvm -target=aarch64-linux-gnu")
+        ll = m.get_source("ll")
+
+        # On non-Darwin OS, don't explicitly specify DWARF version.
+        import re
+        assert not re.search(r""""Dwarf Version""""", ll)
+        assert re.search(r"""llvm.dbg.value""", ll)
+
+        # Try Darwin, require DWARF-2
+        m = tvm.build([f1, f2],
+                      target="llvm -target=x86_64-apple-darwin-macho")
+        ll = m.get_source("ll")
+        assert re.search(r"""i32 4, !"Dwarf Version", i32 2""", ll)
+        assert re.search(r"""llvm.dbg.value""", ll)
+
+    check_llvm_object()
+    check_llvm_ir()
+
 if __name__ == "__main__":
     test_llvm_import()
     test_alignment()
@@ -489,3 +561,4 @@ if __name__ == "__main__":
     test_llvm_lookup_intrin()
     test_llvm_div()
     test_llvm_fp_math()
+    test_dwarf_debug_information()


### PR DESCRIPTION
Emit DWARF debug information. This allows us to set breakpoints on these generated functions, inspect arguments, show reasonable names in AOT mode in profiling tools, etc. There's a subsequent `perf` PR upcoming from Bram which augments this with support for Linux `perf`'s [jit interface](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jit-interface.txt), which makes `perf` work in JIT scenarios.

The implementation is fairly straightforward - for every LoweredFunc, we emit DWARF information for the function, it's signature, and it's arguments. You can see an example query in:

```
(lldb) image lookup -r -n myadd1 -v
1 match found in /var/folders/bk/2wcywy612zx2882l0z06y_w1f8bjlv/T/tmpv5ie135z/mylib.so:
        Address: mylib.so[0x0000000000001270] (mylib.so.__TEXT.__text + 0)
        Summary: mylib.so`myadd1 at model.tvm
         Module: file = "/var/folders/bk/2wcywy612zx2882l0z06y_w1f8bjlv/T/tmpv5ie135z/mylib.so", arch = "x86_64"
    CompileUnit: id = {0xffffffff00000000}, file = "/tmp/model.tvm", language = "c"
       Function: id = {0xffffffff00000036}, name = "myadd1", range = [0x0000000114693270-0x00000001146935f6)
       FuncType: id = {0xffffffff00000036}, compiler_type = "int (char *, char *, int)"
         Blocks: id = {0xffffffff00000036}, range = [0x114693270-0x1146935f6)
      LineEntry: [0x0000000114693270-0x000000011469327b): /tmp/model.tvm
         Symbol: id = {0x00000004}, range = [0x0000000114693270-0x0000000114693600), name="myadd1"
       Variable: id = {0xffffffff00000054}, name = "arg1", type = "char *", location = rdi, decl =
       Variable: id = {0xffffffff00000061}, name = "arg2", type = "char *", location = rsi, decl =
       Variable: id = {0xffffffff0000006e}, name = "arg3", type = "int32", location = rdx, decl =
```

Some more screenshots from Bram:

![64649048_712563002535623_1165287093409153024_o](https://user-images.githubusercontent.com/1121581/59970310-a8c85b00-9517-11e9-9146-f15cfa504150.jpg)


