### PR TITLE
Fix Windows build

### DIFF
--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -237,17 +237,6 @@ class ExprMutator
  */
 void PostOrderVisit(const Expr& node, std::function<void(const Expr&)> fvisit);
 
-/*
- * \brief Bind function parameters or free variables.
- *
- * Parameter binding can only happen if expr is a Function.
- * binds cannot change internal arguments of internal functions.
- *
- * \param expr The function to be binded.
- * \param binds The map of arguments to
- */
-Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& binds);
-
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_EXPR_FUNCTOR_H_

--- a/include/tvm/relay/pass.h
+++ b/include/tvm/relay/pass.h
@@ -444,14 +444,14 @@ TVM_DLL Array<Pattern> UnmatchedCases(const Match& match, const Module& mod);
  */
 TVM_DLL Expr PartialEval(const Expr& e, const Module& mod);
 
-/*!
- * \brief Bind the free variables to a Relay expression.
+/*
+ * \brief Bind function parameters or free variables.
  *
- * \param expr The expression.
- * \param bind_map The variable to expression map that will be used to help the
- *        binding.
+ * Parameter binding can only happen if expr is a Function.
+ * binds cannot change internal arguments of internal functions.
  *
- * \return The updated expression.
+ * \param expr The function to be binded.
+ * \param binds The map of arguments to
  */
 TVM_DLL Expr Bind(const Expr& expr, const tvm::Map<Var, Expr>& bind_map);
 

--- a/src/runtime/vm/vm.cc
+++ b/src/runtime/vm/vm.cc
@@ -720,7 +720,7 @@ void VirtualMachine::Run() {
       }
       case Opcode::AllocTensor: {
         auto shape = std::vector<int64_t>(instr.alloc_tensor.ndim);
-        for (uint i = 0; i < instr.alloc_tensor.ndim; ++i) {
+        for (uint32_t i = 0; i < instr.alloc_tensor.ndim; ++i) {
           shape[i] = instr.alloc_tensor.shape[i];
         }
         auto allocator = MemoryManager::Global()->GetAllocator(ctxs[0]);


### PR DESCRIPTION
* `uint` -> `uint32_t` to match the type of `ndim`
* removing `Bind()` in `expr_functor.h` since it appears to be a duplicate of the same function in `pass.h`. It is better to only keep one declaration. However, they do have different doc strings. Therefore, I think it would be great if one of the authors can confirm and suggest how the doc strings should be merged.