### PR TITLE
Don't force nvcc when using autotvm

### DIFF
--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -568,13 +568,6 @@ def check_remote(target, device_key, host=None, port=None, priority=100, timeout
     return not t.is_alive()
 
 
-@register_func
-def tvm_callback_cuda_compile(code):
-    """use nvcc to generate ptx code for better optimization"""
-    ptx = nvcc.compile_cuda(code, target="ptx", arch=AutotvmGlobalScope.current.cuda_target_arch)
-    return ptx
-
-
 def set_cuda_target_arch(arch):
     """set target architecture of nvcc compiler
 

--- a/python/tvm/autotvm/measure/measure_methods.py
+++ b/python/tvm/autotvm/measure/measure_methods.py
@@ -33,9 +33,9 @@ import tempfile
 
 import numpy as np
 
-from ... import ir_pass, build, build_config, nd, TVMError, register_func, \
-    rpc as _rpc, target as _target
-from ...contrib import nvcc, ndk, tar
+from ... import ir_pass, build, build_config, nd, TVMError, rpc as _rpc, \
+    target as _target
+from ...contrib import ndk, tar
 
 from ..util import get_const_tuple
 from ..env import AutotvmGlobalScope


### PR DESCRIPTION
Currently the default compiler is nvrtc, but as soon as you import tvm.autotvm, it forces the use of nvcc.

It is currently very hard to go back to nvrtc from python since there are no exposed API to remove a registered hook nor there are hooks to compile using nvrtc.  The docstring for the hook seems to suggest that nvcc generates better code than nvrtc, which I haven't found to be the case since cuda 8.0 or so. So I propose that autotvm stops forcing nvcc. It's still possible for people to set the hook if they want it.

If that is unacceptable, then I could make another PR to expose the API to remove hooks so that I can use it.