### PR TITLE
[Relay][Interpreter] Build self referential closure only when letrec is defined

### DIFF
--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -299,7 +299,9 @@ class Interpreter :
     auto closure = ClosureNode::make(captured_mod, func);
     auto mut_closure =
         static_cast<ClosureNode*>(const_cast<Node*>(closure.get()));
-    mut_closure->env.Set(letrec_name, closure);
+    if (letrec_name.defined()) {
+      mut_closure->env.Set(letrec_name, closure);
+    }
     return std::move(closure);
   }
 


### PR DESCRIPTION
Self referential closure creates memory leaks. We can avoid this memory leak in cases where recursive functions are not used. As discussed in https://github.com/dmlc/tvm/issues/3423, garbage collection or weak pointer is needed to fix the memory leak in the recursive case.

Before:
```
==3058763== LEAK SUMMARY:
==3058763==    definitely lost: 48 bytes in 1 blocks
==3058763==    indirectly lost: 128 bytes in 3 blocks
==3058763==      possibly lost: 82,062 bytes in 1,667 blocks
==3058763==    still reachable: 261,640 bytes in 4,301 blocks
==3058763==                       of which reachable via heuristic:
==3058763==                         stdstring          : 50,132 bytes in 1,037 blocks
==3058763==         suppressed: 0 bytes in 0 blocks
```

After:
```
==2878348== LEAK SUMMARY:
==2878348==    definitely lost: 0 bytes in 0 blocks
==2878348==    indirectly lost: 0 bytes in 0 blocks
==2878348==      possibly lost: 82,062 bytes in 1,667 blocks
==2878348==    still reachable: 261,640 bytes in 4,301 blocks
==2878348==                       of which reachable via heuristic:
==2878348==                         stdstring          : 50,132 bytes in 1,037 blocks
==2878348==         suppressed: 0 bytes in 0 blocks
```


@jroesch, @MarisaKirisame please review.  