### PR TITLE
[Runtime] Android argsort support

### DIFF
--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -25,5 +25,5 @@ ifeq ($(USE_VULKAN), 1)
 endif
 
 ifeq ($(USE_SORT), 1)
-	APP_CPPFLAGS += -DUSE_SORT=1
+    APP_CPPFLAGS += -DUSE_SORT=1
 endif

--- a/apps/android_rpc/app/src/main/jni/Application.mk
+++ b/apps/android_rpc/app/src/main/jni/Application.mk
@@ -23,3 +23,7 @@ ifeq ($(USE_VULKAN), 1)
     APP_CPPFLAGS += -DTVM_VULKAN_RUNTIME=1
     APP_LDFLAGS += -lvulkan
 endif
+
+ifeq ($(USE_SORT), 1)
+	APP_CPPFLAGS += -DUSE_SORT=1
+endif

--- a/apps/android_rpc/app/src/main/jni/make/config.mk
+++ b/apps/android_rpc/app/src/main/jni/make/config.mk
@@ -22,6 +22,9 @@ USE_OPENCL = 0
 # whether to enable Vulkan during compile
 USE_VULKAN = 0
 
+# whether to enable contrib sort functions during compile
+USE_SORT = 1
+
 ifeq ($(USE_VULKAN), 1)
   # Statically linking vulkan requires API Level 24 or higher
   APP_PLATFORM = android-24

--- a/apps/android_rpc/app/src/main/jni/tvm_runtime.h
+++ b/apps/android_rpc/app/src/main/jni/tvm_runtime.h
@@ -66,6 +66,10 @@
 #include "../src/runtime/vulkan/vulkan_module.cc"
 #endif
 
+#ifdef USE_SORT
+#include "../src/contrib/sort/sort.cc"
+#endif
+
 
 #include <android/log.h>
 


### PR DESCRIPTION
Simple change on top of the android contrib fix by @tqchen to enable argsort in the android runtime. See [this discussion](https://discuss.tvm.ai/t/using-contrib-libraries-with-android/3151/7) for more details on this fix.
