### PR TITLE
[Relay] add fatal

### DIFF
--- a/include/tvm/relay/adt.h
+++ b/include/tvm/relay/adt.h
@@ -241,14 +241,18 @@ class MatchNode : public ExprNode {
   /*! \brief The match node clauses. */
   tvm::Array<Clause> clauses;
 
+  /*! \brief Is the match complete (cover all cases)? */
+  bool complete;
+
   void VisitAttrs(tvm::AttrVisitor* v) final {
     v->Visit("data", &data);
     v->Visit("clause", &clauses);
+    v->Visit("complete", &complete);
     v->Visit("span", &span);
     v->Visit("_checked_type_", &checked_type_);
   }
 
-  TVM_DLL static Match make(Expr data, tvm::Array<Clause> pattern);
+  TVM_DLL static Match make(Expr data, tvm::Array<Clause> pattern, bool complete = true);
 
   static constexpr const char* _type_key = "relay.Match";
   TVM_DECLARE_NODE_TYPE_INFO(MatchNode, ExprNode);

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -513,6 +513,27 @@ class RefWriteNode : public ExprNode {
 
 RELAY_DEFINE_NODE_REF(RefWrite, RefWriteNode, Expr);
 
+/*! \brief A fatal error has occured. Stop all execution and report with a message. */
+class Fatal;
+class FatalNode : public ExprNode {
+ public:
+  /*! \brief The Message. */
+  std::string msg;
+
+  void VisitAttrs(tvm::AttrVisitor* v) final {
+    v->Visit("msg", &msg);
+    v->Visit("span", &span);
+    v->Visit("_checked_type_", &checked_type_);
+  }
+
+  TVM_DLL static Fatal make(std::string msg);
+
+  static constexpr const char* _type_key = "relay.Fatal";
+  TVM_DECLARE_NODE_TYPE_INFO(FatalNode, ExprNode);
+};
+
+RELAY_DEFINE_NODE_REF(Fatal, FatalNode, Expr);
+
 /*!
  * \brief Base class of the temporary expression.
  *

--- a/include/tvm/relay/expr.h
+++ b/include/tvm/relay/expr.h
@@ -534,6 +534,9 @@ class FatalNode : public ExprNode {
 
 RELAY_DEFINE_NODE_REF(Fatal, FatalNode, Expr);
 
+/*! \brief the fatal message for case unhandled in match. */
+TVM_DLL std::string NoMatchMsg();
+
 /*!
  * \brief Base class of the temporary expression.
  *

--- a/include/tvm/relay/expr_functor.h
+++ b/include/tvm/relay/expr_functor.h
@@ -116,6 +116,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr_(const RefWriteNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const ConstructorNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const MatchNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const FatalNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExprDefault_(const Node* op, Args...) {
     throw Error(std::string("Do not have a default for ") + op->type_key());
   }
@@ -140,6 +141,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAY_EXPR_FUNCTOR_DISPATCH(RefWriteNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(ConstructorNode);
     RELAY_EXPR_FUNCTOR_DISPATCH(MatchNode);
+    RELAY_EXPR_FUNCTOR_DISPATCH(FatalNode);
     return vtable;
   }
 };
@@ -170,6 +172,7 @@ class ExprVisitor
   void VisitExpr_(const RefWriteNode* op) override;
   void VisitExpr_(const ConstructorNode* op) override;
   void VisitExpr_(const MatchNode* op) override;
+  void VisitExpr_(const FatalNode* op) override;
   virtual void VisitType(const Type& t);
   virtual void VisitClause(const Clause& c);
   virtual void VisitPattern(const Pattern& c);
@@ -212,6 +215,7 @@ class ExprMutator
   Expr VisitExpr_(const RefWriteNode* op) override;
   Expr VisitExpr_(const ConstructorNode* op) override;
   Expr VisitExpr_(const MatchNode* op) override;
+  Expr VisitExpr_(const FatalNode* op) override;
 
   /*!
    * \brief Used to visit the types inside of expressions.

--- a/include/tvm/relay/feature.h
+++ b/include/tvm/relay/feature.h
@@ -48,10 +48,11 @@ enum Feature : int {
   fRefWrite = 12,
   fConstructor = 13,
   fMatch = 14,
+  fFatal = 15,
   /*! \brief Whether any non-atom fragment of the program is shared, making the program a graph. */
-  fGraph = 15,
+  fGraph = 16,
   /*! \brief Whether there is local fixpoint in the program. */
-  fLetRec = 16
+  fLetRec = 17
 };
 
 constexpr size_t feature_count = 17;

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -86,6 +86,7 @@ TupleGetItem = expr.TupleGetItem
 RefCreate = expr.RefCreate
 RefRead = expr.RefRead
 RefWrite = expr.RefWrite
+Fatal = expr.Fatal
 
 # ADT
 PatternWildcard = adt.PatternWildcard

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -127,3 +127,6 @@ Sequential = transform.Sequential
 
 # Feature
 Feature = feature.Feature
+
+# Fatal Messages
+NO_MATCH_MSG = expr.NO_MATCH_MSG

--- a/python/tvm/relay/adt.py
+++ b/python/tvm/relay/adt.py
@@ -186,18 +186,23 @@ class Clause(NodeBase):
 class Match(Expr):
     """Pattern matching expression in Relay."""
 
-    def __init__(self, data, clauses):
+    def __init__(self, data, clauses, complete=True):
         """Construct a Match.
 
         Parameters
         ----------
         data: tvm.relay.Expr
             The value being deconstructed and matched.
+
         clauses: List[tvm.relay.Clause]
             The pattern match clauses.
+
+        complete: Optional[Bool]
+            Is the pattern complete(cover all cases)?
+
         Returns
         -------
         match: tvm.relay.Expr
             The match expression.
         """
-        self.__init_handle_by_constructor__(_make.Match, data, clauses)
+        self.__init_handle_by_constructor__(_make.Match, data, clauses, complete)

--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -448,6 +448,8 @@ class Fatal(Expr):
     def __init__(self, msg):
         self.__init_handle_by_constructor__(_make.Fatal, msg)
 
+NO_MATCH_MSG = _expr.NoMatchMsg()
+
 class TempExpr(Expr):
     """Baseclass of all TempExpr.
 

--- a/python/tvm/relay/expr.py
+++ b/python/tvm/relay/expr.py
@@ -395,6 +395,7 @@ class TupleGetItem(Expr):
 @register_relay_node
 class RefCreate(Expr):
     """Create a new reference from initial value.
+
     Parameters
     ----------
     value: tvm.relay.Expr
@@ -407,6 +408,7 @@ class RefCreate(Expr):
 @register_relay_node
 class RefRead(Expr):
     """Get the value inside the reference.
+
     Parameters
     ----------
     ref: tvm.relay.Expr
@@ -421,6 +423,7 @@ class RefWrite(Expr):
     """
     Update the value inside the reference.
     The whole expression will evaluate to an empty tuple.
+
     Parameters
     ----------
     ref: tvm.relay.Expr
@@ -431,6 +434,19 @@ class RefWrite(Expr):
     def __init__(self, ref, value):
         self.__init_handle_by_constructor__(_make.RefWrite, ref, value)
 
+
+@register_relay_node
+class Fatal(Expr):
+    """
+    Abort the execution with a fatal error message.
+
+    Parameters
+    ----------
+    msg: String
+        The message
+    """
+    def __init__(self, msg):
+        self.__init_handle_by_constructor__(_make.Fatal, msg)
 
 class TempExpr(Expr):
     """Baseclass of all TempExpr.

--- a/python/tvm/relay/expr_functor.py
+++ b/python/tvm/relay/expr_functor.py
@@ -248,7 +248,7 @@ class ExprMutator(ExprFunctor):
         return con
 
     def visit_match(self, m):
-        return Match(self.visit(m.data), [Clause(c.lhs, self.visit(c.rhs)) for c in m.pattern])
+        return Match(self.visit(m.data), [Clause(c.lhs, self.visit(c.rhs)) for c in m.pattern], m.complete)
 
     def visit_ref_create(self, r):
         return RefCreate(self.visit(r.value))
@@ -258,3 +258,6 @@ class ExprMutator(ExprFunctor):
 
     def visit_ref_read(self, r):
         return RefRead(self.visit(r.ref))
+
+    def visit_fatal(self, r):
+        pass

--- a/python/tvm/relay/expr_functor.py
+++ b/python/tvm/relay/expr_functor.py
@@ -248,7 +248,9 @@ class ExprMutator(ExprFunctor):
         return con
 
     def visit_match(self, m):
-        return Match(self.visit(m.data), [Clause(c.lhs, self.visit(c.rhs)) for c in m.pattern], m.complete)
+        return Match(self.visit(m.data),
+                     [Clause(c.lhs, self.visit(c.rhs)) for c in m.pattern],
+                     m.complete)
 
     def visit_ref_create(self, r):
         return RefCreate(self.visit(r.value))

--- a/python/tvm/relay/feature.py
+++ b/python/tvm/relay/feature.py
@@ -35,7 +35,8 @@ class Feature(IntEnum):
     fRefWrite = 12
     fConstructor = 13
     fMatch = 14
+    fFatal = 15
     """ Whether any non-atom fragment of the program is shared, making the program a graph. """
-    fGraph = 15
+    fGraph = 16
     """ Whether there is local fixpoint in the program. """
-    fLetRec = 16
+    fLetRec = 17

--- a/python/tvm/relay/prelude.py
+++ b/python/tvm/relay/prelude.py
@@ -51,7 +51,7 @@ class Prelude:
         y = Var("y")
         z = Var("z")
         cons_case = Clause(PatternConstructor(self.cons, [PatternVar(y), PatternVar(z)]), y)
-        self.mod[self.hd] = Function([x], Match(x, [cons_case]), a, [a])
+        self.mod[self.hd] = Function([x], Match(x, [cons_case], False), a, [a])
 
     def define_list_tl(self):
         """Defines a function to get the tail of a list.
@@ -64,7 +64,7 @@ class Prelude:
         y = Var("y")
         z = Var("z")
         cons_case = Clause(PatternConstructor(self.cons, [PatternVar(y), PatternVar(z)]), z)
-        self.mod[self.tl] = Function([x], Match(x, [cons_case]), self.l(a), [a])
+        self.mod[self.tl] = Function([x], Match(x, [cons_case], False), self.l(a), [a])
 
 
     def define_list_nth(self):
@@ -191,7 +191,7 @@ class Prelude:
         cons_case = Clause(PatternConstructor(self.cons, [PatternVar(y), PatternVar(z)]),
                            f(y, self.foldr1(f, z)))
         self.mod[self.foldr1] = Function([f, av],
-                                         Match(av, [one_case, cons_case]), a, [a])
+                                         Match(av, [one_case, cons_case], False), a, [a])
 
 
     def define_list_concat(self):

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -544,6 +544,11 @@ class Interpreter :
     return Value();
   }
 
+  Value VisitExpr_(const FatalNode* op) final {
+    LOG(FATAL) << "fatal message recieved: " << op->msg;
+    return Value();
+  }
+
   bool VisitPattern_(const PatternConstructorNode* op, const Value& v) final {
     const ConstructorValueNode* cvn = v.as<ConstructorValueNode>();
     CHECK(cvn) << "need to be a constructor for match";

--- a/src/relay/ir/adt.cc
+++ b/src/relay/ir/adt.cc
@@ -144,10 +144,11 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
             << node->rhs << ")";
   });
 
-Match MatchNode::make(Expr data, tvm::Array<Clause> clauses) {
+Match MatchNode::make(Expr data, tvm::Array<Clause> clauses, bool complete) {
   NodePtr<MatchNode> n = make_node<MatchNode>();
   n->data = std::move(data);
   n->clauses = std::move(clauses);
+  n->complete = complete;
   return Match(n);
 }
 
@@ -160,7 +161,7 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
 .set_dispatch<MatchNode>([](const MatchNode* node,
                             tvm::IRPrinter* p) {
   p->stream << "MatchNode(" << node->data << ", "
-            << node->clauses << ")";
+            << node->clauses << ", " << node->complete << ")";
 });
 
 }  // namespace relay

--- a/src/relay/ir/alpha_equal.cc
+++ b/src/relay/ir/alpha_equal.cc
@@ -484,7 +484,8 @@ class AlphaEqualHandler:
 
     if (rhs == nullptr
         || !ExprEqual(lhs->data, rhs->data)
-        || lhs->clauses.size() != rhs->clauses.size()) {
+        || lhs->clauses.size() != rhs->clauses.size()
+        || lhs->complete != rhs->complete) {
       return false;
     }
 

--- a/src/relay/ir/alpha_equal.cc
+++ b/src/relay/ir/alpha_equal.cc
@@ -436,6 +436,14 @@ class AlphaEqualHandler:
     return GetRef<Expr>(lhs) == other;
   }
 
+  bool VisitExpr_(const FatalNode* lhs, const Expr& other) final {
+    if (const FatalNode* rhs = other.as<FatalNode>()) {
+      return lhs->msg == rhs->msg;
+    } else {
+      return false;
+    }
+  }
+
   bool ClauseEqual(const Clause& lhs, const Clause& rhs) {
     return PatternEqual(lhs->lhs, rhs->lhs) && ExprEqual(lhs->rhs, rhs->rhs);
   }

--- a/src/relay/ir/doc.h
+++ b/src/relay/ir/doc.h
@@ -93,6 +93,7 @@ Doc PrintBool(bool value);
 Doc PrintDType(DataType dtype);
 // Print a string.
 Doc PrintString(const std::string& value);
+
 /*!
  * \brief special method to print out const scalar
  * \param dtype The data type

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -334,6 +334,13 @@ TVM_REGISTER_NODE_TYPE(FatalNode);
 TVM_REGISTER_API("relay._make.Fatal")
 .set_body_typed(FatalNode::make);
 
+std::string NoMatchMsg() {
+  return "No case Match";
+}
+
+TVM_REGISTER_API("relay._expr.NoMatchMsg")
+.set_body_typed(NoMatchMsg);
+
 TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
 .set_dispatch<FatalNode>([](const FatalNode* node, tvm::IRPrinter* p) {
   p->stream << "FatalNode(" << node->msg << ")";

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -341,7 +341,7 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
 
 TVM_REGISTER_API("relay._expr.TempExprRealize")
 .set_body_typed<Expr(TempExpr)>([](TempExpr temp) {
-   return temp->Realize();
+  return temp->Realize();
 });
 
 }  // namespace relay

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -322,6 +322,23 @@ TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
   p->stream << "RefWriteNode(" << node->ref << ", " << node->value << ")";
 });
 
+
+Fatal FatalNode::make(std::string msg) {
+  NodePtr<FatalNode> n = make_node<FatalNode>();
+  n->msg = std::move(msg);
+  return Fatal(n);
+}
+
+TVM_REGISTER_NODE_TYPE(FatalNode);
+
+TVM_REGISTER_API("relay._make.Fatal")
+.set_body_typed(FatalNode::make);
+
+TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
+.set_dispatch<FatalNode>([](const FatalNode* node, tvm::IRPrinter* p) {
+   p->stream << "FatalNode(" << node->msg << ")";
+});
+
 TVM_REGISTER_API("relay._expr.TempExprRealize")
 .set_body_typed<Expr(TempExpr)>([](TempExpr temp) {
     return temp->Realize();

--- a/src/relay/ir/expr.cc
+++ b/src/relay/ir/expr.cc
@@ -336,12 +336,12 @@ TVM_REGISTER_API("relay._make.Fatal")
 
 TVM_STATIC_IR_FUNCTOR_REGISTER(IRPrinter, vtable)
 .set_dispatch<FatalNode>([](const FatalNode* node, tvm::IRPrinter* p) {
-   p->stream << "FatalNode(" << node->msg << ")";
+  p->stream << "FatalNode(" << node->msg << ")";
 });
 
 TVM_REGISTER_API("relay._expr.TempExprRealize")
 .set_body_typed<Expr(TempExpr)>([](TempExpr temp) {
-    return temp->Realize();
+   return temp->Realize();
 });
 
 }  // namespace relay

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -210,7 +210,7 @@ Expr ExprMutator::VisitExpr_(const MatchNode* m) {
   for (const Clause& p : m->clauses) {
     clauses.push_back(VisitClause(p));
   }
-  return MatchNode::make(VisitExpr(m->data), clauses);
+  return MatchNode::make(VisitExpr(m->data), clauses, m->complete);
 }
 
 Expr ExprMutator::VisitExpr_(const FatalNode* f) {

--- a/src/relay/ir/expr_functor.cc
+++ b/src/relay/ir/expr_functor.cc
@@ -213,6 +213,10 @@ Expr ExprMutator::VisitExpr_(const MatchNode* m) {
   return MatchNode::make(VisitExpr(m->data), clauses);
 }
 
+Expr ExprMutator::VisitExpr_(const FatalNode* f) {
+  return GetRef<Expr>(f);
+}
+
 Clause ExprMutator::VisitClause(const Clause& c) {
   return ClauseNode::make(VisitPattern(c->lhs), VisitExpr(c->rhs));
 }
@@ -314,6 +318,8 @@ void ExprVisitor::VisitExpr_(const MatchNode* op) {
     this->VisitClause(c);
   }
 }
+
+void ExprVisitor::VisitExpr_(const FatalNode* op) { }
 
 void ExprVisitor::VisitClause(const Clause& op) {
   this->VisitPattern(op->lhs);

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -341,6 +341,7 @@ class RelayHashHandler:
       hash = Combine(hash, PatternHash(c->lhs));
       hash = Combine(hash, ExprHash(c->rhs));
     }
+    hash = Combine(hash, std::hash<bool>()(mn->complete));
     return hash;
   }
 

--- a/src/relay/ir/hash.cc
+++ b/src/relay/ir/hash.cc
@@ -350,6 +350,12 @@ class RelayHashHandler:
     return hash;
   }
 
+  size_t VisitExpr_(const FatalNode* fn) final {
+    size_t hash = std::hash<std::string>()(FatalNode::_type_key);
+    hash = Combine(hash, std::hash<std::string>()(fn->msg));
+    return hash;
+  }
+
   size_t VisitType_(const TypeCallNode* tcn) final {
     size_t hash = std::hash<std::string>()(TypeCallNode::_type_key);
     hash = Combine(hash, TypeHash(tcn->func));

--- a/src/relay/ir/pretty_printer.cc
+++ b/src/relay/ir/pretty_printer.cc
@@ -551,6 +551,12 @@ class PrettyPrinter :
     return doc;
   }
 
+  Doc VisitExpr_(const FatalNode* op) final {
+    Doc doc;
+    doc << "Fatal(" << PrintString(op->msg) << ")";
+    return doc;
+  }
+
   Doc VisitPattern_(const PatternConstructorNode* p) final {
     Doc doc;
     doc << p->constructor->name_hint << "(";

--- a/src/relay/pass/dependency_graph.cc
+++ b/src/relay/pass/dependency_graph.cc
@@ -174,6 +174,8 @@ class DependencyGraph::Creator : private ExprFunctor<void(const Expr& e)> {
   void VisitExpr_(const OpNode* o) final { }
 
   void VisitExpr_(const ConstructorNode* c) final { }
+
+  void VisitExpr_(const FatalNode* c) final { }
 };
 
 DependencyGraph DependencyGraph::Create(common::Arena* arena, const Expr& body) {

--- a/src/relay/pass/feature.cc
+++ b/src/relay/pass/feature.cc
@@ -76,6 +76,7 @@ FeatureSet DetectFeature(const Expr& expr) {
     DETECT_DEFAULT_CONSTRUCT(RefWrite)
     DETECT_DEFAULT_CONSTRUCT(Constructor)
     DETECT_DEFAULT_CONSTRUCT(Match)
+    DETECT_DEFAULT_CONSTRUCT(Fatal)
 #undef DETECT_DEFAULT_CONSTRUCT
   } fd;
   fd(expr);

--- a/src/relay/pass/let_list.h
+++ b/src/relay/pass/let_list.h
@@ -34,13 +34,14 @@
 #include <utility>
 #include <vector>
 #include <tuple>
+#include <string>
 #include "tvm/relay/type.h"
 
 namespace tvm {
 namespace relay {
 
 struct EmitFatal : dmlc::Error {
-  EmitFatal(const std::string& msg) : dmlc::Error(msg) { }
+  explicit EmitFatal(const std::string& msg) : dmlc::Error(msg) { }
 };
 
 /*!

--- a/src/relay/pass/partial_eval.cc
+++ b/src/relay/pass/partial_eval.cc
@@ -825,7 +825,7 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
             return NoStatic(ll->Push(MatchNode::make(ps->dynamic, clauses, op->complete)));
           }
         }
-        throw EmitFatal("No case Match");
+        throw EmitFatal(NoMatchMsg());
       });
   }
 

--- a/src/relay/pass/partial_eval.cc
+++ b/src/relay/pass/partial_eval.cc
@@ -704,6 +704,10 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
     return VisitFunc(GetRef<Function>(op), ll);
   }
 
+  PStatic VisitExpr_(const FatalNode* op, LetList* ll) final {
+    throw EmitFatal(op->msg);
+  }
+
   Expr Reflect(const PStatic& st) {
     if (const STensorNode* op = st->pstatic.as<STensorNode>()) {
       return ConstantNode::make(op->data);
@@ -821,8 +825,7 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
             return NoStatic(ll->Push(MatchNode::make(ps->dynamic, clauses)));
           }
         }
-        LOG(FATAL) << "No case Match";
-        throw;
+        throw EmitFatal("No case Match");
       });
   }
 

--- a/src/relay/pass/partial_eval.cc
+++ b/src/relay/pass/partial_eval.cc
@@ -822,7 +822,7 @@ class PartialEvaluator : public ExprFunctor<PStatic(const Expr& e, LetList* ll)>
               clauses.push_back(ClauseNode::make(c->lhs, expr));
             }
             store_.Invalidate();
-            return NoStatic(ll->Push(MatchNode::make(ps->dynamic, clauses)));
+            return NoStatic(ll->Push(MatchNode::make(ps->dynamic, clauses, op->complete)));
           }
         }
         throw EmitFatal("No case Match");

--- a/src/relay/pass/to_a_normal_form.cc
+++ b/src/relay/pass/to_a_normal_form.cc
@@ -262,7 +262,7 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)> {
         c->lhs,
         GetSubScope(e, 1 + clauses.size())->ll->Get(VisitExpr(c->rhs))));
     }
-    return Compound(e, MatchNode::make(data, clauses), v);
+    return Compound(e, MatchNode::make(data, clauses, m->complete), v);
   }
 
   Expr VisitExpr_(const FatalNode* f, const Var& v) final {

--- a/src/relay/pass/to_a_normal_form.cc
+++ b/src/relay/pass/to_a_normal_form.cc
@@ -264,6 +264,11 @@ class Fill : ExprFunctor<Expr(const Expr&, const Var&)> {
     }
     return Compound(e, MatchNode::make(data, clauses), v);
   }
+
+  Expr VisitExpr_(const FatalNode* f, const Var& v) final {
+    Expr e = GetRef<Expr>(f);
+    return Compound(e, e, v);
+  }
 };
 
 Expr ToANormalFormAux(const Expr& e) {

--- a/src/relay/pass/to_cps.cc
+++ b/src/relay/pass/to_cps.cc
@@ -195,7 +195,7 @@ Function ToCPS(const Function& f, const Module& m, CPSMap* cm, VarMap* vm, const
           for (const auto& c : op->clauses) {
             clauses.push_back(ClauseNode::make(VisitPattern(c->lhs), VisitExpr(c->rhs, kf)));
           }
-          return MatchNode::make(v, clauses);
+          return MatchNode::make(v, clauses, op->complete);
         });
       });
     }

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -309,6 +309,10 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
     return op->op_type;
   }
 
+  Type VisitExpr_(const FatalNode* op) final {
+    return IncompleteTypeNode::make(Kind::kType);
+  }
+
   Type VisitExpr_(const LetNode* let) final {
     // if the definition is a function literal, permit recursion
     bool is_functional_literal = let->value.as<FunctionNode>() != nullptr;

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -294,12 +294,14 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
                           op->span);
     }
 
-    // check completness
-    Match match = GetRef<Match>(op);
-    Array<Pattern> unmatched_cases = UnmatchedCases(match, this->mod_);
-    if (unmatched_cases.size() != 0) {
-      LOG(WARNING) << "Match clause " << match <<  " does not handle the following cases: "
+    if (op->complete) {
+      // check completness
+      Match match = GetRef<Match>(op);
+      Array<Pattern> unmatched_cases = UnmatchedCases(match, this->mod_);
+      if (unmatched_cases.size() != 0) {
+        LOG(FATAL) << "Match clause " << match <<  " does not handle the following cases: "
                    << unmatched_cases;
+      }
     }
 
     return rtype;

--- a/tests/python/relay/test_adt.py
+++ b/tests/python/relay/test_adt.py
@@ -20,6 +20,8 @@ from tvm.relay.backend.interpreter import ConstructorValue
 from tvm.relay import create_executor
 from tvm.relay.prelude import Prelude
 from tvm.relay.testing import add_nat_definitions, count as count_, make_nat_value, make_nat_expr
+from tvm.relay import TypeVar, Var, Fatal, Function, Call
+from tvm.relay import PatternConstructor, Clause, PatternVar, Match
 
 mod = relay.Module()
 p = Prelude(mod)
@@ -681,6 +683,19 @@ def test_compose():
 def test_iterate():
     expr = relay.Call(iterate(double, relay.const(2)), [make_nat_expr(3)])
     res = intrp.evaluate(relay.Function([], expr)())
+    assert count(res) == 12
+
+
+def test_head_fatal():
+    a = TypeVar("a")
+    x = Var("x", l(a))
+    y = Var("y")
+    z = Var("z")
+    nil_case = Clause(PatternConstructor(nil, []), Fatal("cannot pass nil into head"))
+    cons_case = Clause(PatternConstructor(cons, [PatternVar(y), PatternVar(z)]), y)
+    hd_fatal = Function([x], Match(x, [cons_case], False), a, [a])
+    expr = Call(hd_fatal, [cons(make_nat_expr(12), nil())])
+    res = intrp.evaluate(expr)
     assert count(res) == 12
 
 

--- a/tests/python/relay/test_pass_partial_eval.py
+++ b/tests/python/relay/test_pass_partial_eval.py
@@ -23,7 +23,7 @@ from tvm.relay.prelude import Prelude
 from tvm.relay import op, create_executor, transform
 from tvm.relay import Var, TypeVar, TupleGetItem, Let, Function, const, RefRead, RefWrite, RefCreate
 from tvm.relay import TensorType, Tuple, If, Module, Clause, PatternConstructor, PatternVar, Match
-from tvm.relay import GlobalVar, Call
+from tvm.relay import GlobalVar, Call, Fatal, TupleType
 from tvm.relay.transform import gradient
 from tvm.relay.testing import add_nat_definitions, make_nat_expr
 
@@ -306,6 +306,15 @@ def test_double():
     assert alpha_equal(res.body, make_nat_expr(p, 6))
 
 
+def test_fatal():
+    msg = "user-defined fatal message"
+    assert alpha_equal(dcpe(Fatal(msg)), Fatal(msg))
+    mod = Module()
+    p = Prelude(mod)
+
+    orig = Function([], p.hd(p.nil()), TupleType([]))
+    assert alpha_equal(dcpe(orig, mod=mod).body, Fatal(relay.NO_MATCH_MSG))
+
 if __name__ == '__main__':
     test_empty_ad()
     test_tuple()
@@ -323,3 +332,4 @@ if __name__ == '__main__':
     test_nat_id()
     test_global_match_nat_id()
     test_match_nat_id()
+    test_fatal()


### PR DESCRIPTION
Fatal can has any type, and it's semantic is to abort execution with a message.
This PR also add a `complete` field to pattern matching, with default to true.
Only match with complete=false can has incomplete pattern.
Additionally, it fix evaluating an incomplete pattern for Partial Eval - previously it will be an internal compiler error, now it will emit fatal in the generated code.


@wweic @ZihengJiang @yzhliu can you guys help review?