### PR TITLE
[TOPI] add basic scheduling for conv2d_transpose on x86

### DIFF
--- a/topi/python/topi/nn/conv2d_transpose.py
+++ b/topi/python/topi/nn/conv2d_transpose.py
@@ -54,6 +54,7 @@ def conv2d_transpose_nchw(Input, Filter, strides, padding, out_dtype):
     return declaration_conv2d_transpose_impl(Input, Filter, strides, padding, out_dtype)
 
 def declaration_conv2d_transpose_impl(data, kernel, strides, padding, out_dtype):
+    """Implementation of conv2d transpose"""
     batch, in_c, in_h, in_w = data.shape
     _, out_c, filter_h, filter_w = kernel.shape
     stride_h, stride_w = strides

--- a/topi/python/topi/nn/conv2d_transpose.py
+++ b/topi/python/topi/nn/conv2d_transpose.py
@@ -51,11 +51,14 @@ def conv2d_transpose_nchw(Input, Filter, strides, padding, out_dtype):
     Output : tvm.Tensor
         4-D with shape [batch, out_channel, out_height, out_width]
     """
-    batch, in_c, in_h, in_w = Input.shape
-    _, out_c, filter_h, filter_w = Filter.shape
+    return declaration_conv2d_transpose_impl(Input, Filter, strides, padding, out_dtype)
+
+def declaration_conv2d_transpose_impl(data, kernel, strides, padding, out_dtype):
+    batch, in_c, in_h, in_w = data.shape
+    _, out_c, filter_h, filter_w = kernel.shape
     stride_h, stride_w = strides
     # dilate stage
-    DilatedInput = dilate(Input, [1, 1, stride_h, stride_w], name='DilatedInput')
+    DilatedInput = dilate(data, [1, 1, stride_h, stride_w], name='DilatedInput')
     # padding stage
     fpad_top, fpad_left, fpad_bottom, fpad_right = get_pad_tuple(padding, (filter_h, filter_w))
     bpad_top = filter_h - 1 - fpad_top
@@ -78,7 +81,7 @@ def conv2d_transpose_nchw(Input, Filter, strides, padding, out_dtype):
         (batch, out_c, out_h, out_w),
         lambda b, c, h, w: tvm.sum(
             PaddedInput[b, dc, h+dh, w+dw].astype(out_dtype) *
-            Filter[dc, c, filter_h-1-dh, filter_w-1-dw].astype(out_dtype),
+            kernel[dc, c, filter_h-1-dh, filter_w-1-dw].astype(out_dtype),
             axis=[dc, dh, dw]), tag="conv2d_transpose_nchw")
 
     return Output

--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -14,3 +14,4 @@ from .depthwise_conv2d import schedule_depthwise_conv2d_NCHWc
 from .dense import _schedule_dense, _schedule_dense_pack, _schedule_dense_nopack
 from .batch_matmul import schedule_batch_matmul
 from .roi_align import roi_align_nchw
+from .conv2d_transpose import schedule_conv2d_transpose

--- a/topi/python/topi/x86/conv2d_transpose.py
+++ b/topi/python/topi/x86/conv2d_transpose.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,unused-variable,unused-argument,no-member
+"""Conv2D Transpose schedule on x86"""
+
+import tvm
+from tvm import autotvm
+from .. import generic, tag
+from ..nn.conv2d_transpose import conv2d_transpose_nchw
+from ..nn.dilate import dilate
+from ..nn.pad import pad
+from ..nn.util import get_pad_tuple
+from ..util import simplify
+
+@autotvm.register_topi_compute(conv2d_transpose_nchw, 'cpu', ['direct'])
+def _declaration_conv2d_transpose(cfg, data, kernel, strides, padding, out_dtype):
+    return _declaration_conv2d_transpose_impl(cfg, data, kernel, strides, padding, out_dtype)
+
+def _declaration_conv2d_transpose_impl(cfg, data, kernel, strides, padding, out_dtype):
+    batch, in_c, in_h, in_w = data.shape
+    _, out_c, filter_h, filter_w = kernel.shape
+    stride_h, stride_w = strides
+    # dilate stage
+    DilatedInput = dilate(data, [1, 1, stride_h, stride_w], name='DilatedInput')
+    # padding stage
+    fpad_top, fpad_left, fpad_bottom, fpad_right = get_pad_tuple(padding, (filter_h, filter_w))
+    bpad_top = filter_h - 1 - fpad_top
+    bpad_bottom = filter_h - 1 - fpad_bottom
+    bpad_left = filter_w - 1 - fpad_left
+    bpad_right = filter_w - 1 - fpad_right
+    PaddedInput = pad(DilatedInput, \
+                        [0, 0, bpad_top, bpad_left], \
+                        [0, 0, bpad_bottom, bpad_right], \
+                        name='PaddedInput')
+    # convolution stage
+    out_c = simplify(out_c)
+    out_h = simplify((in_h - 1) * stride_h - fpad_top - fpad_bottom + filter_h)
+    out_w = simplify((in_w - 1) * stride_w - fpad_left - fpad_right + filter_w)
+    dc = tvm.reduce_axis((0, in_c), name='dc')
+    dh = tvm.reduce_axis((0, filter_h), name='dh')
+    dw = tvm.reduce_axis((0, filter_w), name='dw')
+
+    print("padding: ", padding)
+    print("strides: ", strides)
+
+    Output = tvm.compute(
+        (batch, out_c, out_h, out_w),
+        lambda b, c, h, w: tvm.sum(
+            PaddedInput[b, dc, h+dh, w+dw].astype(out_dtype) *
+            kernel[dc, c, filter_h-1-dh, filter_w-1-dw].astype(out_dtype),
+            axis=[dc, dh, dw]), tag="conv2d_transpose_nchw")
+
+    return Output
+
+@autotvm.register_topi_schedule(generic.schedule_conv2d_transpose_nchw, 'cpu', ['direct'])
+def schedule_conv2d_transpose(cfg, outs):
+    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
+    s = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+    
+    def traverse(op):
+        """Traverse operators from computation graph"""
+        # inline all one-to-one-mapping operators except the last stage (output)
+        if tag.is_broadcast(op.tag) or tag.is_injective(op.tag):
+            if op not in s.outputs:
+                s[op].compute_inline()
+            for tensor in op.input_tensors:
+                if tensor.op.input_tensors and tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+
+        if 'conv2d_transpose_nchw' in op.tag:
+            conv = op.output(0)
+            kernel = op.input_tensors[1]
+            data = op.input_tensors[0]
+
+            C = conv
+
+            N, OC, OH, OW = C.op.axis
+            rc, ry, rx = C.op.reduce_axis
+
+            OH, oh = s[C].split(OH, factor=1)
+            OC, oc = s[C].split(OC, factor=32)
+            IC, ic = s[C].split(rc, factor=32)
+
+            s[C].reorder(N, OC, OH, oh, OW, oc, IC, ry, rx, ic)
+            s[C].vectorize(oc)
+            s[C].parallel(N)
+
+
+        scheduled_ops.append(op)
+
+    traverse(outs[0].op)
+    return s

--- a/topi/python/topi/x86/conv2d_transpose.py
+++ b/topi/python/topi/x86/conv2d_transpose.py
@@ -21,10 +21,6 @@ import tvm
 from tvm import autotvm
 from .. import generic, tag
 from ..nn.conv2d_transpose import conv2d_transpose_nchw, declaration_conv2d_transpose_impl
-from ..nn.dilate import dilate
-from ..nn.pad import pad
-from ..nn.util import get_pad_tuple
-from ..util import simplify
 
 @autotvm.register_topi_compute(conv2d_transpose_nchw, 'cpu', ['direct'])
 def _declaration_conv2d_transpose(cfg, data, kernel, strides, padding, out_dtype):

--- a/topi/python/topi/x86/conv2d_transpose.py
+++ b/topi/python/topi/x86/conv2d_transpose.py
@@ -20,7 +20,7 @@
 import tvm
 from tvm import autotvm
 from .. import generic, tag
-from ..nn.conv2d_transpose import conv2d_transpose_nchw
+from ..nn.conv2d_transpose import conv2d_transpose_nchw, declaration_conv2d_transpose_impl
 from ..nn.dilate import dilate
 from ..nn.pad import pad
 from ..nn.util import get_pad_tuple
@@ -28,40 +28,8 @@ from ..util import simplify
 
 @autotvm.register_topi_compute(conv2d_transpose_nchw, 'cpu', ['direct'])
 def _declaration_conv2d_transpose(cfg, data, kernel, strides, padding, out_dtype):
-    return _declaration_conv2d_transpose_impl(cfg, data, kernel, strides, padding, out_dtype)
-
-def _declaration_conv2d_transpose_impl(cfg, data, kernel, strides, padding, out_dtype):
-    batch, in_c, in_h, in_w = data.shape
-    _, out_c, filter_h, filter_w = kernel.shape
-    stride_h, stride_w = strides
-    # dilate stage
-    DilatedInput = dilate(data, [1, 1, stride_h, stride_w], name='DilatedInput')
-    # padding stage
-    fpad_top, fpad_left, fpad_bottom, fpad_right = get_pad_tuple(padding, (filter_h, filter_w))
-    bpad_top = filter_h - 1 - fpad_top
-    bpad_bottom = filter_h - 1 - fpad_bottom
-    bpad_left = filter_w - 1 - fpad_left
-    bpad_right = filter_w - 1 - fpad_right
-    PaddedInput = pad(DilatedInput, \
-                        [0, 0, bpad_top, bpad_left], \
-                        [0, 0, bpad_bottom, bpad_right], \
-                        name='PaddedInput')
-    # convolution stage
-    out_c = simplify(out_c)
-    out_h = simplify((in_h - 1) * stride_h - fpad_top - fpad_bottom + filter_h)
-    out_w = simplify((in_w - 1) * stride_w - fpad_left - fpad_right + filter_w)
-    dc = tvm.reduce_axis((0, in_c), name='dc')
-    dh = tvm.reduce_axis((0, filter_h), name='dh')
-    dw = tvm.reduce_axis((0, filter_w), name='dw')
-
-    Output = tvm.compute(
-        (batch, out_c, out_h, out_w),
-        lambda b, c, h, w: tvm.sum(
-            PaddedInput[b, dc, h+dh, w+dw].astype(out_dtype) *
-            kernel[dc, c, filter_h-1-dh, filter_w-1-dw].astype(out_dtype),
-            axis=[dc, dh, dw]), tag="conv2d_transpose_nchw")
-
-    return Output
+    # TODO cfg is not used for now
+    return declaration_conv2d_transpose_impl(data, kernel, strides, padding, out_dtype)
 
 @autotvm.register_topi_schedule(generic.schedule_conv2d_transpose_nchw, 'cpu', ['direct'])
 def schedule_conv2d_transpose(cfg, outs):
@@ -73,7 +41,7 @@ def schedule_conv2d_transpose(cfg, outs):
     def traverse(op):
         """Traverse operators from computation graph"""
         # inline all one-to-one-mapping operators except the last stage (output)
-        if tag.is_broadcast(op.tag) or tag.is_injective(op.tag):
+        if tag.is_injective(op.tag):
             if op not in s.outputs:
                 s[op].compute_inline()
             for tensor in op.input_tensors:

--- a/topi/python/topi/x86/conv2d_transpose.py
+++ b/topi/python/topi/x86/conv2d_transpose.py
@@ -65,10 +65,11 @@ def _declaration_conv2d_transpose_impl(cfg, data, kernel, strides, padding, out_
 
 @autotvm.register_topi_schedule(generic.schedule_conv2d_transpose_nchw, 'cpu', ['direct'])
 def schedule_conv2d_transpose(cfg, outs):
+    """Create schedule for tensors"""
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
     scheduled_ops = []
-    
+
     def traverse(op):
         """Traverse operators from computation graph"""
         # inline all one-to-one-mapping operators except the last stage (output)


### PR DESCRIPTION
As the title. For workload of mask r-cnn, the #FLOPS improves from 0.9G to 90G on c5.18xlarge instance of Amazon EC2.

Finer tuning and autotvm remain the future work.

@yzhliu @kevinthesun 