### PR TITLE
[VTA][Hotfix] Avoiding error when environment variable is not set

### DIFF
--- a/vta/python/vta/testing/util.py
+++ b/vta/python/vta/testing/util.py
@@ -55,20 +55,20 @@ def run(run_func):
     elif env.TARGET == "pynq":
 
         tracket_host = os.environ.get("TVM_TRACKER_HOST", None)
-        tracket_port = int(os.environ.get("TVM_TRACKER_PORT", None))
+        tracket_port = os.environ.get("TVM_TRACKER_PORT", None)
         pynq_host = os.environ.get("VTA_PYNQ_RPC_HOST", None)
-        pynq_port = int(os.environ.get("VTA_PYNQ_RPC_PORT", None))
+        pynq_port = os.environ.get("VTA_PYNQ_RPC_PORT", None)
         # Run device from fleet node if env variables are defined
         if tracket_host and tracket_port:
             remote = autotvm.measure.request_remote(env.TARGET,
                                                     tracket_host,
-                                                    tracket_port,
+                                                    int(tracket_port),
                                                     timeout=10000)
             run_func(env, remote)
         else:
             # Next, run on PYNQ if env variables are defined
             if pynq_host and pynq_port:
-                remote = rpc.connect(pynq_host, pynq_port)
+                remote = rpc.connect(pynq_host, int(pynq_port))
                 run_func(env, remote)
             else:
                 raise RuntimeError(

--- a/vta/python/vta/testing/util.py
+++ b/vta/python/vta/testing/util.py
@@ -54,8 +54,12 @@ def run(run_func):
 
     elif env.TARGET == "pynq":
 
+        # The environment variables below should be set if we are using
+        # a tracker to obtain a remote for a test device
         tracket_host = os.environ.get("TVM_TRACKER_HOST", None)
         tracket_port = os.environ.get("TVM_TRACKER_PORT", None)
+        # Otherwise, we can set the variables below to directly
+        # obtain a remote from a test device
         pynq_host = os.environ.get("VTA_PYNQ_RPC_HOST", None)
         pynq_port = os.environ.get("VTA_PYNQ_RPC_PORT", None)
         # Run device from fleet node if env variables are defined


### PR DESCRIPTION
When running hardware tests, we can obtain a test remote via the tracker, or directly. When obtaining from the tracker, one needs to set the `TVM_TRACKER_HOST` and `TVM_TRACKER_PORT` environment variables. If unset, the test utility will try to get the hardware remote from the `VTA_PYNQ_RPC_HOST` and `VTA_PYNQ_RPC_PORT` environment variables. If either PORT variables are unset, the code below causes an error since we are casting `None` to `int` too early.