### PR TITLE
[Relay] use pytest to capture stdout.

### DIFF
--- a/tests/python/relay/test_pass_manager.py
+++ b/tests/python/relay/test_pass_manager.py
@@ -504,7 +504,7 @@ def test_sequential_with_scoping():
     assert analysis.alpha_equal(zz, zexpected)
 
 
-def test_print_ir():
+def test_print_ir(capfd):
     shape = (1, 2, 3)
     tp = relay.TensorType(shape, "float32")
     x = relay.var("x", tp)
@@ -519,45 +519,14 @@ def test_print_ir():
         relay.transform.DeadCodeElimination()
     ])
 
-    def redirect_output(call):
-        """Redirect the C++ logging info."""
-        import sys
-        import os
-        import threading
-        stderr_fileno = sys.stderr.fileno()
-        stderr_save = os.dup(stderr_fileno)
-        stderr_pipe = os.pipe()
-        os.dup2(stderr_pipe[1], stderr_fileno)
-        os.close(stderr_pipe[1])
-        output = ''
+    mod = relay.Module({"main": func})
+    with relay.build_config(opt_level=3):
+        mod = seq(mod)
 
-        def record():
-            nonlocal output
-            while True:
-                data = os.read(stderr_pipe[0], 1024)
-                if not data:
-                    break
-                output += data.decode("utf-8")
-
-        t = threading.Thread(target=record)
-        t.start()
-        call()
-        os.close(stderr_fileno)
-        t.join()
-        os.close(stderr_pipe[0])
-        os.dup2(stderr_save, stderr_fileno)
-        os.close(stderr_save)
-
-        return output
-
-    def run_pass():
-        mod = relay.Module({"main": func})
-        with relay.build_config(opt_level=3):
-            mod = seq(mod)
-
-    out = redirect_output(run_pass)
-    assert "Dumping the module IR" in out
-    assert "multiply" in out
+    if capfd:
+        captured = capfd.readouterr()
+        assert "Dumping the module IR" in captured.err
+        assert "multiply" in captured.err
 
 
 if __name__ == "__main__":
@@ -568,4 +537,4 @@ if __name__ == "__main__":
     test_sequential_pass()
     test_sequential_with_scoping()
     test_pass_info()
-    test_print_ir()
+    test_print_ir(None)


### PR DESCRIPTION
On my machine, redirect_output cannot work when I has pytest on. upon investigation, it seems like pytest already redirect the output, and trying to capture it again cause problem for me.

So, this PR use pytest's capture capability, which is cleaner and more robust.