### PR TITLE
Fix pylint issue in vta/python/vta/top/graphpack.py

### DIFF
--- a/vta/python/vta/top/graphpack.py
+++ b/vta/python/vta/top/graphpack.py
@@ -129,6 +129,7 @@ class ExprPack(ExprMutator):
         super().__init__()
 
     def visit_call(self, call):
+        """ Visit the children. """
         # First visit the children.
         oshape = _get_shape(call)
         odtype = call.checked_type.dtype


### PR DESCRIPTION
This appears in linting using the docker scripts. I'm not sure
why this isn't failing in the standard CI for TVM and it might
be that the docker images haven't been updated in the CI system.

python3 -m pylint vta/python/vta --rcfile=/workspace/tests/lint/pylintrc
Using config file /workspace/tests/lint/pylintrc
************* Module vta.top.graphpack
C:131, 4: Missing method docstring (missing-docstring)

