### PR TITLE
[ARITH][BOUND] Fix bound inference to avoid allocating too much

### DIFF
--- a/include/tvm/operation.h
+++ b/include/tvm/operation.h
@@ -100,6 +100,7 @@ class OperationNode : public FunctionBaseNode {
   /*!
    * \brief Propagate the bounds to inputs
    * \param self The reference to self.
+   * \param analyzer The analyzer to be used in the function.
    * \param dom_map the domain map of Variables(corresponds to root_iter_vars)
    * \param out_dom_map The output domain.
    *  The function is only asked to fill the bounds for Tensors that
@@ -107,6 +108,7 @@ class OperationNode : public FunctionBaseNode {
    */
   virtual void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const = 0;
   /*!
@@ -170,6 +172,7 @@ class PlaceholderOpNode : public OperationNode {
       const std::unordered_map<Tensor, Tensor>& rmap) const final;
   void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const final;
   void GatherBound(
@@ -247,6 +250,7 @@ class TVM_DLL ComputeOpNode : public BaseComputeOpNode {
       const std::unordered_map<Tensor, Tensor>& rmap) const final;
   void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const final;
   Stmt BuildProvide(
@@ -299,6 +303,7 @@ class TensorComputeOpNode : public BaseComputeOpNode {
       const std::unordered_map<Tensor, Tensor>& rmap) const final;
   void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const final;
   Stmt BuildProvide(
@@ -373,6 +378,7 @@ class ScanOpNode : public OperationNode {
       const std::unordered_map<Tensor, Tensor>& rmap) const final;
   void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const final;
   void GatherBound(
@@ -439,6 +445,7 @@ class ExternOpNode : public OperationNode {
       const std::unordered_map<Tensor, Tensor>& rmap) const final;
   void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const final;
   void GatherBound(
@@ -506,6 +513,7 @@ class HybridOpNode : public OperationNode {
       const std::unordered_map<Tensor, Tensor>& rmap) const final;
   void PropBoundToInputs(
       const Operation& self,
+      arith::Analyzer* analyzer,
       const std::unordered_map<const Variable*, IntSet>& dom_map,
       std::unordered_map<Tensor, TensorDom>* out_dom_map) const final;
   void GatherBound(

--- a/src/op/extern_op.cc
+++ b/src/op/extern_op.cc
@@ -112,6 +112,7 @@ Operation ExternOpNode::ReplaceInputs(
 
 void ExternOpNode::PropBoundToInputs(
     const Operation& self,
+    arith::Analyzer* analyzer,
     const std::unordered_map<const Variable*, IntSet>& dom_map,
     std::unordered_map<Tensor, TensorDom>* out_dom_map) const {
   for (Tensor t : this->inputs) {

--- a/src/op/hybrid_op.cc
+++ b/src/op/hybrid_op.cc
@@ -110,6 +110,7 @@ Operation HybridOpNode::ReplaceInputs(
 
 void HybridOpNode::PropBoundToInputs(
     const Operation &self,
+    arith::Analyzer* analyzer,
     const std::unordered_map<const Variable*, IntSet> &dom_map,
     std::unordered_map<Tensor, TensorDom>* out_dom_map) const {
   for (Tensor t : this->inputs) {

--- a/src/op/placeholder_op.cc
+++ b/src/op/placeholder_op.cc
@@ -78,6 +78,7 @@ Operation PlaceholderOpNode::ReplaceInputs(
 
 void PlaceholderOpNode::PropBoundToInputs(
     const Operation& self,
+    arith::Analyzer* analyzer,
     const std::unordered_map<const Variable*, IntSet>& dom_map,
     std::unordered_map<Tensor, TensorDom>* out_dom_map) const {
 }

--- a/src/op/scan_op.cc
+++ b/src/op/scan_op.cc
@@ -176,6 +176,7 @@ Operation ScanOpNode::ReplaceInputs(
 
 void ScanOpNode::PropBoundToInputs(
     const Operation& self,
+    arith::Analyzer* analyzer,
     const std::unordered_map<const Variable*, IntSet>& dom_map,
     std::unordered_map<Tensor, TensorDom>* out_dom_map) const {
   CHECK_EQ(self.operator->(), this);

--- a/src/op/tensor_compute_op.cc
+++ b/src/op/tensor_compute_op.cc
@@ -110,6 +110,7 @@ Operation TensorComputeOpNode::ReplaceInputs(
 
 void TensorComputeOpNode::PropBoundToInputs(
     const Operation& self,
+    arith::Analyzer* analyzer,
     const std::unordered_map<const Variable*, IntSet>& dom_map,
     std::unordered_map<Tensor, TensorDom>* out_dom_map) const {
   for (size_t i = 0; i < this->inputs.size(); ++i) {

--- a/src/schedule/bound.cc
+++ b/src/schedule/bound.cc
@@ -191,6 +191,7 @@ void InferRootBound(const Stage& stage,
     PassUpDomain(op_stage, *rmap, &up_state);
     // Relax if needed.
     std::unordered_map<const Variable*, IntSet> dom_map;
+    arith::Analyzer analyzer;
     for (auto iv : op->root_iter_vars()) {
       Range r;
       if (up_state.count(iv)) {
@@ -203,8 +204,9 @@ void InferRootBound(const Stage& stage,
       } else {
         dom_map[iv->var.get()] = IntSet::range(r);
       }
+      analyzer.Bind(iv->var, r);
     }
-    op->PropBoundToInputs(op, dom_map, &tmap);
+    op->PropBoundToInputs(op, &analyzer, dom_map, &tmap);
   }
   stage->op->GatherBound(stage->op, tmap, rmap);
 }

--- a/tests/python/unittest/test_schedule_schedule_ops.py
+++ b/tests/python/unittest/test_schedule_schedule_ops.py
@@ -286,20 +286,6 @@ def test_schedule_cache_relayout4():
     stmt = tvm.schedule.ScheduleOps(s, bounds)
 
 
-def test_schedule_bound_condition():
-   A = tvm.placeholder((64,), name='A', dtype="float32")
-   Apad = tvm.compute((66,), lambda i: tvm.if_then_else(
-       tvm.all(i>0, i < 65), A[i-1], tvm.const(0., "float32")), name='Apad')
-   Apad2 = tvm.compute((66,), lambda i: Apad[i]*2, name='Apad2')
-   s = tvm.create_schedule(Apad2.op)
-   AL1 = s.cache_read(A,"local",[Apad])
-   s = s.normalize()
-   bounds = tvm.schedule.InferBound(s)
-   stmt = tvm.schedule.ScheduleOps(s, bounds)
-   stmt = tvm.ir_pass.Simplify(stmt)
-   assert (isinstance(stmt.body.body.first.body.body.then_case, tvm.stmt.IfThenElse))
-
-
 def intrin_gemv(m, n):
     w = tvm.placeholder((m, n), name='w')
     x = tvm.placeholder((n,), name='x')
@@ -514,7 +500,6 @@ if __name__ == "__main__":
     test_schedule1()
     test_schedule2()
     test_schedule_cache()
-    test_schedule_bound_condition()
     test_schedule_tensor_compute1()
     test_schedule_tensor_compute2()
     test_schedule_tensor_compute3()


### PR DESCRIPTION
Another attempt to fix the problem of tensor bound expansion ([described here](https://discuss.tvm.ai/t/strange-expansion-of-tensors-bounds/1077)). The previous attempt was #2104. This time, however, tests passed. The fix is to use the declared tensor bounds instead of the estimated bounds for the argument if it is possible to prove that the declared bounds are tighter. Note that this means that out-of-bounds access may really result in out-of-bounds access.
@tqchen @junrushao1994 please take a look
cc @grwlf @derisavi @jdavies-huawei @bulanova-huawei