### PR TITLE
[Relay] Bitserial Operators

### DIFF
--- a/include/tvm/relay/attrs/bitserial.h
+++ b/include/tvm/relay/attrs/bitserial.h
@@ -73,6 +73,36 @@ struct BinaryConv2DAttrs : public tvm::AttrsNode<BinaryConv2DAttrs> {
   }
 };
 
+/*~ \brief Attributes for bitserial dense operator */
+struct BinaryDenseAttrs : public tvm::AttrsNode<BinaryDenseAttrs> {
+  IndexExpr units;
+  int data_bits;
+  int weight_bits;
+  DataType pack_dtype;
+  DataType out_dtype;
+  bool unipolar;
+
+  TVM_DECLARE_ATTRS(BinaryDenseAttrs, "relay.attrs.BinaryDenseAttrs") {
+    TVM_ATTR_FIELD(units)
+      .describe("Number of hidden units of the dense transformation.");
+    TVM_ATTR_FIELD(data_bits)
+      .set_default(1)
+      .describe("Number of bits to pack for incoming tensor.");
+    TVM_ATTR_FIELD(weight_bits)
+      .set_default(1)
+      .describe("Number of bits to pack for weight tensor.");
+    TVM_ATTR_FIELD(pack_dtype)
+      .set_default(NullValue<DataType>())
+      .describe("Datatype to pack bits into before computation.");
+    TVM_ATTR_FIELD(out_dtype)
+      .set_default(NullValue<DataType>())
+      .describe("Output data type.");
+    TVM_ATTR_FIELD(unipolar)
+      .set_default(true)
+      .describe("Whether to use unipolar or bipolar quantization for inputs.");
+  }
+};
+
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_ATTRS_BITSERIAL_H_

--- a/include/tvm/relay/attrs/bitserial.h
+++ b/include/tvm/relay/attrs/bitserial.h
@@ -1,0 +1,35 @@
+#ifndef TVM_RELAY_ATTRS_BITSERIAL_H_
+#define TVM_RELAY_ATTRS_BITSERIAL_H_
+
+#include <tvm/attrs.h>
+#include <string>
+
+namespace tvm {
+namespace relay {
+
+/*! \brief Attributes used in bitpack operators */
+struct BitPackAttrs : public tvm::AttrsNode<BitPackAttrs> {
+  int bits;
+  int pack_axis;
+  int bit_axis;
+  DataType pack_type;
+  std::string name;
+
+  TVM_DECLARE_ATTRS(BitPackAttrs, "relay.attrs.BitPackAttrs") {
+    TVM_ATTR_FIELD(bits).set_default(1)
+        .describe("Number of bits to quantize with.");
+    TVM_ATTR_FIELD(pack_axis).set_default(1)
+        .describe("Axis that should be compressed, typically channels.");
+    TVM_ATTR_FIELD(bit_axis).set_default(-1)
+        .describe("New axis for packed bits.");
+    TVM_ATTR_FIELD(pack_type).set_default(NullValue<DataType>())
+        .describe("Type of int to pack bits into.");
+    TVM_ATTR_FIELD(name).set_default("BitPack")
+        .describe("Name of operation.");
+  }
+};
+
+
+}  // namespace relay
+}  // namespace tvm
+#endif  // TVM_RELAY_ATTRS_BITSERIAL_H_

--- a/include/tvm/relay/attrs/bitserial.h
+++ b/include/tvm/relay/attrs/bitserial.h
@@ -16,19 +16,62 @@ struct BitPackAttrs : public tvm::AttrsNode<BitPackAttrs> {
   std::string name;
 
   TVM_DECLARE_ATTRS(BitPackAttrs, "relay.attrs.BitPackAttrs") {
-    TVM_ATTR_FIELD(bits).set_default(1)
-        .describe("Number of bits to quantize with.");
-    TVM_ATTR_FIELD(pack_axis).set_default(1)
-        .describe("Axis that should be compressed, typically channels.");
-    TVM_ATTR_FIELD(bit_axis).set_default(-1)
-        .describe("New axis for packed bits.");
-    TVM_ATTR_FIELD(pack_type).set_default(NullValue<DataType>())
+    TVM_ATTR_FIELD(bits).set_default(1).describe("Number of bits to quantize with.");
+    TVM_ATTR_FIELD(pack_axis).set_default(1).describe(
+        "Axis that should be compressed, typically channels.");
+    TVM_ATTR_FIELD(bit_axis).set_default(-1).describe("New axis for packed bits.");
+    TVM_ATTR_FIELD(pack_type)
+        .set_default(NullValue<DataType>())
         .describe("Type of int to pack bits into.");
-    TVM_ATTR_FIELD(name).set_default("BitPack")
-        .describe("Name of operation.");
+    TVM_ATTR_FIELD(name).set_default("BitPack").describe("Name of operation.");
   }
 };
 
+/*! \brief Attribues used in bitserial convolution operators */
+struct BinaryConv2DAttrs : public tvm::AttrsNode<BinaryConv2DAttrs> {
+  Array<IndexExpr> strides;
+  Array<IndexExpr> padding;
+  IndexExpr channels;
+  Array<IndexExpr> kernel_size;
+  int activation_bits;
+  int weight_bits;
+  std::string data_layout;
+  DataType pack_dtype;
+  DataType out_dtype;
+  bool unipolar;
+
+  TVM_DECLARE_ATTRS(BinaryConv2DAttrs, "relay.attrs.BinaryConv2DAttrs") {
+    TVM_ATTR_FIELD(strides)
+        .set_default(Array<IndexExpr>({1, 1}))
+        .describe("Specifies the strides of the convolution.");
+    TVM_ATTR_FIELD(padding)
+        .set_default(Array<IndexExpr>({0, 0}))
+        .describe(
+            "If padding is non-zero the input is implicitly zero-padded"
+            "on both sides for padding number of points.");
+    TVM_ATTR_FIELD(kernel_size)
+        .set_default(Array<IndexExpr>({3, 3}))
+        .describe("Specifies the dimensions of the convolution window.");
+    TVM_ATTR_FIELD(channels)
+        .set_default(NullValue<IndexExpr>())
+        .describe("Number of output channels, needed for shape inference.");
+    TVM_ATTR_FIELD(activation_bits)
+        .set_default(1)
+        .describe("Number of bits activation should be packed with.");
+    TVM_ATTR_FIELD(weight_bits)
+        .set_default(1)
+        .describe("Number of bits kernel should be packed with.");
+    TVM_ATTR_FIELD(data_layout)
+        .set_default("NCHW")
+        .describe("Dimension ordering of input data, can be 'NCHW' or NHWC'.");
+    TVM_ATTR_FIELD(pack_dtype)
+        .set_default(NullValue<DataType>())
+        .describe("Datatype to pack bits into.");
+    TVM_ATTR_FIELD(out_dtype).set_default(NullValue<DataType>()).describe("Output datatype.");
+    TVM_ATTR_FIELD(unipolar).set_default(true).describe(
+        "Whether to use unipolar or bipolar quantization.");
+  }
+};
 
 }  // namespace relay
 }  // namespace tvm

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -87,6 +87,8 @@ def extract_from_program(func, params, ops, target, target_host=None):
         tvm.relay.op.nn.conv2d_transpose: [topi.nn.conv2d_transpose_nchw],
         tvm.relay.op.nn.dense: [topi.nn.dense],
         tvm.relay.op.nn.deformable_conv2d: [topi.nn.deformable_conv2d_nchw],
+        tvm.relay.op.nn.bitserial_conv2d: [topi.nn.bitserial_conv2d_nchw],
+        tvm.relay.op.nn.bitserial_dense: [topi.nn.bitserial_dense],
     }
 
     topi_funcs = []
@@ -95,7 +97,6 @@ def extract_from_program(func, params, ops, target, target_host=None):
             topi_funcs.extend(OP2TOPI[op_name])
         else:
             warnings.warn("Op %s is not tunable, ignored" % op_name)
-
     # run compiler to collect all TOPI calls during compilation
     env.reset(topi_funcs)
     with env:

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -87,7 +87,7 @@ def extract_from_program(func, params, ops, target, target_host=None):
         tvm.relay.op.nn.conv2d_transpose: [topi.nn.conv2d_transpose_nchw],
         tvm.relay.op.nn.dense: [topi.nn.dense],
         tvm.relay.op.nn.deformable_conv2d: [topi.nn.deformable_conv2d_nchw],
-        tvm.relay.op.nn.bitserial_conv2d: [topi.nn.bitserial_conv2d_nchw],
+        tvm.relay.op.nn.bitserial_conv2d: [topi.nn.bitserial_conv2d_nchw, topi.nn.bitserial_conv2d_nhwc],
         tvm.relay.op.nn.bitserial_dense: [topi.nn.bitserial_dense],
     }
 

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -534,3 +534,13 @@ def schedule_bitpack(attrs, outs, target):
         return topi.generic.schedule_bitpack(outs)
 
 reg.register_pattern("nn.bitpack", OpPattern.INJECTIVE)
+
+@reg.register_compute("nn.bitserial_conv2d")
+    """Compute definition for bitserial conv2d."""
+    # Need to look at data layout to find proper function.
+    return None
+
+@reg.register_schedule("nn.bitserial_conv2d")
+    """Schedule definition for bitserial conv2d."""
+    # Need to look at data layout to find proper schedule.
+    return None

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -513,3 +513,24 @@ def schedule_deformable_conv2d(attrs, outs, target):
 
 
 reg.register_pattern("nn.deformable_conv2d", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+
+@reg.register_compute("nn.bitpack")
+def compute_bitpack(attrs, inputs, out_dtype, target):
+    """Compute definition for bitpack"""
+    bits = attrs.bits
+    pack_axis = attrs.pack_axis
+    bit_axis = attrs.bit_axis
+    pack_type = attrs.pack_type
+    name = attrs.name
+    with target:
+        out = topi.nn.bitpack(inputs[0], bits, pack_axis, bit_axis, pack_type,
+                              name)
+    return [out]
+
+@reg.register_schedule("nn.bitpack")
+def schedule_bitpack(attrs, outs, target):
+    with target:
+        return topi.generic.schedule_bitpack(outs)
+
+reg.register_pattern("nn.bitpack", OpPattern.INJECTIVE)

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -578,3 +578,35 @@ def schedule_bitserial_conv2d(attrs, outs, target):
 
 
 reg.register_pattern("nn.bitserial_conv2d", OpPattern.OUT_ELEMWISE_FUSABLE)
+
+
+# bitserial_dense
+@reg.register_compute("nn.bitserial_dense")
+def compute_bitserial_dense(attrs, inputs, out_type, target):
+    """Compute definition of bitserial_dense"""
+    data_bits = attrs.data_bits
+    weight_bits = attrs.weight_bits
+    pack_dtype = attrs.pack_dtype
+    out_dtype = attrs.out_dtype
+    out_dtype = inputs[0].dtype if out_dtype == "" else out_dtype
+    unipolar = attrs.unipolar
+    return [
+        topi.nn.bitserial_dense(
+            inputs[0],
+            inputs[1],
+            data_bits,
+            weight_bits,
+            pack_dtype,
+            out_dtype,
+            unipolar)
+    ]
+
+
+@reg.register_schedule("nn.bitserial_dense")
+def schedule_bitserial_dense(attrs, outputs, target):
+    """Schedule definition of bitserial_dense"""
+    with target:
+        return topi.generic.schedule_bitserial_dense(outputs)
+
+
+reg.register_pattern("nn.bitserial_dense", reg.OpPattern.OUT_ELEMWISE_FUSABLE)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1298,3 +1298,53 @@ def bitserial_conv2d(data,
     return _make.bitserial_conv2d(data, weight, strides, padding, channels,
                                   kernel_size, activation_bits, weight_bits,
                                   data_layout, pack_dtype, out_dtype, unipolar)
+
+
+def bitserial_dense(data,
+                    weight,
+                    units=None,
+                    data_bits=1,
+                    weight_bits=1,
+                    pack_dtype='uint32',
+                    out_dtype='int16',
+                    unipolar=True):
+    """Bitserial Dense operator.
+    Applies a linear transformation
+
+    .. math::
+
+    `Y = X * W`
+
+    Parameters
+    ----------
+    data : tvm.relay.Expr
+        The input data to the operator.
+
+    weight : tvm.relay.Expr
+        The weight expressions.
+
+    units : int, optional
+        Number of hidden units of the dense transformation.
+
+    data_bits : int
+        Number of bits incoming tensor should be packed with.
+
+    weight_bits : int
+        Number of bits weight tensor should be packed with.
+
+    pack_dtype : str, optional
+        Datatype to pack individual bits into before computation.
+
+    out_dtype : str, optional
+        Specifies the output data type for mixed precision dense.
+
+    unipolar : bool, optional
+        Whether to use unipolar or bipolar quantization for inputs.
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The computed result.
+    """
+    return _make.bitserial_dense(data, weight, units, data_bits, weight_bits,
+                                 pack_dtype, out_dtype, unipolar)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1238,3 +1238,63 @@ def bitpack(data,
         The packed tensor.
     """
     return _make.bitpack(data, bits, pack_axis, bit_axis, pack_type, name)
+
+
+def bitserial_conv2d(data,
+                     weight,
+                     strides=(1, 1),
+                     padding=(0, 0),
+                     channels=None,
+                     kernel_size=(3, 3),
+                     activation_bits=1,
+                     weight_bits=1,
+                     data_layout='NCHW',
+                     pack_dtype='uint32',
+                     out_dtype='int16',
+                     unipolar=True):
+    r"""Tensor packing for bitserial operations.
+
+    Parameters
+    ----------
+    data : tvm.relay.Expr
+        The input data to the operator.
+
+    weight : tvm.relay.Expr
+        The weight expressions.
+
+    strides : tuple of int, optional
+        The strides of convolution.
+
+    padding : tuple of int, optional
+        The padding of convolution on both sides of inputs before convolution.
+
+    channels : int, optional
+        Number of output channels of this convolution.
+
+    kernel_size : tuple of int, optional
+        The spatial of the convolution kernel.
+
+    activation_bits : int
+        Number of bits to pack for activations.
+
+    weight_bits : int
+        Number of bits to pack for weights.
+
+    data_layout : str, optional
+        Layout of the input.
+
+    pack_dtype: str, optional
+        Datatype to pack bits into.
+
+    out_dtype : str, optional
+        Specifies the output data type for mixed precision conv2d.
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The computed result.
+    """
+
+    return _make.bitserial_conv2d(data, weight, strides, padding, channels,
+                                  kernel_size, activation_bits, weight_bits,
+                                  data_layout, pack_dtype, out_dtype, unipolar)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1203,3 +1203,38 @@ def deformable_conv2d(data,
     return _make.deformable_conv2d(data, offset, weight, strides, padding, dilation,
                                    deformable_groups, groups, channels, kernel_size, data_layout,
                                    kernel_layout, out_layout, out_dtype)
+
+def bitpack(data,
+            bits=1,
+            pack_axis=1,
+            bit_axis=2,
+            pack_type="uint32",
+            name="BitPack"):
+    r"""Tensor packing for bitserial operations.
+
+    Parameters
+    ----------
+    data : tvm.relay.expr
+        The incoming tensor to be packed.
+
+    bits : int
+        Number of bits that should be packed.
+
+    pack_axis : int
+        Axis that should be decomposed and packed.
+
+    bit_axis : int
+        New axis containing bitplane.
+
+    pack_type : str
+        Datatype to pack bits into.
+
+    name : str, optional
+        Name of the operation.
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The packed tensor.
+    """
+    return _make.bitpack(data, bits, pack_axis, bit_axis, pack_type, name)

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -1252,7 +1252,7 @@ def bitserial_conv2d(data,
                      pack_dtype='uint32',
                      out_dtype='int16',
                      unipolar=True):
-    r"""Tensor packing for bitserial operations.
+    r"""2D convolution using bitserial computation.
 
     Parameters
     ----------

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -99,6 +99,7 @@ bool BinaryConv2DRel(const Array<Type>& types,
   const auto trans_in_layout = BijectiveLayoutNode::make(in_layout, kNCHW);
   Array<IndexExpr> dshape_nchw = trans_in_layout.ForwardShape(data->shape); 
   CHECK(param->channels.defined());
+  CHECK(param->kernel_size.defined());
   Array<IndexExpr> oshape({dshape_nchw[0], param->channels, 0, 0});
   oshape.Set(2, (dshape_nchw[2] + param->padding[0] * 2 - param->kernel_size[0]) / param->strides[0] + 1);
   oshape.Set(3, (dshape_nchw[3] + param->padding[1] * 2 - param->kernel_size[1]) / param->strides[1] + 1);

--- a/src/relay/op/nn/bitserial.cc
+++ b/src/relay/op/nn/bitserial.cc
@@ -1,0 +1,82 @@
+#include <tvm/relay/op.h>
+#include <tvm/relay/attrs/bitserial.h>
+
+namespace tvm {
+namespace relay {
+
+// relay.nn.bitpack
+TVM_REGISTER_NODE_TYPE(BitPackAttrs);
+
+bool BitPackRel(const Array<Type>& types,
+                int num_inputs,
+                const Attrs& attrs,
+                const TypeReporter& reporter) {
+  const BitPackAttrs* param = attrs.as<BitPackAttrs>();
+  CHECK_EQ(types.size(), 2);
+  const auto* data = types[0].as<TensorTypeNode>();
+  CHECK(data);
+  int ndim = data->shape.size();
+  int bits = param->bits;
+  int pack_axis = param->pack_axis;
+  int bit_axis = param->bit_axis;
+  DataType pack_type = param->pack_type;
+
+  int pack_bits = pack_type.bits();
+
+  Array<IndexExpr> out_shape;
+  for (int i = 0; i < ndim; ++i) {
+    if (i == bit_axis) {
+      out_shape.push_back(bits);
+      if (i == pack_axis) {
+        out_shape.push_back(data->shape[i] / pack_bits);
+      } else {
+        out_shape.push_back(data->shape[i]);
+      }
+    } else if (i == pack_axis) {
+      out_shape.push_back(data->shape[i] / pack_bits);
+    } else {
+      out_shape.push_back(data->shape[i]);
+    }
+  }
+  reporter->Assign(types[1], TensorTypeNode::make(out_shape, pack_type));
+  return true;
+}
+
+
+Expr MakeBitPack(Expr data,
+                 int bits,
+                 int pack_axis,
+                 int bit_axis,
+                 DataType pack_type,
+                 std::string name) {
+  auto attrs = make_node<BitPackAttrs>();
+  attrs->bits = bits;
+  attrs->pack_axis = pack_axis;
+  attrs->bit_axis = bit_axis;
+  attrs->pack_type = pack_type;
+  attrs->name = name;
+  static const Op& op = Op::Get("nn.bitpack");
+  return CallNode::make(op, {data}, Attrs(attrs), {});
+}
+
+TVM_REGISTER_API("relay.op.nn._make.bitpack")
+.set_body_typed(MakeBitPack);
+
+RELAY_REGISTER_OP("nn.bitpack")
+.describe(R"code(Bitpack layer that prepares data for bitserial operations.
+
+This layer backs the bits of an input into a single datatype, allowing 
+efficient implementation of bitserial operations.
+
+- **data**: Input tensor of any shape, dimension that is to be
+            packed must be divisible by number of bits.
+- **out**:  Packed tensor with shape appropriately compressed. 
+)code" TVM_ADD_FILELINE)
+.set_num_inputs(1)
+.set_attrs_type_key("relay.attrs.BitPackAttrs")
+.add_argument("data", "Tensor", "Input data.")
+.set_support_level(2)
+.add_type_rel("BitPack", BitPackRel);
+
+}  // namespace relay
+}  // namespace tvm

--- a/topi/python/topi/generic/nn.py
+++ b/topi/python/topi/generic/nn.py
@@ -457,6 +457,24 @@ def schedule_binarize_pack(outs):
     return _default_schedule(outs, False)
 
 
+@tvm.target.override_native_generic_func("schedule_bitpack")
+def schedule_bitpack(outs):
+    """Schedule for bitpack
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+          The computation graph description of bitpack 
+          in the format of an array of tensors.
+
+    Returns
+    -------
+    sch: Schedule
+        The computation schedule for the op.
+    """
+    return _default_schedule(outs, False)
+
+
 @tvm.target.override_native_generic_func("schedule_binary_dense")
 def schedule_binary_dense(outs):
     """Schedule for binary_dense

--- a/topi/python/topi/nn/bitserial_conv2d.py
+++ b/topi/python/topi/nn/bitserial_conv2d.py
@@ -65,7 +65,11 @@ def bitserial_conv2d_nchw(data, kernel, stride, padding, activation_bits, weight
     """
     assert isinstance(stride, int) or len(stride) == 2
     Input_q = bitpack(data, activation_bits, pack_axis=1, bit_axis=2, pack_type=pack_dtype)
-    Filter_q = bitpack(filter, weight_bits, pack_axis=1, bit_axis=4, pack_type=pack_dtype)
+    # Kernel hasnt been packed if it has 4 dims.
+    if len(kernel.shape) == 4:
+        Filter_q = bitpack(kernel, weight_bits, pack_axis=1, bit_axis=4, pack_type=pack_dtype)
+    else:
+        Filter_q = kernel
     batch, in_channel, activation_bits, in_height, in_width = Input_q.shape
     num_filter, _, kernel_h, kernel_w, weight_bits = Filter_q.shape
 
@@ -156,10 +160,10 @@ def bitserial_conv2d_nhwc(data, kernel, stride, padding, activation_bits, weight
     Input_q = bitpack(data, activation_bits, pack_axis=3, bit_axis=4, pack_type=pack_dtype)
     if len(kernel.shape) == 4:
         Filter_q = bitpack(kernel, weight_bits, pack_axis=2, bit_axis=4, pack_type=pack_dtype)
-        kernel_h, kernel_w, _, num_filter, _ = get_const_tuple(Filter_q.shape)
     else:
         Filter_q = kernel
-        kernel_h, kernel_w, _, _, num_filter = get_const_tuple(Filter_q.shape)
+        
+    kernel_h, kernel_w, _, num_filter, _ = get_const_tuple(Filter_q.shape)
     batch, in_height, in_width, in_channel_q, _ = get_const_tuple(Input_q.shape)
 
     if isinstance(padding, int) or (isinstance(padding, (tuple, list)) and len(padding) == 2):

--- a/topi/python/topi/nn/bitserial_util.py
+++ b/topi/python/topi/nn/bitserial_util.py
@@ -21,7 +21,7 @@ import tvm
 from topi.transform import concatenate
 from ..util import get_const_int
 
-def bitpack(data, bits, pack_axis, bit_axis, pack_type, name="QuantizeInput"):
+def bitpack(data, bits, pack_axis, bit_axis, pack_type='uint32', name="QuantizeInput"):
     """Packs data into format necessary for bitserial computation
     pack_axis : int
        index of the axis to pack in data
@@ -88,4 +88,4 @@ def binary_op_multiplier(pack_dtype):
     pack_dtype: string
         pack type for the operator (must be a uint)"""
     return int(pack_dtype[4:])
-    
+

--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import as _abs
 
 from .conv2d import schedule_conv2d, schedule_conv2d_nhwc
 from .binarize_pack import schedule_binarize_pack
+from .bitpack import schedule_bitpack
 from .binary_dense import schedule_binary_dense
 from .nn import *
 from .injective import *

--- a/topi/python/topi/x86/bitpack.py
+++ b/topi/python/topi/x86/bitpack.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Schedule for binarization and bit-packing."""
+from __future__ import absolute_import as _abs
+import tvm
+from .. import generic
+
+
+@generic.schedule_bitpack.register(["cpu"])
+def schedule_bitpack(outs):
+    """Schedule for bitpack.
+
+    Parameters
+    ----------
+    outs: Array of Tensor
+        The computation graph description of bitpack 
+        in the format of an array of tensors.
+
+    Returns
+    -------
+    s: Schedule
+        The computation schedule for bitpack.
+    """
+    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
+    s = tvm.create_schedule([x.op for x in outs])
+
+    def _schedule(Out):
+        s[Out].parallel(Out.op.axis[0])
+
+    def traverse(OP):
+        # schedule bitpack
+        if OP.tag == 'bitpack':
+            Out = OP.output(0)
+            _schedule(Out)
+
+    traverse(outs[0].op)
+    return s

--- a/topi/python/topi/x86/bitserial_conv2d.py
+++ b/topi/python/topi/x86/bitserial_conv2d.py
@@ -157,14 +157,6 @@ def _schedule_bitserial_conv2d_nchw(cfg, s, data_q, data_pad, data_vec,
     s[conv_out].compute_at(s[last], ow)
 
     oco, ico = cfg["tile_oh"].apply(s, last, co)
-    if cfg["tile_oh"].size[1] == 1:
-        oaxis = oco
-        paxis = oco
-    else:
-        oco, ico = s[last].split(co, bc)
-        oaxis = oco
-        paxis = ico
-
     s[last].parallel(oco)
     return s
 

--- a/topi/python/topi/x86/bitserial_conv2d.py
+++ b/topi/python/topi/x86/bitserial_conv2d.py
@@ -35,8 +35,8 @@ def schedule_bitserial_conv2d(cfg, outs):
         if tag.is_broadcast(op.tag) or 'elemwise' in op.tag:
             if op not in s.outputs:
                 s[op].compute_inline()
-            for tensor in op.input_tensors and tensor.op not in scheduled_ops:
-                if tensor.op.input_tensors:
+            for tensor in op.input_tensors:
+                if tensor.op.input_tensors and tensor.op not in scheduled_ops:
                     traverse(tensor.op)
 
         elif 'spatial_bitserial_conv_nchw' in op.tag or 'spatial_bitserial_conv_nhwc' in op.tag:


### PR DESCRIPTION
This PR introduces full relay support for the bitserial conv2d, dense, and bitpack operators. Although the current commits allow a relay function to be composed, built, and run, I suspect there are still a few missing features. For example, using relay.create_executor instead of relay.build causes the error
```
TVMError: Check failed: checked_type.as<IncompleteTypeNode>() == nullptr: Cannot resolve type of Var(w) at (nullptr)
```
This makes it difficult to write tests in a way consistent with other relay operators. I'd appreciate feedback on what's missing so that I can fix this issue and add the proper tests.