### PR TITLE
[VTA] Runtime refactor to allow for non-shared memory FPGAs (e.g. F1)

### DIFF
--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -118,32 +118,21 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf);
  * \param dst The desination buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
  * \param src The source buffer in host memory.
  * \param size Size of the region in Bytes.
+ * \param flush When the memory is shared between the FPGA and host, trigger cache flush
+ *              before the transer to make the data visible to the FPGA.
  */
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size);
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush);
 
 /*!
  * \brief Performs a copy operation from buffer allocated with VTAMemAlloc to host memory.
  * \param dst The destination buffer in host memory.
  * \param src The source buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
  * \param size Size of the region in Bytes.
+ * \param invalidate When the memory is shared between the FPGA and host, trigger cache invalidation
+ *                   after the transfer to make the data visible to the host.
  */
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size);
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate);
 
-/*!
- * \brief Flushes the region of memory out of the CPU cache to DRAM.
- * \param buf Pointer to memory region allocated with VTAMemAlloc to be flushed.
- *            This need to be the physical address.
- * \param size Size of the region to flush in Bytes.
- */
-void VTAFlushCache(vta_phy_addr_t buf, int size);
-
-/*!
- * \brief Invalidates the region of memory that is cached.
- * \param buf Pointer to memory region allocated with VTAMemAlloc to be invalidated.
- *            This need to be the physical address.
- * \param size Size of the region to invalidate in Bytes.
- */
-void VTAInvalidateCache(vta_phy_addr_t buf, int size);
 
 #ifdef __cplusplus
 }

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -120,7 +120,7 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf);
 
 /*!
  * \brief Performs a copy operation from host memory to buffer allocated with VTAMemAlloc.
- * \param dst The desination buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
+ * \param dst The desination buffer in FPGA-accessible memory. Has to be allocated with VTAMemAlloc.
  * \param src The source buffer in host memory.
  * \param size Size of the region in Bytes.
  */
@@ -129,7 +129,7 @@ void VTAMemCopyFromHost(void* dst, const void* src, size_t size);
 /*!
  * \brief Performs a copy operation from buffer allocated with VTAMemAlloc to host memory.
  * \param dst The destination buffer in host memory.
- * \param src The source buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
+ * \param src The source buffer in FPGA-accessible memory. Has to be allocated with VTAMemAlloc.
  * \param size Size of the region in Bytes.
  */
 void VTAMemCopyToHost(void* dst, const void* src, size_t size);

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -124,7 +124,7 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf);
  * \param src The source buffer in host memory.
  * \param size Size of the region in Bytes.
  */
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size);
+void VTAMemCopyFromHost(void* dst, const void* src, size_t size);
 
 /*!
  * \brief Performs a copy operation from buffer allocated with VTAMemAlloc to host memory.
@@ -132,7 +132,7 @@ void VTAMemMoveToBuffer(void* dst, const void* src, size_t size);
  * \param src The source buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
  * \param size Size of the region in Bytes.
  */
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size);
+void VTAMemCopyToHost(void* dst, const void* src, size_t size);
 
 /*!
  * \brief Flushes the region of memory out of the CPU cache to DRAM.

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -40,6 +40,11 @@ extern "C" {
 /*! \brief Memory management constants for non-cached memory */
 #define VTA_NOT_CACHED 0
 
+/*! \brief Physically contiguous buffer size limit */
+#ifndef VTA_MAX_XFER
+#define VTA_MAX_XFER (1<<25)
+#endif
+
 /*! PAGE SIZE */
 #define VTA_PAGE_BITS 12
 #define VTA_PAGE_BYTES (1 << VTA_PAGE_BITS)

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -40,11 +40,6 @@ extern "C" {
 /*! \brief Memory management constants for non-cached memory */
 #define VTA_NOT_CACHED 0
 
-/*! \brief Physically contiguous buffer size limit */
-#ifndef VTA_MAX_XFER
-#define VTA_MAX_XFER (1<<25)
-#endif
-
 /*! PAGE SIZE */
 #define VTA_PAGE_BITS 12
 #define VTA_PAGE_BYTES (1 << VTA_PAGE_BITS)
@@ -98,7 +93,7 @@ int VTADeviceRun(VTADeviceHandle device,
 #endif
 
 /*!
- * \brief Allocates physically contiguous region in memory (limited by MAX_XFER).
+ * \brief Allocates physically contiguous region in memory readable/writeable by FPGA.
  * \param size Size of the region in Bytes.
  * \param cached Region can be set to not cached (write-back) if set to 0.
  * \return A pointer to the allocated region.
@@ -106,7 +101,7 @@ int VTADeviceRun(VTADeviceHandle device,
 void* VTAMemAlloc(size_t size, int cached);
 
 /*!
- * \brief Frees a physically contiguous region in memory.
+ * \brief Frees a physically contiguous region in memory readable/writeable by FPGA.
  * \param buf Buffer to free.
  */
 void VTAMemFree(void* buf);
@@ -117,6 +112,22 @@ void VTAMemFree(void* buf);
  * \return The physical address of the memory region.
  */
 vta_phy_addr_t VTAMemGetPhyAddr(void* buf);
+
+/*!
+ * \brief Performs a copy operation from host memory to buffer allocated with VTAMemAlloc.
+ * \param dst The desination buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
+ * \param src The source buffer in host memory.
+ * \param size Size of the region in Bytes.
+ */
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size);
+
+/*!
+ * \brief Performs a copy operation from buffer allocated with VTAMemAlloc to host memory.
+ * \param dst The destination buffer in host memory.
+ * \param src The source buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
+ * \param size Size of the region in Bytes.
+ */
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size);
 
 /*!
  * \brief Flushes the region of memory out of the CPU cache to DRAM.

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -150,7 +150,6 @@ void VTAFlushCache(vta_phy_addr_t buf, int size);
  */
 void VTAInvalidateCache(vta_phy_addr_t buf, int size);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -123,20 +123,32 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf);
  * \param dst The desination buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
  * \param src The source buffer in host memory.
  * \param size Size of the region in Bytes.
- * \param flush When the memory is shared between the FPGA and host, trigger cache flush
- *              before the transer to make the data visible to the FPGA.
  */
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush);
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size);
 
 /*!
  * \brief Performs a copy operation from buffer allocated with VTAMemAlloc to host memory.
  * \param dst The destination buffer in host memory.
  * \param src The source buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
  * \param size Size of the region in Bytes.
- * \param invalidate When the memory is shared between the FPGA and host, trigger cache invalidation
- *                   after the transfer to make the data visible to the host.
  */
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate);
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size);
+
+/*!
+ * \brief Flushes the region of memory out of the CPU cache to DRAM.
+ * \param buf Pointer to memory region allocated with VTAMemAlloc to be flushed.
+ *            This need to be the physical address.
+ * \param size Size of the region to flush in Bytes.
+ */
+void VTAFlushCache(vta_phy_addr_t buf, int size);
+
+/*!
+ * \brief Invalidates the region of memory that is cached.
+ * \param buf Pointer to memory region allocated with VTAMemAlloc to be invalidated.
+ *            This need to be the physical address.
+ * \param size Size of the region to invalidate in Bytes.
+ */
+void VTAInvalidateCache(vta_phy_addr_t buf, int size);
 
 
 #ifdef __cplusplus

--- a/vta/include/vta/runtime.h
+++ b/vta/include/vta/runtime.h
@@ -93,33 +93,6 @@ TVM_DLL VTACommandHandle VTATLSCommandHandle();
 TVM_DLL void* VTABufferCPUPtr(VTACommandHandle cmd, void* buffer);
 
 /*!
- * \brief Perform a write barrier to make a memory region visible to the CPU.
- * \param cmd The VTA command handle.
- * \param buffer The head buffer pointer.
- * \param elem_bits The size in bits of each element.
- * \param start The start of the region (in elements).
- * \param extent The end of the region (in elements).
- */
-TVM_DLL void VTAWriteBarrier(VTACommandHandle cmd,
-                             void* buffer,
-                             uint32_t elem_bits,
-                             uint32_t start,
-                             uint32_t extent);
-/*!
- * \brief Perform a read barrier to a memory region visible to VTA.
- * \param cmd The VTA command handle.
- * \param buffer The head buffer pointer.
- * \param elem_bits The unit bits of each elements.
- * \param start The start of the region (in elements).
- * \param extent The end of the region (in elements).
- */
-TVM_DLL void VTAReadBarrier(VTACommandHandle cmd,
-                            void* buffer,
-                            uint32_t elem_bits,
-                            uint32_t start,
-                            uint32_t extent);
-
-/*!
  * \brief Set debug mode on the command handle.
  * \param cmd The VTA command handle.
  * \param debug_flag The debug flag.

--- a/vta/include/vta/runtime.h
+++ b/vta/include/vta/runtime.h
@@ -92,7 +92,7 @@ TVM_DLL VTACommandHandle VTATLSCommandHandle();
  */
 TVM_DLL void* VTABufferCPUPtr(VTACommandHandle cmd, void* buffer);
 
- /*!
+/*!
  * \brief Perform a write barrier to make a memory region visible to the CPU.
  * \param cmd The VTA command handle.
  * \param buffer The head buffer pointer.

--- a/vta/include/vta/runtime.h
+++ b/vta/include/vta/runtime.h
@@ -92,6 +92,34 @@ TVM_DLL VTACommandHandle VTATLSCommandHandle();
  */
 TVM_DLL void* VTABufferCPUPtr(VTACommandHandle cmd, void* buffer);
 
+ /*!
+ * \brief Perform a write barrier to make a memory region visible to the CPU.
+ * \param cmd The VTA command handle.
+ * \param buffer The head buffer pointer.
+ * \param elem_bits The size in bits of each element.
+ * \param start The start of the region (in elements).
+ * \param extent The end of the region (in elements).
+ */
+TVM_DLL void VTAWriteBarrier(VTACommandHandle cmd,
+                             void* buffer,
+                             uint32_t elem_bits,
+                             uint32_t start,
+                             uint32_t extent);
+
+/*!
+ * \brief Perform a read barrier to a memory region visible to VTA.
+ * \param cmd The VTA command handle.
+ * \param buffer The head buffer pointer.
+ * \param elem_bits The unit bits of each elements.
+ * \param start The start of the region (in elements).
+ * \param extent The end of the region (in elements).
+ */
+TVM_DLL void VTAReadBarrier(VTACommandHandle cmd,
+                            void* buffer,
+                            uint32_t elem_bits,
+                            uint32_t start,
+                            uint32_t extent);
+
 /*!
  * \brief Set debug mode on the command handle.
  * \param cmd The VTA command handle.

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -43,7 +43,7 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return cma_get_phy_addr(buf);
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -60,7 +60,7 @@ void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalida
   // If flush is specified, call the xlnkInvalidateCache on the CMA buffer
   // so that the host needs to read the buffer data.
   if (invalidate) {
-    vta_phy_addr_t phy = VTAMemGetPhyAddr(src);
+    vta_phy_addr_t phy = VTAMemGetPhyAddr(const_cast<void*>(src));
     xlnkInvalidateCache(reinterpret_cast<void*>(phy), size);
   }
 }

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -44,25 +44,25 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
 }
 
 void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
-  // If flush is specified, call the xlnkFlushCache on the CMA buffer
-  // so that the FPGA can read the buffer data.
-  if (flush) {
-    vta_phy_addr_t phy = VTAMemGetPhyAddr(dst);
-    xlnkFlushCache(reinterpret_cast<void*>(phy), size);
-  }
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate) {
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
-  // If flush is specified, call the xlnkInvalidateCache on the CMA buffer
+}
+
+void VTAFlushCache(vta_phy_addr_t buf, int size) {
+  // Call the xlnkFlushCache on the CMA buffer
+  // so that the FPGA can read the buffer data.
+  xlnkFlushCache(reinterpret_cast<void*>(buf), size);
+}
+
+void VTAInvalidateCache(vta_phy_addr_t buf, int size) {
+  // Call the xlnkInvalidateCache on the CMA buffer
   // so that the host needs to read the buffer data.
-  if (invalidate) {
-    vta_phy_addr_t phy = VTAMemGetPhyAddr(const_cast<void*>(src));
-    xlnkInvalidateCache(reinterpret_cast<void*>(phy), size);
-  }
+  xlnkInvalidateCache(reinterpret_cast<void*>(buf), size);
 }
 
 void *VTAMapRegister(uint32_t addr, size_t length) {

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -29,7 +29,7 @@
 
 
 void* VTAMemAlloc(size_t size, int cached) {
-  assert(size < VTA_MAX_XFER);
+  assert(size <= VTA_MAX_XFER);
   // Rely on the pynq-specific cma library
   return cma_alloc(size, cached);
 }

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -43,12 +43,12 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return cma_get_phy_addr(buf);
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
+void VTAMemCopyFromHost(void* dst, const void* src, size_t size) {
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
+void VTAMemCopyToHost(void* dst, const void* src, size_t size) {
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -29,15 +29,28 @@
 
 
 void* VTAMemAlloc(size_t size, int cached) {
+  assert(size < VTA_PYNQ_MAX_XFER);
+  // Rely on the pynq-specific cma library
   return cma_alloc(size, cached);
 }
 
 void VTAMemFree(void* buf) {
+  // Rely on the pynq-specific cma library
   cma_free(buf);
 }
 
 vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return cma_get_phy_addr(buf);
+}
+
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
+  // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
+  memcpy(dst, src, size);
+}
+
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
+  // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
+  memcpy(dst, src, size);
 }
 
 void VTAFlushCache(vta_phy_addr_t buf, int size) {
@@ -54,7 +67,7 @@ void *VTAMapRegister(uint32_t addr, size_t length) {
   // Calculate base address offset w.r.t the base address
   uint32_t virt_offset = addr - virt_base;
   // Open file and mmap
-  uint32_t mmap_file = open(VTA_PYNQ_DEV_MEM_PATH, O_RDWR|O_SYNC);
+  uint32_t mmap_file = open("/dev/mem", O_RDWR|O_SYNC);
   return mmap(NULL,
               (length+virt_offset),
               PROT_READ|PROT_WRITE,

--- a/vta/src/pynq/pynq_driver.cc
+++ b/vta/src/pynq/pynq_driver.cc
@@ -29,7 +29,7 @@
 
 
 void* VTAMemAlloc(size_t size, int cached) {
-  assert(size < VTA_PYNQ_MAX_XFER);
+  assert(size < VTA_MAX_XFER);
   // Rely on the pynq-specific cma library
   return cma_alloc(size, cached);
 }

--- a/vta/src/pynq/pynq_driver.h
+++ b/vta/src/pynq/pynq_driver.h
@@ -26,6 +26,11 @@
 #ifndef VTA_PYNQ_PYNQ_DRIVER_H_
 #define VTA_PYNQ_PYNQ_DRIVER_H_
 
+/*! \brief Physically contiguous buffer size limit */
+#ifndef PYNQ_MAX_XFER
+#define PYNQ_MAX_XFER (1<<25)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -56,11 +61,14 @@ void VTAUnmapRegister(void *vta, size_t length);
 void VTAWriteMappedReg(void* base_addr, uint32_t offset, uint32_t val);
 uint32_t VTAReadMappedReg(void* base_addr, uint32_t offset);
 
-/*! \brief (Pynq only) Path to /dev/mem */
-#define VTA_PYNQ_DEV_MEM_PATH "/dev/mem"
-/*! \brief (Pynq only) MMIO driver constant */
+/*! \brief DMA TRANSFER SIZE LIMIT (may be platform-specific) */
+#ifndef VTA_PYNQ_MAX_XFER
+#define VTA_PYNQ_MAX_XFER (1<<25)
+#endif
+
+/*! \brief MMIO driver constant */
 #define VTA_PYNQ_MMIO_WORD_LENGTH 4
-/*! \brief (Pynq only) MMIO driver constant */
+/*! \brief MMIO driver constant */
 #define VTA_PYNQ_MMIO_WORD_MASK (~(MMIO_WORD_LENGTH - 1))
 
 /*! \brief VTA configuration register address range */

--- a/vta/src/pynq/pynq_driver.h
+++ b/vta/src/pynq/pynq_driver.h
@@ -26,11 +26,6 @@
 #ifndef VTA_PYNQ_PYNQ_DRIVER_H_
 #define VTA_PYNQ_PYNQ_DRIVER_H_
 
-/*! \brief Physically contiguous buffer size limit */
-#ifndef PYNQ_MAX_XFER
-#define PYNQ_MAX_XFER (1<<25)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,11 +55,6 @@ void *VTAMapRegister(uint32_t addr, size_t length);
 void VTAUnmapRegister(void *vta, size_t length);
 void VTAWriteMappedReg(void* base_addr, uint32_t offset, uint32_t val);
 uint32_t VTAReadMappedReg(void* base_addr, uint32_t offset);
-
-/*! \brief DMA TRANSFER SIZE LIMIT (may be platform-specific) */
-#ifndef VTA_PYNQ_MAX_XFER
-#define VTA_PYNQ_MAX_XFER (1<<25)
-#endif
 
 /*! \brief MMIO driver constant */
 #define VTA_PYNQ_MMIO_WORD_LENGTH 4

--- a/vta/src/pynq/pynq_driver.h
+++ b/vta/src/pynq/pynq_driver.h
@@ -56,11 +56,6 @@ void VTAUnmapRegister(void *vta, size_t length);
 void VTAWriteMappedReg(void* base_addr, uint32_t offset, uint32_t val);
 uint32_t VTAReadMappedReg(void* base_addr, uint32_t offset);
 
-/*! \brief MMIO driver constant */
-#define VTA_PYNQ_MMIO_WORD_LENGTH 4
-/*! \brief MMIO driver constant */
-#define VTA_PYNQ_MMIO_WORD_MASK (~(MMIO_WORD_LENGTH - 1))
-
 /*! \brief VTA configuration register address range */
 #define VTA_RANGE 0x100
 /*! \brief VTA configuration register start value */

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -37,7 +37,6 @@
 #include <thread>
 #include <memory>
 #include <atomic>
-#include <map>
 
 namespace vta {
 
@@ -299,7 +298,9 @@ template <class T>
 class BaseQueue {
  public:
   ~BaseQueue() {
-    VTAMemFree(fpga_buff_);
+    if (fpga_buff_ != nullptr){
+      VTAMemFree(fpga_buff_);
+    }
   }
   /*! \return Content of DRAM buffer. */
   char* dram_buffer() const {

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -415,7 +415,7 @@ class UopQueue : public BaseQueue<VTAUop> {
 #ifdef USE_TSIM
       insn->dram_base = fpga_buff_phy_ + offset;
 #else
-      insn->dram_base = (fpga_buff_phy_ + offset) / kElemBytes ;
+      insn->dram_base = (fpga_buff_phy_ + offset) / kElemBytes;
 #endif
       insn->y_size = 1;
       insn->x_size = (sram_end_ - sram_begin_);
@@ -1319,7 +1319,6 @@ void VTABufferCopy(const void* from,
                                  static_cast<const char*>(from) + from_offset,
                                  size);
   }
-
 }
 
 VTACommandHandle VTATLSCommandHandle() {

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -437,7 +437,7 @@ class UopQueue : public BaseQueue<VTAUop> {
     CHECK(fpga_buff_phy_);
     // Iterate over caches; allocate buffer in FPGA-readable memory
     uint32_t buff_size = 0;
-    for (int i = 0; i < cache_.size(); ++i) {
+    for (uint32_t i = 0; i < cache_.size(); ++i) {
       buff_size += cache_[i]->size() * kElemBytes;
     }
     CHECK(buff_size <= kMaxBytes);

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -406,7 +406,7 @@ class UopQueue : public BaseQueue<VTAUop> {
     if (sram_begin_ != sram_end_) {
       // Derive offset in FPGA-readable buffer
       int32_t offset = 0;
-      for (int i = 0; i < cache_idx_ - 1; ++i) {
+      for (uint32_t i = 0; i < cache_idx_ - 1; ++i) {
         offset += cache_[i]->size() * kElemBytes;
       }
       insn->memory_type = VTA_MEM_ID_UOP;

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -958,7 +958,7 @@ class CommandQueue {
     }
     /*
      * elements size should not larger than VTA_PAGE_BYTES.
-     * 
+     *
      */
     CHECK_GE(VTA_PAGE_BYTES, elem_bytes);
     return elem_bytes;

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -81,7 +81,7 @@ struct DataBuffer {
   }
   /*!
    * \brief Performs a copy operation from host memory to buffer allocated with VTAMemAlloc.
-   * \param dst The desination buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
+   * \param dst The desination buffer in FPGA-accessible memory. Has to be allocated with VTAMemAlloc().
    * \param src The source buffer in host memory.
    * \param size Size of the region in Bytes.
    */
@@ -89,9 +89,9 @@ struct DataBuffer {
     VTAMemCopyFromHost(dst, src, size);
   }
   /*!
-   * \brief Performs a copy operation from host memory to buffer allocated with VTAMemAlloc.
-   * \param dst The desination buffer in FPGA-readable memory. Has to be allocated with VTAMemAlloc().
-   * \param src The source buffer in host memory.
+   * \brief Performs a copy operation from buffer allocated with VTAMemAlloc to host memory.
+   * \param dst The desination buffer in host memory.
+   * \param src The source buffer in FPGA-accessible memory. Has to be allocated with VTAMemAlloc().
    * \param size Size of the region in Bytes.
    */
   void MemCopyToHost(void* dst, const void* src, size_t size) {

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -442,8 +442,8 @@ class UopQueue : public BaseQueue<VTAUop> {
     }
     CHECK(buff_size <= kMaxBytes);
     // Move kernel contents to FPGA readable buffer
-    int32_t offset = 0;
-    for (int32_t i = 0; i < cache_.size(); ++i) {
+    uint32_t offset = 0;
+    for (uint32_t i = 0; i < cache_.size(); ++i) {
       uint32_t ksize = cache_[i]->size() * kElemBytes;
       VTAMemMoveToBuffer(static_cast<char*>(fpga_buff_) + offset,
                          cache_[i]->data(),

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -299,9 +299,7 @@ template <class T>
 class BaseQueue {
  public:
   ~BaseQueue() {
-    if (fpga_buff_) {
-      VTAMemFree(fpga_buff_);
-    }
+    VTAMemFree(fpga_buff_);
   }
   /*! \return Content of DRAM buffer. */
   char* dram_buffer() const {
@@ -333,7 +331,6 @@ class BaseQueue {
    */
   void Reset() {
     dram_buffer_.clear();
-    VTAMemFree(fpga_buff_);
     sram_begin_ = sram_end_;
   }
 

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -298,7 +298,7 @@ template <class T>
 class BaseQueue {
  public:
   ~BaseQueue() {
-    if (fpga_buff_ != nullptr){
+    if (fpga_buff_ != nullptr) {
       VTAMemFree(fpga_buff_);
     }
   }

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -443,7 +443,7 @@ class UopQueue : public BaseQueue<VTAUop> {
     CHECK(buff_size <= kMaxBytes);
     // Move kernel contents to FPGA readable buffer
     int32_t offset = 0;
-    for (int i = 0; i < cache_.size(); ++i) {
+    for (int32_t i = 0; i < cache_.size(); ++i) {
       uint32_t ksize = cache_[i]->size() * kElemBytes;
       VTAMemMoveToBuffer(static_cast<char*>(fpga_buff_) + offset,
                          cache_[i]->data(),

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -1016,7 +1016,6 @@ class CommandQueue {
     insn->y_pad_1 = y_pad_after;
     insn->x_pad_0 = x_pad_before;
     insn->x_pad_1 = x_pad_after;
-    // this->CheckInsnOverFlow();
   }
 
   void StoreBuffer2D(uint32_t src_sram_index,
@@ -1043,7 +1042,6 @@ class CommandQueue {
     insn->y_pad_1 = 0;
     insn->x_pad_0 = 0;
     insn->x_pad_1 = 0;
-    // this->CheckInsnOverFlow();
   }
 
   void DepPush(int from_qid, int to_qid) {
@@ -1139,7 +1137,6 @@ class CommandQueue {
       record_kernel_ = nullptr;
     }
     this->PushGEMMOp(static_cast<UopKernel*>(kptr[0]));
-    // this->CheckInsnOverFlow();
   }
 
   void PushALUUop(void** uop_handle,
@@ -1161,7 +1158,6 @@ class CommandQueue {
       record_kernel_ = nullptr;
     }
     this->PushALUUop(static_cast<UopKernel*>(kptr[0]));
-    // this->CheckInsnOverFlow();
   }
 
   static std::shared_ptr<CommandQueue>& ThreadLocal() {
@@ -1271,13 +1267,6 @@ class CommandQueue {
     }
   }
 
-  // void CheckInsnOverFlow() {
-  //   // At each API call, we can at most commit:
-  //   // one pending store, one pending load, and one uop
-  //   if ((insn_queue_.count() + 4) * sizeof(VTAGenericInsn) >= VTA_MAX_XFER) {
-  //     this->AutoSync();
-  //   }
-  // }
   // Auto sync when instruction overflow
   void AutoSync() {
     this->Synchronize(1 << 31);

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -292,7 +292,7 @@ class UopKernel {
   template<int, bool, bool>
   friend class UopQueue;
   friend class CommandQueue;
-  // SRAM location if begin != end.
+  // SRAM location if begin != end
   uint32_t sram_begin_{0};
   uint32_t sram_end_{0};
   // The signature used for verification

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -330,10 +330,6 @@ class BaseQueue {
     dram_buffer_.clear();
     sram_begin_ = sram_end_;
   }
-  void AutoReadBarrier() {
-    ReadBarrier();
-  }
-  virtual void ReadBarrier();
 
  protected:
   // Cache coherence access (shared memory only)
@@ -415,6 +411,9 @@ class UopQueue : public BaseQueue<VTAUop> {
       // Reset indices
       sram_begin_ = sram_end_;
     }
+  }
+  void AutoReadBarrier() {
+    ReadBarrier();
   }
   /*! \brief Writer barrier to make sure that data written by CPU is visible to VTA. */
   void ReadBarrier() {
@@ -843,6 +842,9 @@ class InsnQueue : public BaseQueue<VTAGenericInsn> {
       if (pending_pop_next_[i]) return true;
     }
     return false;
+  }
+  void AutoReadBarrier() {
+    ReadBarrier();
   }
   /*! \brief Writer barrier to make sure that data written by CPU is visible to VTA. */
   void ReadBarrier() {

--- a/vta/src/sim/sim_driver.cc
+++ b/vta/src/sim/sim_driver.cc
@@ -607,20 +607,14 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return vta::sim::DRAM::Global()->GetPhyAddr(buf);
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate) {
   // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
-}
-
-void VTAFlushCache(vta_phy_addr_t buf, int size) {
-}
-
-void VTAInvalidateCache(vta_phy_addr_t buf, int size) {
 }
 
 VTADeviceHandle VTADeviceAlloc() {

--- a/vta/src/sim/sim_driver.cc
+++ b/vta/src/sim/sim_driver.cc
@@ -607,12 +607,18 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return vta::sim::DRAM::Global()->GetPhyAddr(buf);
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate) {
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
+}
+
+void VTAFlushCache(vta_phy_addr_t buf, int size) {
+}
+
+void VTAInvalidateCache(vta_phy_addr_t buf, int size) {
 }
 
 VTADeviceHandle VTADeviceAlloc() {

--- a/vta/src/sim/sim_driver.cc
+++ b/vta/src/sim/sim_driver.cc
@@ -608,12 +608,10 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
 }
 
 void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
-  // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }
 
 void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate) {
-  // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
   memcpy(dst, src, size);
 }
 

--- a/vta/src/sim/sim_driver.cc
+++ b/vta/src/sim/sim_driver.cc
@@ -607,6 +607,16 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return vta::sim::DRAM::Global()->GetPhyAddr(buf);
 }
 
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
+  // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
+  memcpy(dst, src, size);
+}
+
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
+  // For SoC-based FPGAs that used shared memory with the CPU, use memcopy()
+  memcpy(dst, src, size);
+}
+
 void VTAFlushCache(vta_phy_addr_t buf, int size) {
 }
 

--- a/vta/src/sim/sim_driver.cc
+++ b/vta/src/sim/sim_driver.cc
@@ -607,11 +607,11 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return vta::sim::DRAM::Global()->GetPhyAddr(buf);
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
+void VTAMemCopyFromHost(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
+void VTAMemCopyToHost(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
 }
 

--- a/vta/src/tsim/tsim_driver.cc
+++ b/vta/src/tsim/tsim_driver.cc
@@ -220,11 +220,11 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return reinterpret_cast<uint64_t>(reinterpret_cast<uint64_t*>(buf));
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
+void VTAMemCopyFromHost(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
+void VTAMemCopyToHost(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
 }
 

--- a/vta/src/tsim/tsim_driver.cc
+++ b/vta/src/tsim/tsim_driver.cc
@@ -220,12 +220,18 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return reinterpret_cast<uint64_t>(reinterpret_cast<uint64_t*>(buf));
 }
 
-void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
 }
 
-void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate) {
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size) {
   memcpy(dst, src, size);
+}
+
+void VTAFlushCache(vta_phy_addr_t buf, int size) {
+}
+
+void VTAInvalidateCache(vta_phy_addr_t buf, int size) {
 }
 
 VTADeviceHandle VTADeviceAlloc() {

--- a/vta/src/tsim/tsim_driver.cc
+++ b/vta/src/tsim/tsim_driver.cc
@@ -220,10 +220,12 @@ vta_phy_addr_t VTAMemGetPhyAddr(void* buf) {
   return reinterpret_cast<uint64_t>(reinterpret_cast<uint64_t*>(buf));
 }
 
-void VTAFlushCache(vta_phy_addr_t buf, int size) {
+void VTAMemMoveToBuffer(void* dst, const void* src, size_t size, bool flush) {
+  memcpy(dst, src, size);
 }
 
-void VTAInvalidateCache(vta_phy_addr_t buf, int size) {
+void VTAMemMoveFromBuffer(void* dst, const void* src, size_t size, bool invalidate) {
+  memcpy(dst, src, size);
 }
 
 VTADeviceHandle VTADeviceAlloc() {


### PR DESCRIPTION
This runtime refactor will make it easier to support FPGAs that do not rely on shared memory with the host (most PCI-E based FPGA systems).

The idea is to allocate instruction and micro op buffers right before invoking the VTA accelerator: this will let us allocate and transfer the buffers from main memory to an "FPGA-readable" buffer. For the Pynq FPGA, that can be a buffer that was allocated using `cma_alloc()` to obtain a physically contiguous buffer in memory; or for an F1 FPGA, that means allocating a buffer in the FPGA DRAM that the FPGA can access.

In terms of micro-op the challenge is that the earlier runtime would copy the kernels as they get JITed to the FPGA-readable buffer. Here we wait until we synchronize with VTA to do that: we size the FPGA buffer to be just-the-right width based on the kernel that we have to ship; then we copy them over one by one. In addition, we need to keep track of the physical addresses of these kernels now that they are in FPGA-readable memory. This means that we have to retroactively modify the DRAM source address in the `load_uop` instructions in the instruction stream since those are added to the stream as kernels are JITted.