### PR TITLE
[JS]fix js test load module example

### DIFF
--- a/tests/web/prepare_test_libs.py
+++ b/tests/web/prepare_test_libs.py
@@ -30,7 +30,9 @@ def prepare_test_libs(base_path):
     fadd1 = tvm.build(s, [A, B], target, name="add_one")
     obj_path = os.path.join(base_path, "test_add_one.bc")
     fadd1.save(obj_path)
-    emscripten.create_js(os.path.join(base_path, "test_module.js"), obj_path)
+    emscripten.create_js(os.path.join(base_path, "test_module.js"), obj_path,
+                         options=["-s", "WASM=0", "-s", "USE_GLFW=3", "-s",
+                                  "USE_WEBGL2=1", "-lglfw"])
 
 if __name__ == "__main__":
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))

--- a/tests/web/test_module_load.js
+++ b/tests/web/test_module_load.js
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,15 +37,18 @@ function randomArray(length, max) {
 function testAddOne() {
   // grab pre-loaded function
   var faddOne = sysLib.getFunction("add_one");
+  var assert = require('assert');
   tvm.assert(tvm.isPackedFunc(faddOne));
   var n = 124;
   var A = tvm.empty(n).copyFrom(randomArray(n, 1));
   var B = tvm.empty(n);
   // call the function.
   faddOne(A, B);
+  AA = A.asArray();  // retrieve values in js array
+  BB = B.asArray();  // retrieve values in js array
   // verify
-  for (var i = 0; i < B.length; ++i) {
-    tvm.assert(B[i] == A[i] + 1);
+  for (var i = 0; i < BB.length; ++i) {
+    assert(Math.abs(BB[i] - (AA[i] + 1)) < 1e-5);
   }
   faddOne.release();
 }

--- a/web/README.md
+++ b/web/README.md
@@ -120,13 +120,13 @@ how to run the compiled library.
 ```js
 // Load Emscripten Module, need to change path to root/build
 const path = require("path");
-process.chdir(path.join(__dirname, "../../buld"));
+process.chdir(path.join(__dirname, "../../build"));
 var Module = require("../../build/test_module.js");
 // Bootstrap TVMruntime with emscripten module.
 const tvm_runtime = require("../../web/tvm_runtime.js");
 const tvm = tvm_runtime.create(Module);
 
-// Load system library, the compiled functions is registered in sysLib.
+// Load system library, the compiled function is registered in sysLib.
 var sysLib = tvm.systemLib();
 
 function randomArray(length, max) {
@@ -138,22 +138,25 @@ function randomArray(length, max) {
 function testAddOne() {
   // grab pre-loaded function
   var faddOne = sysLib.getFunction("add_one");
+  var assert = require('assert');
   tvm.assert(tvm.isPackedFunc(faddOne));
   var n = 124;
   var A = tvm.empty(n).copyFrom(randomArray(n, 1));
   var B = tvm.empty(n);
   // call the function.
   faddOne(A, B);
+  AA = A.asArray();  // retrieve values in js array
+  BB = B.asArray();  // retrieve values in js array
   // verify
-  for (var i = 0; i < B.length; ++i) {
-    tvm.assert(B[i] == A[i] + 1);
+  for (var i = 0; i < BB.length; ++i) {
+    assert(Math.abs(BB[i] - (AA[i] + 1)) < 1e-5);
   }
   faddOne.release();
 }
 
 testAddOne();
 sysLib.release();
-
+console.log("Finish verifying test_module_load");
 ```
 
 Current example supports static linking, which is the preferred way to get more efficiency


### PR DESCRIPTION


Fix the js example which isn't working at all.
JS tvm.ndarray.length is undefined, indexing like A[i] with tvm.ndarray is not defined as well.
So the block

```js
for (var i = 0; i < B.length; ++i) {
    tvm.assert(B[i] == A[i] + 1);
}
```
was not entered at all.

Also fixing an error when the script is trying to generate js library where options are not properly set.