### PR TITLE
[Relay] fix exponential blowup in interpreter

### DIFF
--- a/include/tvm/relay/feature.h
+++ b/include/tvm/relay/feature.h
@@ -81,13 +81,13 @@ class FeatureSet {
     return ret;
   }
   /*! \brief A set that contain all the Feature. */
-  static FeatureSet AllFeature() {
+  static FeatureSet All() {
     FeatureSet fs;
     fs.bs_.flip();
     return fs;
   }
   /*! \brief The empty set. Contain no Feature. */
-  static FeatureSet NoFeature() {
+  static FeatureSet No() {
     FeatureSet fs;
     return fs;
   }

--- a/python/tvm/relay/backend/interpreter.py
+++ b/python/tvm/relay/backend/interpreter.py
@@ -280,6 +280,7 @@ class Interpreter(Executor):
         """
         seq = transform.Sequential([transform.SimplifyInference(),
                                     transform.FuseOps(0),
+                                    transform.ToANormalForm(),
                                     transform.InferType()])
         return seq(self.mod)
 

--- a/src/relay/backend/interpreter.cc
+++ b/src/relay/backend/interpreter.cc
@@ -29,6 +29,7 @@
 #include <tvm/relay/interpreter.h>
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/attrs/debug.h>
+#include <tvm/relay/feature.h>
 #include "compile_engine.h"
 
 namespace tvm {
@@ -761,6 +762,8 @@ CreateInterpreter(
     Target target) {
   auto intrp = std::make_shared<Interpreter>(mod, context, target);
   auto packed = [intrp](Expr expr) {
+    auto f = DetectFeature(expr);
+    CHECK(f.is_subset_of(FeatureSet::All() - fGraph));
     return intrp->Eval(expr);
   };
   return TypedPackedFunc<Value(Expr)>(packed);

--- a/src/relay/ir/alpha_equal.cc
+++ b/src/relay/ir/alpha_equal.cc
@@ -120,7 +120,7 @@ class AlphaEqualHandler:
    * \return the comparison result.
    */
   bool TypeEqual(const Type& lhs, const Type& rhs) {
-    auto compute = [&](){
+    auto compute = [&]() {
       if (lhs.same_as(rhs)) return true;
       if (!lhs.defined() || !rhs.defined()) return false;
       return this->VisitType(lhs, rhs);

--- a/src/relay/pass/type_infer.cc
+++ b/src/relay/pass/type_infer.cc
@@ -139,19 +139,8 @@ class TypeInferencer : private ExprFunctor<Type(const Expr&)>,
   // Perform unification on two types and report the error at the expression
   // or the span of the expression.
   Type Unify(const Type& t1, const Type& t2, const NodeRef& expr) {
-    // TODO(tqchen, jroesch): propagate span to solver
     try {
-      // instantiate higher-order func types when unifying because
-      // we only allow polymorphism at the top level
-      Type first = t1;
-      Type second = t2;
-      if (auto* ft1 = t1.as<FuncTypeNode>()) {
-        first = InstantiateFuncType(ft1);
-      }
-      if (auto* ft2 = t2.as<FuncTypeNode>()) {
-        second = InstantiateFuncType(ft2);
-      }
-      return solver_.Unify(first, second, expr);
+      return solver_.Unify(t1, t2, expr);
     } catch (const dmlc::Error &e) {
       this->ReportFatalError(
         expr,

--- a/src/relay/pass/type_solver.cc
+++ b/src/relay/pass/type_solver.cc
@@ -289,30 +289,44 @@ class TypeSolver::Unifier : public TypeFunctor<Type(const Type&, const Type&)> {
     const auto* ftn = tn.as<FuncTypeNode>();
     if (!ftn
         || op->arg_types.size() != ftn->arg_types.size()
-        || op->type_params.size() != ftn->type_params.size()
         || op->type_constraints.size() != ftn->type_constraints.size()) {
       return Type(nullptr);
     }
 
-    // remap type vars so they match
-    Map<TypeVar, Type> subst_map;
-    for (size_t i = 0; i < op->type_params.size(); i++) {
-      subst_map.Set(ftn->type_params[i], op->type_params[i]);
+    // without loss of generality, suppose op->type_params.size() >= ftn->type_params.size().
+    if (op->type_params.size() < ftn->type_params.size()) {
+      return VisitType_(ftn, GetRef<FuncType>(op));
     }
 
-    auto ft1 = GetRef<FuncType>(op);
-    auto ft2 = Downcast<FuncType>(Bind(GetRef<FuncType>(ftn), subst_map));
+    // remap type vars so they match
+    Map<TypeVar, Type> subst_map;
+    tvm::Array<TypeVar> ft_type_params;
+    for (size_t i = 0; i < ftn->type_params.size(); ++i) {
+      subst_map.Set(op->type_params[i], ftn->type_params[i]);
+      ft_type_params.push_back(op->type_params[i]);
+    }
+
+    for (size_t i = ftn->type_params.size(); i < op->type_params.size(); ++i) {
+      subst_map.Set(op->type_params[i], IncompleteTypeNode::make(kType));
+    }
+
+    FuncType ft = FuncTypeNode::make(op->arg_types,
+                                     op->ret_type,
+                                     ft_type_params,
+                                     op->type_constraints);
+    auto ft1 = Downcast<FuncType>(Bind(ft, subst_map));
+    auto ft2 = GetRef<FuncType>(ftn);
 
     Type ret_type = Unify(ft1->ret_type, ft2->ret_type);
 
     std::vector<Type> arg_types;
-    for (size_t i = 0; i < ft1->arg_types.size(); i++) {
+    for (size_t i = 0; i < ft2->arg_types.size(); ++i) {
       Type arg_type = Unify(ft1->arg_types[i], ft2->arg_types[i]);
       arg_types.push_back(arg_type);
     }
 
     std::vector<TypeConstraint> type_constraints;
-    for (size_t i = 0; i < ft1->type_constraints.size(); i++) {
+    for (size_t i = 0; i < ft1->type_constraints.size(); ++i) {
       Type unified_constraint = Unify(ft1->type_constraints[i],
                                       ft2->type_constraints[i]);
       const auto* tcn = unified_constraint.as<TypeConstraintNode>();
@@ -321,7 +335,7 @@ class TypeSolver::Unifier : public TypeFunctor<Type(const Type&, const Type&)> {
       type_constraints.push_back(GetRef<TypeConstraint>(tcn));
     }
 
-    return FuncTypeNode::make(arg_types, ret_type, ft1->type_params, type_constraints);
+    return FuncTypeNode::make(arg_types, ret_type, ft2->type_params, type_constraints);
   }
 
   Type VisitType_(const RefTypeNode* op, const Type& tn) final {

--- a/tests/python/relay/test_feature.py
+++ b/tests/python/relay/test_feature.py
@@ -63,7 +63,8 @@ def test_ad():
         Feature.fLet,
         Feature.fRefCreate,
         Feature.fRefRead,
-        Feature.fRefWrite
+        Feature.fRefWrite,
+        Feature.fGraph
     ])
 
 

--- a/tests/python/relay/test_pass_to_cps.py
+++ b/tests/python/relay/test_pass_to_cps.py
@@ -30,6 +30,20 @@ def rand(dtype='float32', *shape):
     return tvm.nd.array(np.random.rand(*shape).astype(dtype))
 
 
+def test_id():
+    x = relay.var("x", shape=[])
+    id = run_infer_type(relay.Function([x], x))
+    id_cps = run_infer_type(to_cps(id))
+
+
+def test_double():
+    t = relay.TypeVar("t")
+    x = relay.var("x", t)
+    f = relay.var("f", relay.FuncType([t], t))
+    double = run_infer_type(relay.Function([f, x], f(f(x)), t, [t]))
+    double_cps = run_infer_type(to_cps(double))
+
+
 # make sure cps work for recursion.
 def test_recursion():
     mod = relay.Module()


### PR DESCRIPTION
previously, interpreter evaluate everything as tree form irregardless of graph sharing. This is bad because it cause exponential blowup:
a = 1
b = a + a
c = b + b
d = c + c
will be interpreter as ((1 + 1) + (1 + 1)) + ((1 + 1) + (1 + 1)) in the interpreter.
this fix use `feature` to detect that there are no such graph sharing (or it will just failed).
Additionally, it make executor anf before passing, and restore let polymorphism, as it is required to anf polymorphic code.
@icemelon9 @junrushao1994 @slyubomirsky @jroesch @vinx13 @tqchen can you guys help review?