### PR TITLE
Temporary Disable MicroTVM on i386 CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,6 @@ stage('Build') {
            cd build
            cp ../cmake/config.cmake .
            echo set\\(USE_SORT ON\\) >> config.cmake
-           echo set\\(USE_MICRO ON\\) >> config.cmake
            echo set\\(USE_RPC ON\\) >> config.cmake
            echo set\\(USE_GRAPH_RUNTIME_DEBUG ON\\) >> config.cmake
            echo set\\(USE_LLVM llvm-config-5.0\\) >> config.cmake


### PR DESCRIPTION
Currently, MicroTVM does not work on 32-bit devices.  Until it does, we would like to disable it on CI.

CC @tqchen @liangfu @vinx13 