### PR TITLE
[Community] Zhi Chen -> Committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ We do encourage everyone to work anything they are interested in.
 
 - [Aditya Atluri](https://github.com/adityaatluri): @adityaatluri - rocm
 - [Tianqi Chen](https://github.com/tqchen) (PMC): @tqchen - topi, compiler, relay, docs
+- [Zhi Chen](https://github.com/zhiics): @zhiics - relay, quantization, pass manager
 - [Yuwei Hu](https://github.com/Huyuwei): @Huyuwei - topi, frontends
 - [Nick Hynes](https://github.com/nhynes): @nhynes: - sgx, rust
 - [Ziheng Jiang](https://github.com/ZihengJiang) (PMC): @ZihengJiang - relay, compiler


### PR DESCRIPTION
Zhi has made major contributions to Relay (quantization, pass manager, heterogeneous compilation etc.) and has been very active in reviewing PRs, and being involved in the TVM forum community, which has been key towards growing Apache TVM.

Commits:
https://github.com/dmlc/tvm/commits?author=zhiics

Code Review:
https://github.com/dmlc/tvm/pulls?utf8=%E2%9C%93&q=reviewed-by%3Azhiics

Forum:
https://discuss.tvm.ai/u/zhiics/activity

Let's welcome Zhi as a new Apache TVM Committer!
