### PR TITLE
[RPC] Better handle tempdir if subprocess killed.

### DIFF
--- a/python/tvm/contrib/util.py
+++ b/python/tvm/contrib/util.py
@@ -30,8 +30,12 @@ class TempDirectory(object):
 
     Automatically removes the directory when it went out of scope.
     """
-    def __init__(self):
-        self.temp_dir = tempfile.mkdtemp()
+    def __init__(self, custom_path=None):
+        if custom_path:
+            os.mkdir(custom_path)
+            self.temp_dir = custom_path
+        else:
+            self.temp_dir = tempfile.mkdtemp()
         self._rmtree = shutil.rmtree
 
     def remove(self):
@@ -69,15 +73,20 @@ class TempDirectory(object):
         return os.listdir(self.temp_dir)
 
 
-def tempdir():
+def tempdir(custom_path=None):
     """Create temp dir which deletes the contents when exit.
+
+    Parameters
+    ----------
+    custom_path : str, optional
+        Manually specify the exact temp dir path
 
     Returns
     -------
     temp : TempDirectory
         The temp directory object
     """
-    return TempDirectory()
+    return TempDirectory(custom_path)
 
 
 class FileLock(object):

--- a/python/tvm/module.py
+++ b/python/tvm/module.py
@@ -251,7 +251,7 @@ def load(path, fmt=""):
         _cc.create_shared(path + ".so", path)
         path += ".so"
     elif path.endswith(".tar"):
-        tar_temp = _util.tempdir()
+        tar_temp = _util.tempdir(custom_path=path.replace('.tar', ''))
         _tar.untar(path, tar_temp.temp_dir)
         files = [tar_temp.relpath(x) for x in tar_temp.listdir()]
         _cc.create_shared(path + ".so", files)


### PR DESCRIPTION
This PR enhance temporary directories and subcontent handling for RPC server.

---
Description:

* It fix "no space left" for small devices like rk3399 or rpi where disk space is scarce, or even worse the very /tmp is a ramdisk:
```
[root@rk3399 tmp]# df -h | grep '/tmp'
none            1.9G  168K  1.9G   1% /tmp
```
---
Fixes:

1. In case of timeout (quite frequent) the RPC subprocess [join(timeout)](https://github.com/dmlc/tvm/blob/master/python/tvm/rpc/server.py#L207) receive SIGTERM so have no chance to clean, but [root process can do](https://github.com/dmlc/tvm/pull/3574/files#diff-db3f1c8882ec8257706c885bf280f661R214) the cleaning instead.
2. In case of ```untar```-ing,  make sure unpacking occur in [already existing](https://github.com/dmlc/tvm/pull/3574/files#diff-82e4b32f06c6b90becbb21b77980d666R254) root temporary no need another new one (will be not cleaned at SIGTERM), thus this new root temporary can be erased too by the master process.
---

@eqy, @zhiics, @vinx13, @kevinthesun 
Can help review ?

Thank you !