### PR TITLE
[VTA][Hotfix] Fix cast from None to int when reading TVM_TRACKER_PORT var

### DIFF
--- a/vta/scripts/tune_conv2d.py
+++ b/vta/scripts/tune_conv2d.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     # Get tracker info from env
     tracket_host = os.environ.get("TVM_TRACKER_HOST", None)
-    tracket_port = int(os.environ.get("TVM_TRACKER_PORT", None))
+    tracket_port = os.environ.get("TVM_TRACKER_PORT", None)
     if not tracket_host or not tracket_port:
         print("Set your AutoTVM tracker node host and port variables to run the autotuner")
         exit()
@@ -118,7 +118,7 @@ if __name__ == '__main__':
 
         measure_option = autotvm.measure_option(
                 builder=autotvm.LocalBuilder(build_func=vta.vta_autotvm_build_func),
-                runner=autotvm.RPCRunner(env.TARGET, tracket_host, tracket_port, number=4, repeat=3, timeout=10000,
+                runner=autotvm.RPCRunner(env.TARGET, tracket_host, int(tracket_port), number=4, repeat=3, timeout=10000,
                                         check_correctness=True))
 
         tuner = autotvm.tuner.RandomTuner(task)

--- a/vta/scripts/tune_dense.py
+++ b/vta/scripts/tune_dense.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
 
     # Get tracker info from env
     tracket_host = os.environ.get("TVM_TRACKER_HOST", None)
-    tracket_port = int(os.environ.get("TVM_TRACKER_PORT", None))
+    tracket_port = os.environ.get("TVM_TRACKER_PORT", None)
     if not tracket_host or not tracket_port:
         print("Set your AutoTVM tracker node host and port variables to run the autotuner")
         exit()
@@ -93,7 +93,7 @@ if __name__ == '__main__':
 
         measure_option = autotvm.measure_option(
                 builder=autotvm.LocalBuilder(build_func=vta.vta_autotvm_build_func),
-                runner=autotvm.RPCRunner(env.TARGET, tracket_host, tracket_port, number=4, repeat=3, timeout=10000,
+                runner=autotvm.RPCRunner(env.TARGET, tracket_host, int(tracket_port), number=4, repeat=3, timeout=10000,
                                         check_correctness=True))
 
         tuner = autotvm.tuner.RandomTuner(task)

--- a/vta/scripts/tune_resnet.py
+++ b/vta/scripts/tune_resnet.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
 
     # Get remote from fleet node
     tracker_host = os.environ.get("TVM_TRACKER_HOST", None)
-    tracker_port = int(os.environ.get("TVM_TRACKER_PORT", None))
+    tracker_port = os.environ.get("TVM_TRACKER_PORT", None)
     if not tracker_host or not tracker_port:
         print("Set your AutoTVM tracker node host and port variables to run the autotuner")
         exit()
@@ -213,7 +213,7 @@ if __name__ == '__main__':
         reconfig_start = time.time()
 
         # Get remote from fleet node
-        remote = autotvm.measure.request_remote(env.TARGET, tracker_host, tracker_port, timeout=10000)
+        remote = autotvm.measure.request_remote(env.TARGET, tracker_host, int(tracker_port), timeout=10000)
 
         # Reconfigure the JIT runtime and FPGA.
         # You can program the FPGA with your own custom bitstream

--- a/vta/scripts/tune_resnet_nnvm.py
+++ b/vta/scripts/tune_resnet_nnvm.py
@@ -181,7 +181,7 @@ if __name__ == '__main__':
 
     # Get tracker info from env
     tracker_host = os.environ.get("TVM_TRACKER_HOST", None)
-    tracker_port = int(os.environ.get("TVM_TRACKER_PORT", None))
+    tracker_port = os.environ.get("TVM_TRACKER_PORT", None)
     if not tracker_host or not tracker_port:
         print("Set your AutoTVM tracker node host and port variables to run the autotuner")
         exit()
@@ -209,7 +209,7 @@ if __name__ == '__main__':
 
         'measure_option':  autotvm.measure_option(
                 builder=autotvm.LocalBuilder(build_func=vta.vta_autotvm_build_func),
-                runner=autotvm.RPCRunner(env.TARGET, tracker_host, tracker_port,
+                runner=autotvm.RPCRunner(env.TARGET, tracker_host, int(tracker_port),
                     number=4, repeat=3, timeout=60,
                     check_correctness=True))
     }

--- a/vta/tutorials/frontend/deploy_resnet_on_vta.py
+++ b/vta/tutorials/frontend/deploy_resnet_on_vta.py
@@ -95,7 +95,7 @@ if env.TARGET not in ["sim", "tsim"]:
     # To set up the tracker, you'll need to follow the "Auto-tuning
     # a convolutional network for VTA" tutorial.
     tracker_host = os.environ.get("TVM_TRACKER_HOST", None)
-    tracker_port = int(os.environ.get("TVM_TRACKER_PORT", None))
+    tracker_port = os.environ.get("TVM_TRACKER_PORT", None)
     # Otherwise if you have a device you want to program directly from
     # the host, make sure you've set the variables below to the IP of
     # your board.
@@ -104,7 +104,7 @@ if env.TARGET not in ["sim", "tsim"]:
     if not tracker_host or not tracker_port:
         remote = rpc.connect(device_host, device_port)
     else:
-        remote = autotvm.measure.request_remote(env.TARGET, tracker_host, tracker_port, timeout=10000)
+        remote = autotvm.measure.request_remote(env.TARGET, tracker_host, int(tracker_port), timeout=10000)
 
     # Reconfigure the JIT runtime and FPGA.
     # You can program the FPGA with your own custom bitstream


### PR DESCRIPTION
Tracker lets us obtain an FPGA device easily. If the host and port numbers are not set, we fall back to a direct connection with a host-connected board. However not having the `TVM_TRACKER_PORT` environment variable can lead to an ugly error. This hotfix pr fixes the error.