### PR TITLE
Mention minimum version of python features one should stick to

### DIFF
--- a/docs/contribute/code_guide.rst
+++ b/docs/contribute/code_guide.rst
@@ -38,6 +38,7 @@ Python Code Styles
 ------------------
 - The functions and classes are documented in `numpydoc <https://numpydoc.readthedocs.io/en/latest/>`_ format.
 - Check your code style using ``make pylint``
+- Stick to language features as in ``python 3.5``
 
 
 Handle Integer Constant Expression


### PR DESCRIPTION
As per PR1652, we decided to keep python3.5 as the minimum dialect for use . Document this here. 

Ok ?
