### PR TITLE
[Relay][vm] Small bug fix for DataTypeObject

### DIFF
--- a/python/tvm/relay/backend/vmobj.py
+++ b/python/tvm/relay/backend/vmobj.py
@@ -85,7 +85,7 @@ class DatatypeObject(Object):
         return self.fields[idx]
 
     def __len__(self):
-        return self.num_fields
+        return len(self.fields)
 
     def __iter__(self):
         return iter(self.fields)

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -213,6 +213,9 @@ def test_list_constructor():
     mod["main"] = f
 
     result = veval(mod)
+    assert len(result) == 2
+    assert len(result[1]) == 2
+
     obj = vmobj_to_list(result)
     tvm.testing.assert_allclose(obj, np.array([3,2,1]))
 


### PR DESCRIPTION
It looks that this is a bug 

https://github.com/dmlc/tvm/blob/d6dcd6c56febfbb12efe67884c188f045f435893/python/tvm/relay/backend/vmobj.py#L87-L88

cc @icemelon9 