### PR TITLE
[Hotfix] Remove prints in `generic_op_impl.py`

### DIFF
--- a/topi/python/topi/generic_op_impl.py
+++ b/topi/python/topi/generic_op_impl.py
@@ -79,8 +79,6 @@ def _make_bop(broadcast_bop, orig_bop):
               tvm.Expr (otherwise)
             The result of {op} operation.
         """
-        print(lhs, type(lhs))
-        print(rhs, type(rhs))
         if not isinstance(lhs, tvm.tensor.Tensor) and not isinstance(rhs, tvm.tensor.Tensor):
             return orig_bop(lhs, rhs)
         return broadcast_bop(lhs, rhs)


### PR DESCRIPTION
There are some leftover prints from [this](https://github.com/dmlc/tvm/commit/90eee08746d7b96d834331aa910a760451330f7b) commit