### PR TITLE
Add a missing header in cuda_device_api.cc

### DIFF
--- a/src/runtime/cuda/cuda_device_api.cc
+++ b/src/runtime/cuda/cuda_device_api.cc
@@ -28,6 +28,7 @@
 #include <tvm/runtime/registry.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <cstring>
 #include "cuda_common.h"
 
 namespace tvm {


### PR DESCRIPTION
The use of function `strlen()` requires the header `<cstring>`.

cc @zhiics 