### PR TITLE
[GOLANG] Fix type error in assignment

### DIFF
--- a/golang/src/ndarray.go
+++ b/golang/src/ndarray.go
@@ -267,7 +267,7 @@ func (parray Array) GetCtx() (retVal Context) {
 func nativeTVMArrayAlloc(shape []int64, ndim int32,
                    dtypeCode int32, dtypeBits int32, dtypeLanes int32,
                    deviceType int32, deviceID int32) (retVal uintptr, err error) {
-    ret := (int32)(C.TVMArrayAlloc((*C.long)(&(shape[0])),
+    ret := (int32)(C.TVMArrayAlloc((*C.longlong)(&(shape[0])),
                                    C.int(ndim),
                                    C.int(dtypeCode),
                                    C.int(dtypeBits),


### PR DESCRIPTION
Hi @srkreddy1238 , @tqchen 

Please help to review this PR for fixing the error when I build gotvm package. 

Many thanks,

Error Message:
```
cch:golang cch$ make
# gotvm
./ndarray.go:270:43: cannot use (*_Ctype_long)(&shape[0]) (type *_Ctype_long) as type *_Ctype_longlong in assignment
make: *** [all] Error 2
```

My OS environment:
```
cch:golang cch$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.12.6
BuildVersion:	16G2016
```

My golang version & environment:
```
cch:golang cch$ go version
go version go1.12.6 darwin/amd64
cch:golang cch$ 
cch:golang cch$ go env
GOARCH="amd64"
GOBIN="/Users/cch/go/bin"
GOCACHE="/Users/cch/Library/Caches/go-build"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOOS="darwin"
GOPATH="/Users/cch/go"
GOPROXY=""
GORACE=""
GOROOT="/usr/local/Cellar/go/1.12.6/libexec"
GOTMPDIR=""
GOTOOLDIR="/usr/local/Cellar/go/1.12.6/libexec/pkg/tool/darwin_amd64"
GCCGO="gccgo"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/m5/s5hk4mln5_3dnxmjv4t8lf8c0000gn/T/go-build666214302=/tmp/go-build -gno-record-gcc-switches -fno-common"
```

```
cch:golang cch$ g++ -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/c++/4.2.1
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
cch:golang cch$ 
```
