### PR TITLE
[VTA] [Chisel] fix tensor issue/commit in gemm

### DIFF
--- a/vta/hardware/chisel/src/main/scala/core/TensorGemm.scala
+++ b/vta/hardware/chisel/src/main/scala/core/TensorGemm.scala
@@ -39,10 +39,10 @@ class MAC(aBits: Int = 8, bBits: Int = 8, cBits: Int = 16) extends Module {
   val rA = RegNext(io.a)
   val rB = RegNext(io.b)
   val rC = RegNext(io.c)
-  
+
   mult := rA * rB
   add := rC +& mult
-  
+
   io.y := add
 }
 
@@ -226,9 +226,9 @@ class TensorGemm(debug: Boolean = false)(implicit p: Parameters) extends Module 
   when (state === sIdle) {
     inflight := 0.U
   } .elsewhen (!dec.reset) {
-    when (state === sExe && inflight =/= ((1 << pBits) - 1).asUInt) { // overflow check
+    when (state === sReadTensor) { // issue a tensor
       inflight := inflight + 1.U
-    } .elsewhen (mvc.io.acc_o.data.valid && inflight =/= 0.U) { // underflow check
+    } .elsewhen (mvc.io.acc_o.data.valid) { // commit a tensor
       inflight := inflight - 1.U
     }
   }

--- a/vta/hardware/chisel/src/main/scala/core/TensorStore.scala
+++ b/vta/hardware/chisel/src/main/scala/core/TensorStore.scala
@@ -28,7 +28,7 @@ import vta.shell._
   *
   * Store 1D and 2D tensors from out-scratchpad (SRAM) to main memory (DRAM).
   */
-class TensorStore(tensorType: String = "true", debug: Boolean = false)
+class TensorStore(tensorType: String = "none", debug: Boolean = false)
   (implicit p: Parameters) extends Module {
   val tp = new TensorParams(tensorType)
   val mp = p(ShellKey).memParams

--- a/vta/tests/hardware/metal_test/metal_test.cc
+++ b/vta/tests/hardware/metal_test/metal_test.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
**Background**
The `inflight` counter tracks the number of `inp` and `wgt` tensors issue to the `MatrixVectorMultiplication` module.

**Bug**
The current bug is related to the way the counter is being incremented. The counter is incremented on the same state `sExe` where the `GEMM` unit asserts the `done` signal. Since the increment happen on the next cycle then the unit will assert `done` but the values are not written back to memory yet because of the depth of the pipeline.

**Solution**
Now, we increment the `inflight` counter once we read the tensors and decrement it when we write-back.