### PR TITLE
Fix kernel_size != 3 on winograd arm/mali.

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -36,13 +36,13 @@ AUTOTVM_TOPHUB_ROOT_PATH = os.path.join(os.path.expanduser('~'), ".tvm", "tophub
 
 # the version of each package
 PACKAGE_VERSION = {
-    'arm_cpu': "v0.04",
+    'arm_cpu': "v0.05",
     'llvm':    "v0.03",
 
-    'cuda':    "v0.04",
+    'cuda':    "v0.05",
     'rocm':    "v0.02",
-    'opencl':  "v0.02",
-    'mali':    "v0.05",
+    'opencl':  "v0.03",
+    'mali':    "v0.06",
 
     'vta':     "v0.06",
 }

--- a/topi/tests/python/test_topi_conv2d_winograd.py
+++ b/topi/tests/python/test_topi_conv2d_winograd.py
@@ -83,7 +83,7 @@ def verify_conv2d_nchw(batch, in_channel, in_size, num_filter, kernel, stride, p
             func(a, w, c)
 
         rtol = 1e-5
-        if (kernel > 3):
+        if (kernel > 5):
           rtol = 2e-5
 
         tvm.testing.assert_allclose(c.asnumpy(), c_np, rtol=rtol)
@@ -110,16 +110,16 @@ def test_conv2d_nchw():
     with WinogradFallback():
 
         # inception v3 workloads
-        verify_conv2d_nchw(1, 128, 17, 192, 7, 1, 3, devices=['cuda'])
-        verify_conv2d_nchw(1, 128, 17, 128, 7, 1, 3, devices=['cuda'])
-        verify_conv2d_nchw(1, 160, 17, 160, 7, 1, 3, devices=['cuda'])
+        verify_conv2d_nchw(1, 128, 17, 192, 7, 1, 3)
+        verify_conv2d_nchw(1, 128, 17, 128, 7, 1, 3)
+        verify_conv2d_nchw(1, 160, 17, 160, 7, 1, 3)
 
         # resnet 18 workloads
         verify_conv2d_nchw(1, 64, 56, 64, 3, 1, 1)
         verify_conv2d_nchw(1, 128, 28, 128, 3, 1, 1)
         verify_conv2d_nchw(1, 256, 14, 256, 3, 1, 1)
         verify_conv2d_nchw(1, 512, 7, 512, 3, 1, 1)
-        verify_conv2d_nchw(1, 48,  35, 64, 5, 1, 2, devices=['cuda'])
+        verify_conv2d_nchw(1, 48, 35, 64, 5, 1, 2)
 
         # batch size = 2
         verify_conv2d_nchw(2, 64, 56, 64, 3, 1, 1)


### PR DESCRIPTION
This PR fix/enable cases for kernel_size other than 3x3.

* It is a continuation on #3553 work.
* Fix testcases for arm / mali and also #3641 .

@tmoreau89 , @merrymercy , @kevinthesun , @FrozenGene 
Please help with the review.

------
**Main benefit:**
We have flexible ```tile_size``` and any ```kernel_size``` for winograd.

------

**Examples** (yolov3-tiny) of having **tuned ```tile_size```**:

**```original (only direct)```**
[Task 13/20 (1, 384, 26, 26)|(256, 384, 3, 3)] (conv2d) {53.46 GFLOPS /direct}
[Task 14/20 (1, 512, 13, 13)|(1024, 512, 3, 3)] (conv2d) {31.17 GFLOPS /direct}
[Task 15/20 (1, 256, 13, 13)|(512, 256, 3, 3)] (conv2d) {28.77 GFLOPS /direct}

**```original (no tile_size autotune)```**
[Task 13/20 (1, 384, 26, 26, 'float16')] (conv2d) {93.78 GFLOPS /winograd} ```tile_size=2```
[Task 14/20 (1, 512, 13, 13, 'float16')] (conv2d) {93.31 GFLOPS /winograd} ```tile_size=2```
[Task 15/20 (1, 256, 13, 13, 'float16')] (conv2d) {81.34 GFLOPS /winograd} ```tile_size=2```

**```proposed (with tile_size autotune)```**
[Task 13/20 (1, 384, 26, 26, 'float16')] (conv2d) {98.48 GFLOPS /winograd} ```tile_size=4```
[Task 14/20 (1, 512, 13, 13, 'float16')] (conv2d) {106.15 GFLOPS /winograd} ```tile_size=4```
[Task 15/20 (1, 256, 13, 13, 'float16')] (conv2d) {84.54 GFLOPS /winograd} ```tile_size=4```


It is quite tedious to expose more benefits (WiP on my side) for tuned ```tile_size```, these 3 was found running >1 week on mali. That's all what I personally found up to this day, i am sure there are more, will try soon 5x5 & 7x7 kernels (Unet, SuperRes), and post on tophub exceptional ones.