### PR TITLE
[VTA] [Chisel] fix uop load request

### DIFF
--- a/vta/hardware/chisel/src/main/scala/core/LoadUop.scala
+++ b/vta/hardware/chisel/src/main/scala/core/LoadUop.scala
@@ -76,7 +76,7 @@ class LoadUop(debug: Boolean = false)(implicit p: Parameters) extends Module {
   val xcnt = Reg(chiselTypeOf(io.vme_rd.cmd.bits.len))
   val xlen = Reg(chiselTypeOf(io.vme_rd.cmd.bits.len))
   val xrem = Reg(chiselTypeOf(dec.xsize))
-  val xsize = dec.xsize(0) + (dec.xsize >> log2Ceil(numUop)) - 1.U
+  val xsize =  (dec.xsize >> log2Ceil(numUop)) + dec.xsize(0) + (dec.sram_offset % 2.U) - 1.U
   val xmax = (1 << mp.lenBits).U
   val xmax_bytes = ((1 << mp.lenBits)*mp.dataBits/8).U
 


### PR DESCRIPTION
**Background**

Currently, micro-operations `uop` in VTA are 32-bit wide, which is usually lower to the number of bits used by the memory bus. In order to take full advantage of memory bandwidth, micro-ops are loaded in memory burst and written to `uop` memory. The cost for this approach is aligning/masking the data to be written on SRAMs with the benefit of fully utilizing the bandwidth available.

**Bug**

I recently found a bug when `uop` load-requests had an odd offset (SRAM) and even number of `uop`. This was causing the integration gemm test `test_benchmark_gemm.py` to fail. With this fix, VTA chisel is now passing the following tests (unit-tests, integration, and tutorial) except for `deploy_resnet_on_vta.py`

**Solution**

Incorporate the offset into the calculation of the size of the dma request.
