### PR TITLE
Enable the sparse schedule

### DIFF
--- a/topi/python/topi/x86/__init__.py
+++ b/topi/python/topi/x86/__init__.py
@@ -15,3 +15,4 @@ from .dense import _schedule_dense, _schedule_dense_pack, _schedule_dense_nopack
 from .batch_matmul import schedule_batch_matmul
 from .roi_align import roi_align_nchw
 from .conv2d_transpose import schedule_conv2d_transpose
+from .sparse import *


### PR DESCRIPTION
https://github.com/dmlc/tvm/pull/3566 added the sparse operators. Need to include the sparse schedule in __init__.py so that it can be picked up. 

@ajtulloch , do you think whether it makes sense? Thanks.
