### PR TITLE
Print llvm source by default in ROCMModuleNode::GetSource

### DIFF
--- a/src/runtime/rocm/rocm_module.cc
+++ b/src/runtime/rocm/rocm_module.cc
@@ -79,7 +79,7 @@ class ROCMModuleNode : public runtime::ModuleNode {
 
   std::string GetSource(const std::string& format) final {
     if (format == fmt_) { return data_; }
-    if (format == "llvm") { return hip_source_; }
+    if (format == "llvm" || format == "") { return hip_source_; }
     if (format == "asm") { return assembly_; }
     return "";
   }


### PR DESCRIPTION
This is similar to the LLVM module, which also prints the LLVM IR by default. Currently it just returns an empty string, which is useful in the rarest cases.

The other id that might be worth supporting for compatibility with the other LLVM might be `"ll"`, but I would check with you first.

I briefly looked for a canonical place to add a test, but must admit I didn't really find one. There are some uses of get_source in `tests/python/unittest/test_codegen_*`, but those seem to be check very specific things about the generated code rather then whether `Module` works in general.
