### PR TITLE
[RPC] Terminate worker's childs first.

### DIFF
--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -39,6 +39,7 @@ import subprocess
 import time
 import sys
 import signal
+import psutil
 
 from .._ffi.function import register_func
 from .._ffi.base import py_str
@@ -210,6 +211,11 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
         server_proc.join(opts.get("timeout", None))
         if server_proc.is_alive():
             logger.info("Timeout in RPC session, kill..")
+            parent = psutil.Process(server_proc.pid)
+            # terminate worker childs
+            for child in parent.children(recursive=True):
+                child.terminate()
+            # terminate the worker
             server_proc.terminate()
         work_path.remove()
 


### PR DESCRIPTION
This small PR address the issue of orphaned sub-process in the RPC.

**Description:**
During atotune process on small remote edges (like rpi, rk3399, etc) the transfered ```tar``` is unpacked and further compiled into shared object. It can happen that sub-process (usually compile process) runs much longer and will get orphaned on timeout ```.terminate()```. See the list below. 

**Problem:**
Such longer running orphans overlaps with current measuring process using CPU cycles and even on worse case can lead to ```out of memory``` on limited 1G-4G low memory devices.

**Fix:**
The PR assures that in case of timeout all childen instances are terminated with parent too and with help of #3574 the residual files are now cleaned properly.


```
  ├─g++ -shared -fPIC -o /tmp/tmpy1javnqz/tmp_func_4ad0b36aa69fae99.tar.so /tmp/tmpy1javnqz/tmp_func_4ad0b36aa69fae99/devc.cc...
  │   └─cc1plus -quiet -D_GNU_SOURCE /tmp/tmpy1javnqz/tmp_func_4ad0b36aa69fae99/devc.cc -quiet -dumpbase devc.cc-ml
  ├─g++ -shared -fPIC -o /tmp/tmpy3cbmbck/tmp_func_34edb6ad7349ebf1.tar.so /tmp/tmpy3cbmbck/tmp_func_34edb6ad7349ebf1/devc.cc...
  │   └─cc1plus -quiet -D_GNU_SOURCE /tmp/tmpy3cbmbck/tmp_func_34edb6ad7349ebf1/devc.cc -quiet -dumpbase devc.cc-ml
  ├─g++ -shared -fPIC -o /tmp/tmp182f7df1/tmp_func_4888c9a4c281177d.tar.so /tmp/tmp182f7df1/tmp_func_4888c9a4c281177d/devc.cc...
  │   └─cc1plus -quiet -D_GNU_SOURCE /tmp/tmp182f7df1/tmp_func_4888c9a4c281177d/devc.cc -quiet -dumpbase devc.cc-ml
  ├─g++ -shared -fPIC -o /tmp/tmpjk358ic7/tmp_func_99d315bf5d46550.tar.so /tmp/tmpjk358ic7/tmp_func_99d315bf5d46550/devc.cc...
  │   └─cc1plus -quiet -D_GNU_SOURCE /tmp/tmpjk358ic7/tmp_func_99d315bf5d46550/devc.cc -quiet -dumpbase devc.cc-mli
  ├─rngd -f
  │   └─4*[{rngd}]
  ├─sshd -D -oCiphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc,aes128-gcm@openssh.com,aes128-ctr,aes128-cbc
  │   ├─sshd                                                                                                                                  
  │   │   └─sshd                                                                                                                                ...
  │   │       └─bash
  │   │           └─python3 -m tvm.exec.rpc_server --tracker=192.168.1.2:9190 --key=rk3399
  │   │               └─python3 -m tvm.exec.rpc_server --tracker=192.168.1.2:9190 --key=rk3399
  │   │                   └─python3 -m tvm.exec.rpc_server --tracker=192.168.1.2:9190 --key=rk3399
  │   │                       └─g++ -shared -fPIC -o /tmp/tmps7iiv8bj/tmp_func_7e67258cb8079498.tar.so ...
  │   │                           └─cc1plus -quiet -D_GNU_SOURCE /tmp/tmps7iiv8bj/tmp_func_7e67258cb8079498/devc.cc -quiet -dumpbase devc.cc-ml
```