### PR TITLE
[TOPI] Update softmax compute and CPU schedule

### DIFF
--- a/topi/include/topi/nn/softmax.h
+++ b/topi/include/topi/nn/softmax.h
@@ -62,6 +62,9 @@ inline Tensor softmax(const Tensor &x,
   auto k2 = tvm::reduce_axis(Range(0, input_shape[axis]), "k2");
   auto reduced_shape = MakeReduceTargetShape({axis}, x, false, false);
 
+  tvm::Map<std::string, NodeRef> attrs;
+  attrs.Set("axis", Integer(axis));
+
   auto insert_reduce_index = [axis, ndim](const Array<Var> &indices,
                                           const IterVar &reduce_index) {
     Array<Expr> eval_range;
@@ -75,35 +78,48 @@ inline Tensor softmax(const Tensor &x,
     return eval_range;
   };
 
-  auto _compute_max = [&](const Array<Var> &indices) {
-    auto eval_range = insert_reduce_index(indices, k1);
-    return topi::MaxOp(x(eval_range), {k1});
-  };
-
-  auto _compute_expsum = [&](const Tensor &max_elem,
-                             const Array<Var> &indices) {
-    auto eval_range = insert_reduce_index(indices, k2);
-    return tvm::sum(tvm::exp(x(eval_range) - max_elem(indices)), {k2});
-  };
-
-  auto _normalize = [&](const Tensor &max_elem, const Tensor &expsum,
-                        const Array<Var> &indices) {
+  auto get_non_reduce_indices = [axis, ndim](const Array<Var> &indices) {
     Array<Expr> non_reduce_indices;
     for (size_t i = 0; i < ndim; ++i) {
       if (static_cast<int>(i) != axis)
         non_reduce_indices.push_back(indices[i]);
     }
-    return tvm::exp(x(indices) - max_elem(non_reduce_indices)) /
-           expsum(non_reduce_indices);
+    return non_reduce_indices;
+  };
+
+  auto _compute_max = [&](const Array<Var> &indices) {
+    auto eval_range = insert_reduce_index(indices, k1);
+    return topi::MaxOp(x(eval_range), {k1});
+  };
+
+  auto _compute_exp = [&](const Tensor &max_elem,
+                          const Array<Var> &indices) {
+    auto non_reduce_indices = get_non_reduce_indices(indices);
+    return tvm::exp(x(indices) - max_elem(non_reduce_indices));
+  };
+
+  auto _compute_expsum = [&](const Tensor &exp,
+                             const Array<Var> &indices) {
+    auto eval_range = insert_reduce_index(indices, k2);
+    return tvm::sum(exp(eval_range), {k2});
+  };
+
+  auto _normalize = [&](const Tensor &exp, const Tensor &expsum,
+                        const Array<Var> &indices) {
+    auto non_reduce_indices = get_non_reduce_indices(indices);
+    return exp(indices) / expsum(non_reduce_indices);
   };
 
   auto max_elem = tvm::compute(reduced_shape, _compute_max);
+  auto exp = tvm::compute(input_shape, [&](const Array<Var> &indices) {
+      return _compute_exp(max_elem, indices);
+  });
   auto expsum = tvm::compute(reduced_shape, [&](const Array<Var> &indices) {
-      return _compute_expsum(max_elem, indices);
+      return _compute_expsum(exp, indices);
   });
   return tvm::compute(input_shape, [&](const Array<Var> &indices) {
-      return _normalize(max_elem, expsum, indices);
-  }, name, tag);
+      return _normalize(exp, expsum, indices);
+  }, name, tag, attrs);
 }
 
 /*!

--- a/topi/python/topi/cuda/softmax.py
+++ b/topi/python/topi/cuda/softmax.py
@@ -38,9 +38,18 @@ def schedule_softmax(outs):
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
     softmax = outs[0]
-    exp = softmax.op.input_tensors[0]
-    expsum = softmax.op.input_tensors[1]
-    maxelem = s[exp].op.input_tensors[1]
+
+    op_tag = softmax.op.tag
+    if op_tag == 'softmax_output':
+        expsum = softmax.op.input_tensors[1]
+        exp = softmax.op.input_tensors[0]
+        max_elem = s[exp].op.input_tensors[1]
+    elif op_tag == 'log_softmax_output':
+        max_elem = softmax.op.input_tensors[1]
+        expsum = softmax.op.input_tensors[2]
+    else:
+        raise ValueError('Tag is expected to be softmax_output or log_softmax_output. \
+                         Got {0}'.format(op_tag))
 
     if len(softmax.shape) > 2:
         for op in [max_elem.op, expsum.op, softmax.op]:

--- a/topi/python/topi/cuda/softmax.py
+++ b/topi/python/topi/cuda/softmax.py
@@ -38,8 +38,9 @@ def schedule_softmax(outs):
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
     softmax = outs[0]
-    max_elem = softmax.op.input_tensors[1]
-    expsum = softmax.op.input_tensors[2]
+    exp = softmax.op.input_tensors[0]
+    expsum = softmax.op.input_tensors[1]
+    maxelem = s[exp].op.input_tensors[1]
 
     if len(softmax.shape) > 2:
         for op in [max_elem.op, expsum.op, softmax.op]:

--- a/topi/python/topi/hls/nn.py
+++ b/topi/python/topi/hls/nn.py
@@ -268,11 +268,15 @@ def schedule_softmax(outs):
         exp = softmax.op.input_tensors[0]
         max_elem = s[exp].op.input_tensors[1]
     elif op_tag == 'log_softmax_output':
+        exp = None
         max_elem = softmax.op.input_tensors[1]
         expsum = softmax.op.input_tensors[2]
     else:
         raise ValueError('Tag is expected to be softmax_output or log_softmax_output. \
                          Got {0}'.format(op_tag))
+
+    if exp != None:
+        s[exp].compute_at(s[softmax], s[softmax].op.axis[1])
 
     s[expsum].compute_at(s[softmax], s[softmax].op.axis[1])
     s[max_elem].compute_at(s[softmax], s[softmax].op.axis[1])

--- a/topi/python/topi/hls/nn.py
+++ b/topi/python/topi/hls/nn.py
@@ -261,8 +261,18 @@ def schedule_softmax(outs):
     tvm.schedule.AutoInlineInjective(s)
 
     softmax = outs[0]
-    max_elem = softmax.op.input_tensors[1]
-    expsum = softmax.op.input_tensors[2]
+
+    op_tag = softmax.op.tag
+    if op_tag == 'softmax_output':
+        expsum = softmax.op.input_tensors[1]
+        exp = softmax.op.input_tensors[0]
+        max_elem = s[exp].op.input_tensors[1]
+    elif op_tag == 'log_softmax_output':
+        max_elem = softmax.op.input_tensors[1]
+        expsum = softmax.op.input_tensors[2]
+    else:
+        raise ValueError('Tag is expected to be softmax_output or log_softmax_output. \
+                         Got {0}'.format(op_tag))
 
     s[expsum].compute_at(s[softmax], s[softmax].op.axis[1])
     s[max_elem].compute_at(s[softmax], s[softmax].op.axis[1])

--- a/topi/python/topi/nn/softmax.py
+++ b/topi/python/topi/nn/softmax.py
@@ -48,24 +48,33 @@ def softmax(x, axis=-1):
     def insert_reduce_index(indices, reduce_index):
         return indices[:axis] + (reduce_index,) + indices[axis:]
 
+    def get_non_reduce_indices(indices):
+        return tuple([var for (i, var) in enumerate(indices) if i != axis])
+
     def _compute_max(*indices):
         eval_range = insert_reduce_index(indices, k1)
         return tvm.max(x[eval_range], axis=k1)
 
-    def _compute_expsum(max_elem, *indices):
-        eval_range = insert_reduce_index(indices, k2)
-        return tvm.sum(tvm.exp(x[eval_range] - max_elem[indices]), axis=k2)
+    def _compute_exp(max_elem, *indices):
+        non_reduce_indices = get_non_reduce_indices(indices)
+        return tvm.exp(x[indices] - max_elem[non_reduce_indices])
 
-    def _normalize(max_elem, expsum, *indices):
-        non_reduce_indices = tuple([var for (i, var) in enumerate(indices) if i != axis])
-        return tvm.exp(x[indices] - max_elem[non_reduce_indices]) / expsum[non_reduce_indices]
+    def _compute_expsum(exp, *indices):
+        eval_range = insert_reduce_index(indices, k2)
+        return tvm.sum(exp[eval_range], axis=k2)
+
+    def _normalize(exp, expsum, *indices):
+        non_reduce_indices = get_non_reduce_indices(indices)
+        return exp[indices] / expsum[non_reduce_indices]
 
     reduced_shape = tuple([dim for (i, dim) in enumerate(shape) if i != axis])
     max_elem = tvm.compute(reduced_shape, _compute_max, name='T_softmax_maxelem')
-    expsum = tvm.compute(reduced_shape, lambda *indices: _compute_expsum(max_elem, *indices),
+    exp = tvm.compute(shape, lambda *indices: _compute_exp(max_elem, *indices),
+                      name='T_softmax_exp')
+    expsum = tvm.compute(reduced_shape, lambda *indices: _compute_expsum(exp, *indices),
                          name='T_softmax_expsum')
-    return tvm.compute(shape, lambda *indices: _normalize(max_elem, expsum, *indices),
-                       name='T_softmax_norm')
+    return tvm.compute(shape, lambda *indices: _normalize(exp, expsum, *indices),
+                       name='T_softmax_norm', attrs={"axis" : axis})
 
 
 @tvm.tag_scope(tag='log_softmax_output')

--- a/topi/python/topi/opengl/softmax.py
+++ b/topi/python/topi/opengl/softmax.py
@@ -37,8 +37,9 @@ def schedule_softmax(outs):
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     s = tvm.create_schedule([x.op for x in outs])
     softmax = outs[0]
-    max_elem = softmax.op.input_tensors[1]
-    expsum = softmax.op.input_tensors[2]
+    exp = softmax.op.input_tensors[0]
+    expsum = softmax.op.input_tensors[1]
+    maxelem = s[exp].op.input_tensors[1]
     s[max_elem].opengl()
     s[expsum].opengl()
     s[softmax].opengl()

--- a/topi/python/topi/opengl/softmax.py
+++ b/topi/python/topi/opengl/softmax.py
@@ -44,11 +44,15 @@ def schedule_softmax(outs):
         exp = softmax.op.input_tensors[0]
         max_elem = s[exp].op.input_tensors[1]
     elif op_tag == 'log_softmax_output':
+        exp = None
         max_elem = softmax.op.input_tensors[1]
         expsum = softmax.op.input_tensors[2]
     else:
         raise ValueError('Tag is expected to be softmax_output or log_softmax_output. \
                          Got {0}'.format(op_tag))
+
+    if exp != None:
+        s[exp].opengl()
 
     s[max_elem].opengl()
     s[expsum].opengl()

--- a/topi/python/topi/x86/nn.py
+++ b/topi/python/topi/x86/nn.py
@@ -35,8 +35,9 @@ def schedule_softmax(outs):
     sch: Schedule
         The computation schedule for the op.
     """
+    outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     softmax = outs[0]
-    s = tvm.create_schedule([softmax.op for softmax in outs])
+    s = tvm.create_schedule([x.op for x in outs])
 
     exp = softmax.op.input_tensors[0]
     expsum = softmax.op.input_tensors[1]


### PR DESCRIPTION
This change improves performance for softmax by simplifying the computation and writing a schedule that supports better parallelization.

**Compute**: Currently, `exp(input - max)` is computed twice: once in the `_compute_expsum` stage and once in the `_normalize` stage. This change adds an extra stage to compute this tensor once. It is then re-used in the `_compute_expsum` and `_normalize` stages.

**Schedule**: Currently, the schedule only parallelizes the `_normalize` stage of the computation. This change puts all stages of computation under a common root and parallelizes the outer dimensions.

The following results are with a tensor of shape `(1,12,128,128)` and `axis=-1`. This simulates the softmax in BERT base. The CPU is Intel Xeon E5-2650, and the Relay target string is `llvm -mcpu=core-avx2`.

| TVM_NUM_THREADS  | Latency in ms (master branch) | Latency in ms (new branch) |
| ------------- | ------------- | ------------- |
| 1 | 4.7 | 3.0 |
| 2 | 3.8 | 1.8 |
| 4 | 3.3 | 1.0 |
| 8 | 3.1 | 0.74 |
| 16 | 3.2 | 0.55 |
