### PR TITLE
Make tests multi-process friendly.

### DIFF
--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -120,8 +120,8 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
 
 
 TEST_DATA_ROOT_PATH = os.path.join(os.path.expanduser('~'), '.tvm_test_data')
-if not os.path.exists(TEST_DATA_ROOT_PATH):
-    os.mkdir(TEST_DATA_ROOT_PATH)
+os.makedirs(TEST_DATA_ROOT_PATH, exist_ok=True)
+
 
 def download_testdata(url, relpath, module=None):
     """Downloads the test data from the internet.


### PR DESCRIPTION
This side effect at module import time has a race condition between the "exists" check and the "mkdir" call.  The safer thing is to just call mkdir and catch the "already exists" error which is what makedirs does.

Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).
