### PR TITLE
Replace learnt with learned

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Checkout the [Contributor Guide](https://docs.tvm.ai/contribute/)
 
 Acknowledgement
 ---------------
-We learnt a lot from the following projects when building TVM.
+We learned a lot from the following projects when building TVM.
 - [Halide](https://github.com/halide/Halide): TVM uses [HalideIR](https://github.com/dmlc/HalideIR) as data structure for
-  arithmetic simplification and low level lowering. We also learnt and adapted some part of lowering pipeline from Halide.
+  arithmetic simplification and low level lowering. We also learned and adapted some part of lowering pipeline from Halide.
 - [Loopy](https://github.com/inducer/loopy): use of integer set analysis and its loop transformation primitives.
 - [Theano](https://github.com/Theano/Theano): the design inspiration of symbolic scan operator for recurrence.


### PR DESCRIPTION
The use of `learnt` as the past tense or past participle of to learn is considered a spelling mistake by many in US.
Outside America learned is also generally accepted.

https://www.grammar-monster.com/easily_confused/learned_learnt.htm