### PR TITLE
[Relay][Frontend] Fix typo names in frontend

### DIFF
--- a/python/tvm/relay/frontend/caffe2.py
+++ b/python/tvm/relay/frontend/caffe2.py
@@ -123,7 +123,7 @@ class Caffe2OpConverter(object):
 
         if hasattr(cls, '_impl'):
             return getattr(cls, '_impl')
-        raise tvm.error.OpNotInplemented(
+        raise tvm.error.OpNotImplemented(
             'Operator {} is not supported in frontend Caffe2.'.format(cls.__name__))
 
 

--- a/python/tvm/relay/frontend/onnx.py
+++ b/python/tvm/relay/frontend/onnx.py
@@ -60,7 +60,7 @@ def onnx_storage_order2layout(storage_order):
     if storage_order not in (0, 1):
         raise tvm.error.OpAttributeInvalid('Mode of storage_order must be either 0 or 1')
 
-    return 'NCHW' if sotrage_order == 0 else 'NHWC'
+    return 'NCHW' if storage_order == 0 else 'NHWC'
 
 
 def dimension_constraint():


### PR DESCRIPTION
Fix typo names in caffe2 and onnx frontend:
* sotrage_order -> storage_order
* OpNotInplemented -> OpNotImplemented
