### PR TITLE
[TOPI] Memoize winograd matrix

### DIFF
--- a/topi/python/topi/nn/winograd_util.py
+++ b/topi/python/topi/nn/winograd_util.py
@@ -26,6 +26,7 @@ from operator import mul
 from functools import reduce
 import numpy as np
 from ..util import const_matrix
+from tvm.contrib.pickle_memoize import memoize
 
 
 # pylint: disable=invalid-name
@@ -131,6 +132,8 @@ def _interpolation_points(degree):
 
     return np.array(in_pts[degree-1], dtype=np.float64)
 
+
+@memoize("topi.nn.winograd_util", save_at_exit=False)
 def winograd_transform_matrices(tile_size, kernel_size, out_dtype):
     """Compute the A, B, and G transform matrices for `tile_size` as a `tvm.Expr`.
     """

--- a/topi/python/topi/nn/winograd_util.py
+++ b/topi/python/topi/nn/winograd_util.py
@@ -25,8 +25,8 @@
 from operator import mul
 from functools import reduce
 import numpy as np
-from ..util import const_matrix
 from tvm.contrib.pickle_memoize import memoize
+from ..util import const_matrix
 
 
 # pylint: disable=invalid-name

--- a/topi/python/topi/nn/winograd_util.py
+++ b/topi/python/topi/nn/winograd_util.py
@@ -133,7 +133,7 @@ def _interpolation_points(degree):
     return np.array(in_pts[degree-1], dtype=np.float64)
 
 
-@memoize("topi.nn.winograd_util", save_at_exit=False)
+@memoize("topi.nn.winograd_matrices", save_at_exit=False)
 def winograd_transform_matrices(tile_size, kernel_size, out_dtype):
     """Compute the A, B, and G transform matrices for `tile_size` as a `tvm.Expr`.
     """


### PR DESCRIPTION
I found https://github.com/dmlc/tvm/pull/3553 makes feature extraction for arm cpu about 4x slower, which will cause tuning about 2x slower.

Memoizing winograd matrix computation can fix this performance regression, and is slightly faster the the original hard-coded one.