### PR TITLE
Align naming rule for OpAttributeUnImplemented

### DIFF
--- a/nnvm/python/nnvm/frontend/darknet.py
+++ b/nnvm/python/nnvm/frontend/darknet.py
@@ -78,7 +78,7 @@ def _darknet_maxpooling(inputs, attrs):
     """Process the max pool 2d operation."""
     kernel = parse_tshape(required_attr(attrs, 'kernel', 'maxpool'))
     if len(kernel) != 1:
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Non-2D kernels for Max Pooling are not supported in frontend Darknet.')
 
     op_name, new_attrs = 'max_pool2d', {}

--- a/nnvm/python/nnvm/frontend/mxnet.py
+++ b/nnvm/python/nnvm/frontend/mxnet.py
@@ -32,7 +32,7 @@ def _rename(new_name):
 def _pooling(inputs, attrs):
     kernel = parse_tshape(required_attr(attrs, 'kernel', 'pooling'))
     if len(kernel) != 2:
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Non-2D kernels are not supported for Pool2D.')
     global_pool = 'global' if parse_bool_str(attrs, 'global_pool') else ''
     pool_type = required_attr(attrs, 'pool_type', 'pooling')
@@ -52,7 +52,7 @@ def _pooling(inputs, attrs):
 
 def _batch_norm(inputs, attrs):
     if parse_bool_str(attrs, 'output_mean_var'):
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Attribute "output_mean_var" is not supported in operator batch_norm.')
     # if parse_bool_str(attrs, 'fix_gamma'):
     #     _warn_not_used('fix_gamma', 'batch_norm')

--- a/nnvm/python/nnvm/frontend/tensorflow.py
+++ b/nnvm/python/nnvm/frontend/tensorflow.py
@@ -84,7 +84,7 @@ def _dimension_picker(prefix, surfix=''):
         kernel = attr['kernel_shape']
         if len(kernel) == 2:
             return prefix + '2d' + surfix
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Non-2D kernels are not supported for operator {}.'.format(prefix))
     return _impl
 
@@ -177,7 +177,7 @@ def _pooling(name):
             attr['padding'] = [pad_v[0], pad_h[0], pad_v[1], pad_h[1]]
         else:
             msg = 'Value {} in attribute "padding" of operator Pooling is not valid.'
-            raise tvm.error.OpAttributeUnimplemented(msg.format(attr['padding']))
+            raise tvm.error.OpAttributeUnImplemented(msg.format(attr['padding']))
 
         if name == "avg_pool":
             attr['count_include_pad'] = False

--- a/python/tvm/error.py
+++ b/python/tvm/error.py
@@ -99,14 +99,14 @@ class OpAttributeInvalid(OpError, AttributeError):
 
 
 @register_error
-class OpAttributeUnimplemented(OpError, NotImplementedError):
+class OpAttributeUnImplemented(OpError, NotImplementedError):
     """Attribute is not supported in a certain frontend.
 
     Example
     -------
     .. code:: python
 
-        raise OpAttributeUnimplemented(
+        raise OpAttributeUnImplemented(
             "Attribute {} is not supported in operator {}".format(
                 attr_name, op_name))
     """

--- a/python/tvm/relay/frontend/caffe2.py
+++ b/python/tvm/relay/frontend/caffe2.py
@@ -33,7 +33,7 @@ def dimension_picker(prefix, surfix=''):
         kernel = attr['kernel_shape']
         if len(kernel) == 2:
             return prefix + '2d' + surfix
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Non-2D kernels are not supported for operator {}2d'.format(prefix))
 
     return _impl
@@ -244,7 +244,7 @@ class Concat(Caffe2OpConverter):
                 return 1
             if order == 'NHWC':
                 return 3
-            raise tvm.error.OpAttributeUnimplemented(
+            raise tvm.error.OpAttributeUnImplemented(
                 'Order {} is not supported in operator Concat.'.format(order))
 
         return AttrCvt(

--- a/python/tvm/relay/frontend/coreml.py
+++ b/python/tvm/relay/frontend/coreml.py
@@ -207,7 +207,7 @@ def _PoolingLayerParams(op, inexpr, etab):
         else:
             msg = 'PoolingPaddingType {} is not supported in operator Pooling.'
             op_name = op.WhichOneof('PoolingPaddingType')
-            raise tvm.error.OpAttributeUnimplemented(msg.format(op_name))
+            raise tvm.error.OpAttributeUnImplemented(msg.format(op_name))
 
         # consume padding layer
         if etab.in_padding:
@@ -280,7 +280,7 @@ def _PaddingLayerParams(op, inexpr, etab):
     if op.WhichOneof('PaddingType') == 'constant':
         constant = op.constant
         if constant.value != 0:
-            raise tvm.error.OpAttributeUnimplemented(
+            raise tvm.error.OpAttributeUnImplemented(
                 '{} is not supported in operator Padding.'.format(constant.value))
         padding = [b.startEdgeSize for b in op.paddingAmounts.borderAmounts]
         padding2 = [b.endEdgeSize for b in op.paddingAmounts.borderAmounts]

--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -242,7 +242,7 @@ def _convert_convolution(inexpr, keras_layer, etab):
     else:
         msg = 'Padding with {} is not supported for operator Convolution ' \
               'in frontend Keras.'
-        raise tvm.error.OpAttributeUnimplemented(msg.format(keras_layer.padding))
+        raise tvm.error.OpAttributeUnImplemented(msg.format(keras_layer.padding))
     if is_deconv:
         out = _op.nn.conv2d_transpose(data=inexpr, **params)
     else:
@@ -290,7 +290,7 @@ def _convert_separable_convolution(inexpr, keras_layer, etab):
     else:
         msg = 'Padding with {} is not supported for operator Separable ' \
               'Convolution in frontend Keras.'
-        raise tvm.error.OpAttributeUnimplemented(msg.format(keras_layer.padding))
+        raise tvm.error.OpAttributeUnImplemented(msg.format(keras_layer.padding))
 
     depthconv = _op.nn.conv2d(data=inexpr, **params0)
     # pointwise conv

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -143,7 +143,7 @@ def _mx_conv2d(inputs, attrs):
 
 def _mx_conv2d_transpose(inputs, attrs):
     if "target_shape" in attrs.attrs:
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Attribute "target_shape" is not supported for operator Conv2D-transpose.')
     kernel_size = attrs.get_int_tuple("kernel")
     if len(kernel_size) != 2:
@@ -222,7 +222,7 @@ def _mx_BlockGrad(inputs, attrs): #pylint: disable=unused-argument
 
 def _mx_batch_norm(inputs, attrs):
     if attrs.get_bool("output_mean_var", False):
-        raise tvm.error.OpAttributeUnimplemented(
+        raise tvm.error.OpAttributeUnImplemented(
             'Attribute "output_mean_var" is not supported for operator Batch Norm.')
     if attrs.get_bool("use_global_stats", False):
         _warn_not_used("use_global_stats", "batch_norm")

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -130,7 +130,7 @@ class AttrCvt(object):
         new_attrs = {}
         for k in attrs.keys():
             if k in self._excludes:
-                raise tvm.error.OpAttributeUnimplemented(
+                raise tvm.error.OpAttributeUnImplemented(
                     'Attribute {} in operator {} is not supported.'.format(k, op_name))
             elif k in self._disables:
                 logging.warning("Attribute %s is disabled in relay.%s", k, op_name)
@@ -517,7 +517,7 @@ def _crop_and_resize():
         attrs['size'] = crop_size
         attrs['layout'] = 'NHWC'
         if method.lower() == 'nearest':
-            raise tvm.error.OpAttributeUnimplemented(
+            raise tvm.error.OpAttributeUnImplemented(
                 'Attribute method=nearest is not supported')
         else:
             attrs['align_corners'] = True

--- a/python/tvm/relay/frontend/tflite.py
+++ b/python/tvm/relay/frontend/tflite.py
@@ -683,7 +683,7 @@ class OperatorConverter(object):
                                                           (pad_left, pad_right),
                                                           (0, 0)))
         else:
-            raise tvm.error.OpAttributeUnimplemented(
+            raise tvm.error.OpAttributeUnImplemented(
                 'Padding format {} is not supported for operator Conv.'.format(padding))
 
         out = _op.nn.conv2d(data=in_expr, weight=weight_expr, **params)
@@ -786,7 +786,7 @@ class OperatorConverter(object):
             pad_left, pad_right = get_pad_value(input_w, filter_w, stride_w)
             params['padding'] = [pad_top, pad_left, pad_bottom, pad_right]
         else:
-            raise tvm.error.OpAttributeUnimplemented(
+            raise tvm.error.OpAttributeUnImplemented(
                 'Padding format {} for operator Pool2D is not supported.'.format(padding))
 
         if pool_type == "average":


### PR DESCRIPTION
Hi @tqchen 

I saw the class name **OpAttributeUnimplemented** in [python/tvm/error.py](https://github.com/dmlc/tvm/blob/master/python/tvm/error.py#L102) that did not follow the naming  rule like **OpNotImplemented**. Therefore I align the class name in this PR, I would appreciate if you can help to review/merge it, thanks. :)
