### PR TITLE
Fix reinterpret intrinsic code generation on Metal backend.

### DIFF
--- a/src/codegen/codegen_metal.cc
+++ b/src/codegen/codegen_metal.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -244,6 +244,19 @@ void CodeGenMetal::VisitExpr_(const Broadcast* op, std::ostream& os) {   // NOLI
     os << v;
   }
   os << ')';
+}
+
+void CodeGenMetal::VisitExpr_(const Call* op, std::ostream& os) {  // NOLINT(*)
+  if (op->is_intrinsic(Call::reinterpret)) {
+    // generate as_type<TYPE>(ARG)
+    os << "(as_type<";
+    this->PrintType(op->type, os);
+    os << ">(";
+    this->PrintExpr(op->args[0], os);
+    os << "))";
+  } else {
+    CodeGenC::VisitExpr_(op, os);
+  }
 }
 
 runtime::Module BuildMetal(Array<LoweredFunc> funcs) {

--- a/src/codegen/codegen_metal.h
+++ b/src/codegen/codegen_metal.h
@@ -53,6 +53,9 @@ class CodeGenMetal final : public CodeGenC {
   // overload visitor
   void VisitExpr_(const Broadcast* op, std::ostream& os) final; // NOLINT(*)
 
+  // overload visitor
+  void VisitExpr_(const Call* op, std::ostream& os) final; // NOLINT(*)
+
  private:
   int thread_index_bits_{32};
 };


### PR DESCRIPTION
The correct way to do this is the Metal-specific `as_type<T>(arg)`. See "2.14 Type Conversions and Re-interpreting Data" in https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf.


```
∴ nosetests -v ./topi/tests/python/test_topi_transform.py -m test_reinterpret
-- Build with RPC support...
test_topi_transform.test_reinterpret ... [17:33:36] /Users/tulloch/src/tvm/src/runtime/metal/metal_device_api.mm:136: Intializing Metal device 0, name=Intel Iris Pro Graphics
ok

----------------------------------------------------------------------
Ran 1 test in 0.352s

OK
```