### PR TITLE
[VTA] Remove Unused Headers in VTA Runtime

### DIFF
--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -34,9 +34,7 @@
 #include <cassert>
 #include <cstring>
 #include <vector>
-#include <thread>
 #include <memory>
-#include <atomic>
 
 namespace vta {
 


### PR DESCRIPTION
An experiment that shows thread related headers can be removed safely.