### PR TITLE
[TOPI][FIX] Typo in schedule template for conv2d_direct (#3648)

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -39,7 +39,7 @@ PACKAGE_VERSION = {
     'arm_cpu': "v0.04",
     'llvm':    "v0.03",
 
-    'cuda':    "v0.04",
+    'cuda':    "v0.05",
     'rocm':    "v0.02",
     'opencl':  "v0.02",
     'mali':    "v0.05",

--- a/topi/python/topi/cuda/conv2d_direct.py
+++ b/topi/python/topi/cuda/conv2d_direct.py
@@ -90,8 +90,8 @@ def schedule_direct_cuda(cfg, s, conv):
     n, f, y, x = s[OL].op.axis
     rc, ry, rx = s[OL].op.reduce_axis
     rco, rci = cfg['tile_rc'].apply(s, OL, rc)
-    ryo, ryi = cfg['tile_rx'].apply(s, OL, ry)
-    rxo, rxi = cfg['tile_ry'].apply(s, OL, rx)
+    ryo, ryi = cfg['tile_ry'].apply(s, OL, ry)
+    rxo, rxi = cfg['tile_rx'].apply(s, OL, rx)
     s[OL].reorder(rco, ryo, rxo, rci, ryi, rxi, n, f, y, x)
 
     s[AA].compute_at(s[OL], rxo)


### PR DESCRIPTION
    * Fix the tile_rx and tile_ry issue.

    Note that this patch depends on pull request #9 in tvm-distro.

    Please review. Thanks.
