### PR TITLE
Remove sccache from Rust install

### DIFF
--- a/docker/Dockerfile.ci_cpu
+++ b/docker/Dockerfile.ci_cpu
@@ -43,7 +43,6 @@ COPY install/ubuntu_install_rust.sh /install/ubuntu_install_rust.sh
 RUN bash /install/ubuntu_install_rust.sh
 ENV RUSTUP_HOME /opt/rust
 ENV CARGO_HOME /opt/rust
-ENV RUSTC_WRAPPER sccache
 
 # AutoTVM deps
 COPY install/ubuntu_install_redis.sh /install/ubuntu_install_redis.sh

--- a/docker/install/ubuntu_install_rust.sh
+++ b/docker/install/ubuntu_install_rust.sh
@@ -28,7 +28,6 @@ export CARGO_HOME=/opt/rust
 curl -s -S -L https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain nightly-2019-03-24
 . $CARGO_HOME/env
 rustup component add rustfmt
-cargo install sccache --no-default-features
 
 # make rust usable by all users
 chmod -R a+w /opt/rust


### PR DESCRIPTION
resolves #3696

While removing sccache is somewhat of a blunt hammer, rustc incremental builds have gotten pretty good such that it can be more complication than it's worth. Once #2885 lands (it's ready; just needs some testing, so hopefully this week) we can update the nightly version or move to stable, if possible, to benefit from better incremental builds.