### PR TITLE
Fix extent one for the post_stmt in loop partition

### DIFF
--- a/tests/python/unittest/test_pass_bound_checkers.py
+++ b/tests/python/unittest/test_pass_bound_checkers.py
@@ -37,6 +37,7 @@ def lower(sch, args):
     bounds = tvm.schedule.InferBound(sch)
     stmt = tvm.schedule.ScheduleOps(sch, bounds)
     stmt = tvm.ir_pass.LoopPartition(stmt, True)
+    stmt = tvm.ir_pass.RemoveNoOp(stmt)
     stmt = tvm.ir_pass.StorageFlatten(stmt, binds, 64, True)
     stmt = tvm.ir_pass.CanonicalSimplify(stmt)
     stmt = tvm.ir_pass.VectorizeLoop(stmt)

--- a/topi/tests/python/test_topi_math.py
+++ b/topi/tests/python/test_topi_math.py
@@ -69,8 +69,16 @@ def test_ewise():
             foo(a, b)
             tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5, atol=1e-5)
 
-        for device in get_all_backend():
-            check_device(device)
+        check_device('llvm')
+        check_device('cuda')
+        check_device('opencl')
+        check_device('metal')
+        check_device('rocm')
+        check_device('vulkan')
+        check_device('nvptx')
+        check_device('llvm -device=arm-cpu')
+        check_device('opencl -device=mali')
+        check_device('aocl_sw_emu')
 
     def test_isnan(
         low,
@@ -109,8 +117,16 @@ def test_ewise():
             foo(a, b)
             tvm.testing.assert_allclose(b.asnumpy(), b_np, rtol=1e-5, atol=1e-5)
 
-        for device in get_all_backend():
-            check_device(device)
+        check_device('llvm')
+        check_device('cuda')
+        check_device('opencl')
+        check_device('metal')
+        check_device('rocm')
+        check_device('vulkan')
+        check_device('nvptx')
+        check_device('llvm -device=arm-cpu')
+        check_device('opencl -device=mali')
+        check_device('aocl_sw_emu')
 
     test_apply(topi.floor, "floor", np.floor, -100, 100)
     test_apply(topi.ceil, "ceil", np.ceil, -100, 100)


### PR DESCRIPTION
- solves #3733 
- removes redundant condition check for `pre_stmt` and `post_stmt`