### PR TITLE
Revert compile_cmd kwarg name change

### DIFF
--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -27,7 +27,7 @@ from .util import tempdir
 def create_shared(output,
                   objects,
                   options=None,
-                  compile_cmd="g++"):
+                  cc="g++"):
     """Create shared library.
 
     Parameters
@@ -41,11 +41,11 @@ def create_shared(output,
     options : List[str]
         The list of additional options string.
 
-    compile_cmd : Optional[str]
+    cc : Optional[str]
         The compiler command.
     """
     if sys.platform == "darwin" or sys.platform.startswith("linux"):
-        _linux_compile(output, objects, options, compile_cmd)
+        _linux_compile(output, objects, options, cc)
     elif sys.platform == "win32":
         _windows_shared(output, objects, options)
     else:

--- a/tests/python/contrib/test_binutil.py
+++ b/tests/python/contrib/test_binutil.py
@@ -43,7 +43,7 @@ def make_binary():
     with open(tmp_source, "w") as f:
         f.write(prog)
     cc.create_shared(tmp_obj, tmp_source, [],
-                     compile_cmd="{}gcc".format(TOOLCHAIN_PREFIX))
+                     cc="{}gcc".format(TOOLCHAIN_PREFIX))
     prog_bin = bytearray(open(tmp_obj, "rb").read())
     return prog_bin
 


### PR DESCRIPTION
In #3227, I accidentally made a breaking change in a public API (that somehow wasn't picked up by the CI tests).  Discussion can be found [here](https://discuss.tvm.ai/t/lib-export-library-cc-param-was-renamed-to-compile-cmd/3644).

CC @apivovarov @tqchen