### PR TITLE
[Relay] Fix the potential index overflow

### DIFF
--- a/src/relay/op/tensor/transform.cc
+++ b/src/relay/op/tensor/transform.cc
@@ -1451,9 +1451,10 @@ bool WhereRel(const Array<Type>& types,
     CHECK(reporter->AssertEQ(x_shape[i], y_shape[i]))
         << "x and y must have the same shape: " << x_shape << " vs " << y_shape;
 
-    CHECK(reporter->AssertEQ(cond_shape[i], x_shape[i]))
-        << "Shape of condition " << condition->shape
-        << " must be either equal to x or has dimension of 1.";
+    if (i < cond_shape.size()) {
+        CHECK(reporter->AssertEQ(cond_shape[i], x_shape[i]))
+        << "condition and x must have the same shape: " << cond_shape << " vs " << x_shape;
+    }
   }
   reporter->Assign(types[3], TensorTypeNode::make(x_shape, x->dtype));
   return true;


### PR DESCRIPTION
Hi @tqchen @YPBlib 

Following the issue [3652](https://github.com/dmlc/tvm/issues/3652), I add the additional check to make sure that the cond_shape would only be checked when the index i small than cond_shape and x_shape both in order to avoid a case when cond_shape.size() == 1 but x_shape.size is not.
