### PR TITLE
[TOPI] Update tophub according to the fix in schedule (opencl and rocm)

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -40,8 +40,8 @@ PACKAGE_VERSION = {
     'llvm':    "v0.03",
 
     'cuda':    "v0.05",
-    'rocm':    "v0.02",
-    'opencl':  "v0.02",
+    'rocm':    "v0.03",
+    'opencl':  "v0.03",
     'mali':    "v0.05",
 
     'vta':     "v0.06",


### PR DESCRIPTION
This is the follow up of https://github.com/dmlc/tvm/pull/3717
We also have to update for opencl and rocm, because opencl and rocm uses cuda templates.