### PR TITLE
 [ARITH] Simplify casts of constants 0 and 1

### DIFF
--- a/include/tvm/expr_operator.h
+++ b/include/tvm/expr_operator.h
@@ -105,6 +105,16 @@ inline const uint64_t* as_const_uint(const Expr& x) {
 inline bool is_const_int(const Expr& x, int64_t value);
 
 /*!
+ * \brief Check if the given expr is a const of any type equal to the given integer value.
+ * \param e The expression.
+ * \param value The value to compare to.
+ * \return Whether the expression is a const equal to the value.
+ * \tparam ValueType The value type
+ */
+template <typename ValueType>
+inline bool is_const_value(const Expr& e, ValueType value);
+
+/*!
  * \brief Check whether stmt is nop.
  * \param stmt The input statement
  * \return whether stmt is nop
@@ -551,18 +561,31 @@ inline bool is_negative_const(const Expr& a) {
   }
 }
 
+template <typename ValueType>
+inline bool is_const_value(const Expr& e, ValueType value) {
+  static_assert(std::is_integral<ValueType>::value,
+                "Comparison to non-integer values is forbidden.");
+  // This implementation was copy-pasted from HalideIR
+  if (const ir::IntImm* i = e.as<ir::IntImm>()) {
+    return i->value == value;
+  } else if (const ir::UIntImm* i = e.as<ir::UIntImm>()) {
+    return (value >= 0) && (i->value == static_cast<uint64_t>(value));
+  } else if (const ir::FloatImm* i = e.as<ir::FloatImm>()) {
+    return i->value == value;
+  } else if (const ir::Cast* c = e.as<ir::Cast>()) {
+    return is_const_value(c->value, value);
+  } else if (const ir::Broadcast* b = e.as<ir::Broadcast>()) {
+    return is_const_value(b->value, value);
+  } else {
+    return false;
+  }
+}
+
 inline bool is_const_int(const Expr& x, int64_t value) {
-  if (const auto* op = x.as<ir::IntImm>()) {
-    return op->value == value;
-  } else if (const auto* op = x.as<ir::UIntImm>()) {
-    return op->value == static_cast<uint64_t>(value);
+  if (x.as<ir::IntImm>() || x.as<ir::UIntImm>()) {
+    return is_const_value(x, value);
   } else if (const auto* op = x.as<ir::Broadcast>()) {
-    const Expr& val = op->value;
-    if (const auto* opv = val.as<ir::IntImm>()) {
-      return opv->value == value;
-    } else if (const auto* opv = val.as<ir::UIntImm>()) {
-      return opv->value == static_cast<uint64_t>(value);
-    }
+    return !op->value.as<ir::Broadcast>() && is_const_int(op->value, value);
   }
   return false;
 }

--- a/include/tvm/expr_operator.h
+++ b/include/tvm/expr_operator.h
@@ -105,16 +105,6 @@ inline const uint64_t* as_const_uint(const Expr& x) {
 inline bool is_const_int(const Expr& x, int64_t value);
 
 /*!
- * \brief Check if the given expr is a const of any type equal to the given integer value.
- * \param e The expression.
- * \param value The value to compare to.
- * \return Whether the expression is a const equal to the value.
- * \tparam ValueType The value type
- */
-template <typename ValueType>
-inline bool is_const_value(const Expr& e, ValueType value);
-
-/*!
  * \brief Check whether stmt is nop.
  * \param stmt The input statement
  * \return whether stmt is nop
@@ -561,31 +551,18 @@ inline bool is_negative_const(const Expr& a) {
   }
 }
 
-template <typename ValueType>
-inline bool is_const_value(const Expr& e, ValueType value) {
-  static_assert(std::is_integral<ValueType>::value,
-                "Comparison to non-integer values is forbidden.");
-  // This implementation was copy-pasted from HalideIR
-  if (const ir::IntImm* i = e.as<ir::IntImm>()) {
-    return i->value == value;
-  } else if (const ir::UIntImm* i = e.as<ir::UIntImm>()) {
-    return (value >= 0) && (i->value == static_cast<uint64_t>(value));
-  } else if (const ir::FloatImm* i = e.as<ir::FloatImm>()) {
-    return i->value == value;
-  } else if (const ir::Cast* c = e.as<ir::Cast>()) {
-    return is_const_value(c->value, value);
-  } else if (const ir::Broadcast* b = e.as<ir::Broadcast>()) {
-    return is_const_value(b->value, value);
-  } else {
-    return false;
-  }
-}
-
 inline bool is_const_int(const Expr& x, int64_t value) {
-  if (x.as<ir::IntImm>() || x.as<ir::UIntImm>()) {
-    return is_const_value(x, value);
+  if (const auto* op = x.as<ir::IntImm>()) {
+    return op->value == value;
+  } else if (const auto* op = x.as<ir::UIntImm>()) {
+    return op->value == static_cast<uint64_t>(value);
   } else if (const auto* op = x.as<ir::Broadcast>()) {
-    return !op->value.as<ir::Broadcast>() && is_const_int(op->value, value);
+    const Expr& val = op->value;
+    if (const auto* opv = val.as<ir::IntImm>()) {
+      return opv->value == value;
+    } else if (const auto* opv = val.as<ir::UIntImm>()) {
+      return opv->value == static_cast<uint64_t>(value);
+    }
   }
   return false;
 }

--- a/src/arithmetic/rewrite_simplify.cc
+++ b/src/arithmetic/rewrite_simplify.cc
@@ -1757,6 +1757,20 @@ Mutate_(const Variable* op, const Expr& self) {
   return self;
 }
 
+Expr RewriteSimplifier::Impl::
+Mutate_(const Cast* op, const Expr& self) {
+  Expr ret = IRMutator::Mutate_(op, self);
+  op = ret.as<Cast>();
+  // 0 and 1 are very common and useful for simplification
+  if (is_const_value(op->value, 0)) {
+    return make_const(op->type, 0);
+  }
+  if (is_const_value(op->value, 1)) {
+    return make_const(op->type, 1);
+  }
+  return ret;
+}
+
 Expr RewriteSimplifier::operator()(const Expr& expr) {
   // Run simplification in post order
   Expr res = expr;

--- a/src/arithmetic/rewrite_simplify.cc
+++ b/src/arithmetic/rewrite_simplify.cc
@@ -1761,14 +1761,7 @@ Expr RewriteSimplifier::Impl::
 Mutate_(const Cast* op, const Expr& self) {
   Expr ret = IRMutator::Mutate_(op, self);
   op = ret.as<Cast>();
-  // 0 and 1 are very common and useful for simplification
-  if (is_const_value(op->value, 0)) {
-    return make_const(op->type, 0);
-  }
-  if (is_const_value(op->value, 1)) {
-    return make_const(op->type, 1);
-  }
-  return ret;
+  return cast(op->type, op->value);
 }
 
 Expr RewriteSimplifier::operator()(const Expr& expr) {

--- a/src/arithmetic/rewrite_simplify.h
+++ b/src/arithmetic/rewrite_simplify.h
@@ -70,6 +70,7 @@ class RewriteSimplifier::Impl : public IRMutator {
   Expr Mutate_(const Call* op, const Expr& self) override;
   Expr Mutate_(const Let* op, const Expr& self) override;
   Expr Mutate_(const Variable* op, const Expr& self) override;
+  Expr Mutate_(const Cast* op, const Expr& self) override;
 
  protected:
   /*! \brief internal structure for comparison. */

--- a/src/lang/expr_operator.cc
+++ b/src/lang/expr_operator.cc
@@ -105,11 +105,14 @@ bool is_const_power_of_two_integer(const Expr& x, int* shift) {
 
 Expr cast(const Type& t, Expr value) {
   using ir::IntImm;
+  using ir::UIntImm;
   using ir::FloatImm;
   if (value.type() == t) return value;
   // const fold IntImm as they are used in index computations
   if (t.lanes() == 1) {
     if (const IntImm* op = value.as<IntImm>()) {
+      return make_const(t, op->value);
+    } else if (const UIntImm* op = value.as<UIntImm>()) {
       return make_const(t, op->value);
     } else if (const FloatImm* op = value.as<FloatImm>()) {
       return make_const(t, op->value);
@@ -122,6 +125,8 @@ Expr cast(const Type& t, Expr value) {
       if (value.type() != vtype) {
         if (const IntImm* op = value.as<IntImm>()) {
           value = make_const(vtype, op->value);
+        } else if (const UIntImm* op = value.as<UIntImm>()) {
+          return make_const(t, op->value);
         } else if (const FloatImm* op = value.as<FloatImm>()) {
           value = make_const(vtype, op->value);
         } else {

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -813,8 +813,8 @@ def test_cast_simplify():
         ck.verify(tvm.expr.Cast(dtype1, x - x), tvm.const(0, dtype1))
         ck.verify(tvm.expr.Cast(dtype1, x == x), tvm.const(1, dtype1))
         for dtype2 in dtypes:
-            ck.verify(tvm.expr.Cast(dtype1, tvm.const(0, dtype2)), tvm.const(0, dtype1))
-            ck.verify(tvm.expr.Cast(dtype1, tvm.const(1, dtype2)), tvm.const(1, dtype1))
+            for i in [0, 1, 2, 3]:
+                ck.verify(tvm.expr.Cast(dtype1, tvm.const(i, dtype2)), tvm.const(i, dtype1))
 
 if __name__ == "__main__":
     test_floordiv_index_simplify()

--- a/tests/python/unittest/test_arith_rewrite_simplify.py
+++ b/tests/python/unittest/test_arith_rewrite_simplify.py
@@ -804,6 +804,18 @@ def test_let_simplify():
     z = tvm.expr.Let(x, 1, x + 1)
     ck.verify(z + z, 4)
 
+def test_cast_simplify():
+    ck = RewriteChecker()
+    x = tvm.var("x")
+
+    dtypes = ["float32", "float16", "int32", "int8", "bool"]
+    for dtype1 in dtypes:
+        ck.verify(tvm.expr.Cast(dtype1, x - x), tvm.const(0, dtype1))
+        ck.verify(tvm.expr.Cast(dtype1, x == x), tvm.const(1, dtype1))
+        for dtype2 in dtypes:
+            ck.verify(tvm.expr.Cast(dtype1, tvm.const(0, dtype2)), tvm.const(0, dtype1))
+            ck.verify(tvm.expr.Cast(dtype1, tvm.const(1, dtype2)), tvm.const(1, dtype1))
+
 if __name__ == "__main__":
     test_floordiv_index_simplify()
     test_floormod_index_simplify()
@@ -819,3 +831,4 @@ if __name__ == "__main__":
     test_select_simplify()
     test_logical_simplify()
     test_let_simplify()
+    test_cast_simplify()


### PR DESCRIPTION
This PR implements simplification of some casts of constants in the rewrite simplifier. The use case I have in mind is conversion from boolean expressions to floats (`float32(i < j)` instead of `select(i < k, 1.0, 0.0)`). I restricted consts to be just 0 and 1 because I'm not sure about usefulness and safety of other values (0 and 1 should be safe for all types, except maybe for some custom types).

This PR also introduces the `is_const_value` functions which is like `is_const_int`, but works for float expressions too. Besides this PR, it is also used in the tensor expression autodiff implementation.