### PR TITLE
Fixed onnx test failures when run on a cpu backend

### DIFF
--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1083,8 +1083,11 @@ def check_torch_conversion(model, input_size):
     # Set verbose=True for more output
     torch.onnx.export(model(), dummy_input, file_name, export_params=True, verbose=False)
     onnx_model = onnx.load(file_name)
-    shapes = { onnx_model.graph.input[0].name : input_size }
-    expr, params = relay.frontend.from_onnx(onnx_model, shape=shapes)
+    for target, ctx in ctx_list():
+        input_data = np.random.uniform(size=input_size).astype('int32')
+        c2_out = get_caffe2_output(onnx_model, input_data)
+        tvm_out = get_tvm_output(onnx_model, input_data, target, ctx)
+        tvm.testing.assert_allclose(c2_out, tvm_out)
 
 def test_resnet():
     check_torch_conversion(torchvision.models.resnet18, (1,3,224,224))

--- a/tests/python/frontend/onnx/test_forward.py
+++ b/tests/python/frontend/onnx/test_forward.py
@@ -1083,7 +1083,7 @@ def check_torch_conversion(model, input_size):
     # Set verbose=True for more output
     torch.onnx.export(model(), dummy_input, file_name, export_params=True, verbose=False)
     onnx_model = onnx.load(file_name)
-    shapes = { '0' : input_size }
+    shapes = { onnx_model.graph.input[0].name : input_size }
     expr, params = relay.frontend.from_onnx(onnx_model, shape=shapes)
 
 def test_resnet():


### PR DESCRIPTION
One of the error message we're seeing:

`ERROR: test_forward.test_inception Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/workspace/tests/python/frontend/onnx/test_forward.py", line 1109, in test_inception
    check_torch_conversion(torchvision.models.inception_v3, (1,3,224,224))
  File "/workspace/tests/python/frontend/onnx/test_forward.py", line 1086, in check_torch_conversion
    expr, params = relay.frontend.from_onnx(onnx_model, shape=shapes)
  File "/workspace/python/tvm/relay/frontend/onnx.py", line 1263, in from_onnx
    mod, params = g.from_onnx(graph, opset)
  File "/workspace/python/tvm/relay/frontend/onnx.py", line 1042, in from_onnx
    raise ValueError("Must provide an input shape for `{0}`.".format(i_name))
ValueError: Must provide an input shape for 'input.1'.`
