### PR TITLE
[IntSet] Avoid overly pessimizing while recursively evaluating bounds

### DIFF
--- a/src/arithmetic/int_set.cc
+++ b/src/arithmetic/int_set.cc
@@ -375,7 +375,9 @@ class IntervalSetEvaluator :
     IntervalSet min_set = this->Eval(val->min_value);
     IntervalSet max_set = this->Eval(val->max_value);
     --recur_depth_;
-    return IntervalSet(min_set->min_value, max_set->max_value);
+    return IntervalSet(
+        min_set->IsEverything() && !val->IsEverything() ? val->min_value : min_set->min_value,
+        max_set->IsEverything() && !val->IsEverything() ? val->max_value : max_set->max_value);
   }
 
   IntervalSet VisitExpr_(const IntImm* op) final {


### PR DESCRIPTION
Proposed solution for (part of) https://github.com/dmlc/tvm/issues/3770.

This doesn't solve the whole problem but helps a bit in some cases. I would much prefer a better solution, possibly the one in https://github.com/ajtulloch/tvm/commit/ca1088c63c51e14a9d3c02df7eaa44fd60c23ce4.

Reproduction:

```
import tvm

n = tvm.var('n')
X = tvm.placeholder(shape=(n,), name="x")
W = tvm.placeholder(shape=(n + 1,), dtype="int32", name="w")

def f(i):
    start = W[i]
    extent = W[i+1] - W[i]
    rv = tvm.reduce_axis((0, extent))
    return tvm.sum(X[rv + start], axis=rv)
Y = tvm.compute(X.shape, f, name="y")
s = tvm.create_schedule([Y.op])
print(tvm.lower(s, [X, W, Y], simple_mode=True))
```

Before:

```
produce y {
  for (i, 0, n) {
    y[i] = 0f
    for (rv, 0, (w[(i + 1)] - w[i])) {
      if ((rv < (w[(i + 1)] - w[i]))) {
        y[i] = (y[i] + x[(rv + w[i])])
      }
    }
  }
}
```

After:

```
produce y {
  for (i, 0, n) {
    y[i] = 0.000000f
    for (rv, 0, (w[(i + 1)] - w[i])) {
      y[i] = (y[i] + x[(w[i] + rv)])
    }
  }
}
```