### PR TITLE
[ARITH] Add support for `EQ` op in the deduce bound and the loop partition

### DIFF
--- a/src/pass/loop_partition.cc
+++ b/src/pass/loop_partition.cc
@@ -226,8 +226,6 @@ class PartitionFinder : public IRVisitor {
 
  private:
   Expr InverseCond(const Expr& cond) {
-    // We expect most condition not to be of EQ or NE form.
-    // Currently we do not handle inversing EQ or NE.
     Expr inverse_cond;
     if (const LT* op = cond.as<LT>()) {
       // a < b -> a >= b
@@ -241,6 +239,12 @@ class PartitionFinder : public IRVisitor {
     } else if (const GE* op = cond.as<GE>()) {
       // a >= b -> a < b
       inverse_cond = LT::make(op->a, op->b);
+    } else if (const EQ* op = cond.as<EQ>()) {
+      // a == b -> a != b
+      inverse_cond = NE::make(op->a, op->b);
+      // a != b -> a == b
+    } else if (const NE* op = cond.as<NE>()) {
+      inverse_cond = EQ::make(op->a, op->b);
     }
     return inverse_cond;
   }

--- a/tests/python/unittest/test_pass_loop_partition.py
+++ b/tests/python/unittest/test_pass_loop_partition.py
@@ -171,6 +171,18 @@ def test_condition():
     stmt = tvm.ir_pass.Simplify(stmt)
     assert(not any(collect_visit(stmt.first, lambda x: isinstance(x, tvm.expr.Select))))
 
+def test_condition_EQ():
+    ib = tvm.ir_builder.create()
+    m = tvm.var('m')
+    n = tvm.var('n')
+    with ib.for_range(0, 10, 'i') as i:
+            ib.emit(tvm.make.Evaluate(
+                tvm.make.Select(ib.likely(tvm.expr.EQ(i, 5)), m, n)))
+    stmt = ib.get()
+    stmt = tvm.ir_pass.LoopPartition(stmt, True)
+    stmt = tvm.ir_pass.Simplify(stmt)
+    assert(not any(collect_visit(stmt.first, lambda x: isinstance(x, tvm.expr.Select))))
+
 def test_thread_axis2():
     n = tvm.convert(4096)
     m = tvm.var('m')
@@ -420,6 +432,7 @@ if __name__ == "__main__":
     test_thread_axis()
     test_vectorize()
     test_condition()
+    test_condition_EQ()
     test_thread_axis2()
     test_everything_during_deduction()
     test_single_likely()


### PR DESCRIPTION
Solves #3774 

Adds support for `EQ` op in the deduce bound. 

The main check required for `EQ` is that both LHS and RHS should be constant at the time of relaxing them. e.g. for `(i==j)` then, both `EvalSet` over 
`i` and `j` both should be a single point.  In other words, `EQ` condition can not be resolved if one of the operands is variable. 

Secondly, for `EQ` with multiplication where there is no perfect division, e.g `(4 * i == 10)` can not be solved because division truncation will change one of the operands. 

This PR extends `DeduceBound` for `EQ` and adds unittests for the same. 

LoopPartition uses the deduce_bound and with `EQ` support, LoopPartition is also changed to partition based on `EQ` conditions. Unittest for the same is added. 
