### PR TITLE
[Vulkan] Vulkan backend supports Call::reinterpret and vectorized comparison.

### DIFF
--- a/src/codegen/spirv/codegen_spirv.cc
+++ b/src/codegen/spirv/codegen_spirv.cc
@@ -283,6 +283,9 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const Call* op) {
     } else {
       return builder_->MakeValue(spv::OpShiftRightLogical, a.stype, a, b);
     }
+  } else if (op->is_intrinsic(Call::reinterpret)) {
+    return builder_->MakeValue(spv::OpBitcast, builder_->GetSType(op->type),
+                               MakeValue(op->args[0]));
   } else if (op->is_intrinsic(intrinsic::tvm_storage_sync)) {
     return this->CreateStorageSync(op);
   } else if (op->is_intrinsic(intrinsic::tvm_if_then_else)) {

--- a/tests/python/unittest/test_codegen_vulkan.py
+++ b/tests/python/unittest/test_codegen_vulkan.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+import re
+
+
+def test_vector_comparison():
+    if not tvm.module.enabled("vulkan"):
+        print("Skipping due to no Vulkan module")
+        return
+
+    target = 'vulkan'
+
+    def check_correct_assembly(dtype):
+        n = (1024,)
+        A = tvm.placeholder(n, dtype=dtype, name='A')
+        B = tvm.compute(
+            A.shape,
+            lambda i: tvm.expr.Select(
+                A[i] >= 0, A[i] + tvm.const(1, dtype),
+                tvm.const(0, dtype)), name='B')
+        s = tvm.create_schedule(B.op)
+
+        (bx, tx) = s[B].split(s[B].op.axis[0], factor=128)
+        (tx, vx) = s[B].split(tx, factor=4)
+        s[B].bind(bx, tvm.thread_axis("blockIdx.x"))
+        s[B].bind(tx, tvm.thread_axis("threadIdx.x"))
+        s[B].vectorize(vx)
+        f = tvm.build(s, [A, B], target)
+
+        # Verify we generate the boolx4 type declaration and the OpSelect
+        # v4{float,half,int} instruction
+        assembly = f.imported_modules[0].get_source()
+        matches = re.findall("%v4bool = OpTypeVector %bool 4", assembly)
+        assert len(matches) == 1
+        matches = re.findall("OpSelect %v4.*", assembly)
+        assert len(matches) == 1
+    check_correct_assembly('float32')
+    check_correct_assembly('int32')
+    check_correct_assembly('float16')
+
+
+if __name__ == "__main__":
+    test_vector_comparison()


### PR DESCRIPTION
See unit test. This allows us to generate vectorized code for common pointwise operations, which is helpful on some platforms. For e.g. Metal, this lowers to `select(true, false, cond)`, glsl to the vectorized versions, etc. This fixes a bug where we'd unconditionally set the result type of comparison operations to a scalar boolean, which leads to failures downstream.

From the SPIR-V specification, vectorized selections (and comparisons) are explicitly supported.

```
OpSelect

Select between two objects.

Result Type must be a scalar or vector.

The type of Object 1 must be the same as Result Type. Object 1 is selected as the result if Condition is true.

The type of Object 2 must be the same as Result Type. Object 2 is selected as the result if Condition is false.

Condition must be a scalar or vector of Boolean type. 

It must have the same number of components as Result Type.

Results are computed per component.
```
 
and 

```
OpUGreaterThan

Unsigned-integer comparison if Operand 1 is greater than Operand 2.

Result Type must be a scalar or vector of Boolean type. 

The type of Operand 1 and Operand 2 must be a scalar or vector of integer type. 

They must have the same component width, and they must have the same number of components as Result Type. 

Results are computed per component.
```
 



