### PR TITLE
[CI] Solve occasional CI issue when pad value is all 0

### DIFF
--- a/python/tvm/relay/frontend/coreml.py
+++ b/python/tvm/relay/frontend/coreml.py
@@ -74,10 +74,11 @@ def _ConvolutionLayerParams(op, inexpr, etab):
             pad_l = valid.paddingAmounts.borderAmounts[1].startEdgeSize
             pad_b = valid.paddingAmounts.borderAmounts[0].endEdgeSize
             pad_r = valid.paddingAmounts.borderAmounts[1].endEdgeSize
-            inexpr = _op.nn.pad(data=inexpr, pad_width=((0, 0),
-                                                        (0, 0),
-                                                        (pad_t, pad_b),
-                                                        (pad_l, pad_r)))
+            if not all(v == 0 for v in (pad_t, pad_l, pad_b, pad_r)):
+                inexpr = _op.nn.pad(data=inexpr, pad_width=((0, 0),
+                                                            (0, 0),
+                                                            (pad_t, pad_b),
+                                                            (pad_l, pad_r)))
     elif op.WhichOneof('ConvolutionPaddingType') == 'same':
         assert op.same.asymmetryMode == 0, "Only support BOTTOM_RIGHT_HEAVY mode, " \
                                            "which is used by tf/caffe and so on"
@@ -208,7 +209,8 @@ def _PoolingLayerParams(op, inexpr, etab):
                 pad_l = valid.paddingAmounts.borderAmounts[1].startEdgeSize
                 pad_b = valid.paddingAmounts.borderAmounts[0].endEdgeSize
                 pad_r = valid.paddingAmounts.borderAmounts[1].endEdgeSize
-                params['padding'] = [pad_t, pad_l, pad_b, pad_r]
+                if not all(v == 0 for v in (pad_t, pad_l, pad_b, pad_r)):
+                    params['padding'] = [pad_t, pad_l, pad_b, pad_r]
         elif op.WhichOneof('PoolingPaddingType') == 'includeLastPixel':
             # I don't know if this is correct
             valid = op.includeLastPixel

--- a/tests/python/frontend/coreml/model_zoo/__init__.py
+++ b/tests/python/frontend/coreml/model_zoo/__init__.py
@@ -20,5 +20,7 @@ def get_cat_image():
     dst = 'cat.png'
     real_dst = download_testdata(url, dst, module='data')
     img = Image.open(real_dst).resize((224, 224))
-    img = np.transpose(img, (2, 0, 1))[np.newaxis, :]
+    # CoreML's standard model image format is BGR
+    img_bgr = np.array(img)[:, :, ::-1]
+    img = np.transpose(img_bgr, (2, 0, 1))[np.newaxis, :]
     return np.asarray(img)


### PR DESCRIPTION
When we insert nn.pad if pad value is all 0, our CI (CUDA) sometimes will raise the layout problem. (I reproduce it after I tried ~100 times in my local machine). see more detail https://github.com/dmlc/tvm/pull/3800#issuecomment-522476488 

Also correct the image format from RGB to BGR for CoreML model.

@tqchen 
