### PR TITLE
[TEST] Not assuming HOME in tvm/download.py

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -113,3 +113,4 @@ We do encourage everyone to work anything they are interested in.
 - [Cody Hao Yu](https://github.com/comaniac)
 - [Chris Nuernberger](https://github.com/cnuernber)
 - [Shoubhik Bhattacharya](https://github.com/shoubhik)
+- [Neo Chien](https://github.com/cchung100m)

--- a/python/tvm/contrib/download.py
+++ b/python/tvm/contrib/download.py
@@ -119,7 +119,10 @@ def download(url, path, overwrite=False, size_compare=False, verbose=1, retries=
                       .format(repr(err), retries, 's' if retries > 1 else ''))
 
 
-TEST_DATA_ROOT_PATH = os.path.join(os.path.expanduser('~'), '.tvm_test_data')
+if "TEST_DATA_ROOT_PATH" in os.environ:
+    TEST_DATA_ROOT_PATH = os.environ.get("TEST_DATA_ROOT_PATH")
+else:
+    TEST_DATA_ROOT_PATH = os.path.join(os.path.expanduser('~'), '.tvm_test_data')
 os.makedirs(TEST_DATA_ROOT_PATH, exist_ok=True)
 
 


### PR DESCRIPTION
Hi @tqchen,

Following issue #3759, I add the **TEST_DATA_ROOT_PATH** configurable through environment variable and default to the original one if the environment variable is not set.

I would appreciate if you could help to review/manage this PR, thank you.