### PR TITLE
Fix AMD GPU architecture Detection

### DIFF
--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -46,7 +46,7 @@ def find_lld(required=True):
         major = codegen.llvm_version_major()
         lld_list += ["ld.lld-%d.0" % major]
         lld_list += ["ld.lld-%d" % major]
-    lld_list += ["lld"]
+    lld_list += ["ld.lld"]
     valid_list = [util.which(x) for x in lld_list]
     valid_list = [x for x in valid_list if x]
     if not valid_list and required:


### PR DESCRIPTION
The PR 

- Implement logic to detect different gcn architecture for AMD ROCm backend; instead of string parsing or using a default value 
- Fix find-lld()

Change is verified with tutorials(relay_quick_start/tensor_expr_get_started with rocm related change ) on ROCm 2.6 and gfx803/gfx900/gfx906.

Feedbacks are welcome!