### PR TITLE
[Relay, TOPI] add onehot op support

### DIFF
--- a/include/tvm/relay/attrs/transform.h
+++ b/include/tvm/relay/attrs/transform.h
@@ -298,6 +298,18 @@ struct NdarraySizeAttrs : public tvm::AttrsNode<NdarraySizeAttrs> {
   }
 };
 
+/*! \brief Attributes used in one_hot operators */
+struct OneHotAttrs : public tvm::AttrsNode<OneHotAttrs> {
+  Integer depth;
+  Integer axis;
+
+  TVM_DECLARE_ATTRS(OneHotAttrs, "relay.attrs.OneHotAttrs") {
+    TVM_ATTR_FIELD(depth).set_default(NullValue<Integer>())
+        .describe("Defining the depth of the one hot dimension.");
+    TVM_ATTR_FIELD(axis).set_default(-1)
+        .describe("The axis at which the input arrays are expand dims.");
+  }
+};  // struct OneHotAttrs
 }  // namespace relay
 }  // namespace tvm
 #endif  // TVM_RELAY_ATTRS_TRANSFORM_H_

--- a/python/tvm/relay/op/_transform.py
+++ b/python/tvm/relay/op/_transform.py
@@ -52,7 +52,7 @@ _reg.register_schedule("concatenate", schedule_concatenate)
 _reg.register_schedule("_contrib_reverse_reshape", schedule_injective)
 _reg.register_schedule("gather_nd", schedule_injective)
 _reg.register_schedule("sequence_mask", schedule_injective)
-
+_reg.register_schedule("one_hot", schedule_injective)
 
 # layout_transform
 _reg.register_schedule("layout_transform", schedule_injective)

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -264,3 +264,8 @@ class MaxPool2DAttrs(Attrs):
 @register_relay_attr_node
 class AvgPool2DAttrs(Attrs):
     """Attributes used in avg_pool2d operators"""
+
+
+@register_relay_attr_node
+class OneHotAttrs(Attrs):
+    """Attributes used in one_hot operators"""

--- a/python/tvm/relay/op/transform.py
+++ b/python/tvm/relay/op/transform.py
@@ -340,6 +340,51 @@ def arange(start, stop=None, step=None, dtype="float32"):
     return _make.arange(start, stop, step, dtype)
 
 
+def one_hot(data, on_value=None, off_value=None, depth=None, axis=None):
+    """Onehot
+
+    This operator takes in a 1-D(n) or more dimension tensor and expand the
+    dimension by the specified depths using the specified value to (n, depth).
+
+    Parameters
+    ----------
+    data: tvm.relay.Expr
+        The input data to the operator
+
+    depth: int
+        A scalar defining the depth of the one hot dimension.
+
+    on_value: tvm.relay.Expr
+        The input data defining the value to fill in output when indices[j] = i.
+
+    off_value: tvm.relay.Expr,
+        The input data defining the value to fill in output when indices[j] != i.
+
+    axis: int, optional
+        The axis along which to add depth shape. The default axis is -1.
+
+    Returns
+    -------
+    result : tvm.relay.Expr
+        The resulting one-hot tensor.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        indices = [0, 2, -1, 1]
+        depth = 3
+        relay.one_hot(data, depth,
+                on_value=5.0, off_value=0.0,
+                axis=-1)  # output: [4 x 3]
+        # [[5.0, 0.0, 0.0],  # one_hot(0)
+        #  [0.0, 0.0, 5.0],  # one_hot(2)
+        #  [0.0, 0.0, 0.0],  # one_hot(-1)
+        #  [0.0, 5.0, 0.0]]  # one_hot(1)
+    """
+
+    return _make.one_hot(data, depth, on_value, off_value, axis)
+
 def repeat(data, repeats, axis):
     """Repeats elements of an array.
     By default, repeat flattens the input array into 1-D and then repeats the elements.

--- a/topi/python/topi/transform.py
+++ b/topi/python/topi/transform.py
@@ -518,3 +518,30 @@ def where(condition, x, y):
         A Tensor selected from x or y depending on condition.
     """
     return cpp.where(condition, x, y)
+
+def one_hot(data, depth, on_value, off_value, axis=-1):
+    """Creates a one_hot tensor from an input tensor along the axis.
+
+    Parameters
+    ----------
+    data : tvm.Tensor
+        n-D input, can be any layout.
+
+    depth : Expr.Constant
+        A scalar defining the depth of the one hot dimension.
+
+    on_value : tvm.Tensor
+        The input data defining the value to fill in output when indices[j] = i.
+
+    off_value : tvm.Tensor
+        The input data defining the value to fill in output when indices[j] != i.
+
+    axis : Expr.Constant, optional
+        The axis along which to add depth shape. The default axis is -1.
+
+    Returns
+    -------
+    result : tvm.Tensor
+        The resulting one-hot tensor.
+    """
+    return cpp.one_hot(data, depth, on_value, off_value, axis)

--- a/topi/src/topi.cc
+++ b/topi/src/topi.cc
@@ -157,7 +157,6 @@ TVM_REGISTER_GLOBAL("topi.sin")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
   *rv = sin(args[0]);
   });
-
 TVM_REGISTER_GLOBAL("topi.tanh")
 .set_body([](TVMArgs args, TVMRetValue *rv) {
   *rv = tanh(args[0]);
@@ -357,6 +356,13 @@ TVM_REGISTER_GLOBAL("topi.take")
     *rv = take(args[0], args[1], axis, mode);
   }
   });
+
+TVM_REGISTER_GLOBAL("topi.one_hot")
+.set_body([](TVMArgs args, TVMRetValue *rv) {
+  int depth = args[1];
+  int axis = args[4];
+  *rv = one_hot(args[0], depth, args[2], args[3], axis);
+});
 
 TVM_REGISTER_GLOBAL("topi.sequence_mask")
 .set_body([](TVMArgs args, TVMRetValue *rv) {


### PR DESCRIPTION
add the onehot op support of tensorflow  in Relay and Topi. Currently onehot operator supports multiple on_values/off_value/depth, and 0 <= axis < data.shape.size(). The default value: on_value=1.0, off_value=0.0, axis=-1.

 @vinx13  would you be able to take a look?
