### PR TITLE
Add gfx906 bc for AMD ROCm backend

### DIFF
--- a/python/tvm/contrib/rocm.py
+++ b/python/tvm/contrib/rocm.py
@@ -130,6 +130,7 @@ def callback_rocm_bitcode_path(rocdl_dir="/opt/rocm/lib/"):
         "oclc_finite_only_on.amdgcn.bc",
         "oclc_isa_version_803.amdgcn.bc",
         "oclc_isa_version_900.amdgcn.bc",
+        "oclc_isa_version_906.amdgcn.bc",
         "oclc_unsafe_math_off.amdgcn.bc",
         "oclc_unsafe_math_on.amdgcn.bc"
     ]


### PR DESCRIPTION
The PR add gfx906 bc to support AMD Radeon Instinct MI50/MI60 and Radeon vii
