### PR TITLE
[CI] Temporary disable rust test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,6 @@ stage('Build') {
         make(ci_cpu, 'build', '-j2')
         pack_lib('cpu', tvm_lib)
         timeout(time: max_time, unit: 'MINUTES') {
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_rust.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"


### PR DESCRIPTION
see https://github.com/dmlc/tvm/issues/3802

The main reason was serde package does not support nightly compiler, while the version was released in stable. The dependent type NonZeroI was removed then added back(thus it broken one of the nightly). 

Given that rust tests is blocking all our PRs, as well as master tests, this PR disables rust tests for now. We should add rust test back once we fixed the env. Perhaps a good reason to start use stable version of the compiler.

cc @nhynes @jroesch 