### PR TITLE
[TVM] Fix warnings

### DIFF
--- a/include/tvm/attrs.h
+++ b/include/tvm/attrs.h
@@ -65,7 +65,7 @@ namespace tvm {
  */
 #define TVM_DECLARE_ATTRS(ClassName, TypeKey)                   \
   static constexpr const char* _type_key = TypeKey;             \
-  TVM_DECLARE_NODE_TYPE_INFO(ClassName, ::tvm::BaseAttrsNode);  \
+  TVM_DECLARE_NODE_TYPE_INFO(ClassName, ::tvm::BaseAttrsNode)   \
   template<typename FVisit>                                     \
   void __VisitAttrs__(FVisit& __fvisit__)  // NOLINT(*)
 

--- a/include/tvm/node/node.h
+++ b/include/tvm/node/node.h
@@ -91,7 +91,7 @@ class TVM_DLL Node : public NodeBase {
    */
   virtual void VisitAttrs(AttrVisitor* visitor) {}
   /*! \return the type index of the node */
-  virtual const uint32_t type_index() const = 0;
+  virtual uint32_t type_index() const = 0;
   /*!
    * \brief Whether this node derives from node with type_index=tid.
    *  Implemented by TVM_DECLARE_NODE_TYPE_INFO
@@ -99,7 +99,7 @@ class TVM_DLL Node : public NodeBase {
    * \param tid The type index.
    * \return the check result.
    */
-  virtual const bool _DerivedFrom(uint32_t tid) const;
+  virtual bool _DerivedFrom(uint32_t tid) const;
   /*!
    * \brief get a runtime unique type index given a type key
    * \param type_key Type key of a type.
@@ -228,7 +228,7 @@ inline SubRef Downcast(BaseRef ref);
  * \brief helper macro to declare type information in a base node.
  */
 #define TVM_DECLARE_BASE_NODE_INFO(TypeName, Parent)                    \
-  const bool _DerivedFrom(uint32_t tid) const override {                \
+  bool _DerivedFrom(uint32_t tid) const override {                      \
     static uint32_t tidx = TypeKey2Index(TypeName::_type_key);          \
     if (tidx == tid) return true;                                       \
     return Parent::_DerivedFrom(tid);                                   \
@@ -241,11 +241,11 @@ inline SubRef Downcast(BaseRef ref);
   const char* type_key() const final {                                  \
     return TypeName::_type_key;                                         \
   }                                                                     \
-  const uint32_t type_index() const final {                             \
+  uint32_t type_index() const final {                                   \
     static uint32_t tidx = TypeKey2Index(TypeName::_type_key);          \
     return tidx;                                                        \
   }                                                                     \
-  const bool _DerivedFrom(uint32_t tid) const final {                   \
+  bool _DerivedFrom(uint32_t tid) const final {                         \
     static uint32_t tidx = TypeKey2Index(TypeName::_type_key);          \
     if (tidx == tid) return true;                                       \
     return Parent::_DerivedFrom(tid);                                   \

--- a/src/node/node.cc
+++ b/src/node/node.cc
@@ -47,7 +47,7 @@ struct TypeManager {
 };
 }  // namespace
 
-TVM_DLL const bool Node::_DerivedFrom(uint32_t tid) const {
+TVM_DLL bool Node::_DerivedFrom(uint32_t tid) const {
   static uint32_t tindex = TypeKey2Index(Node::_type_key);
   return tid == tindex;
 }


### PR DESCRIPTION
transform.h:118:3: warning: 'const' type qualifier on return type has no
effect
attrs.h:68:3: note: expanded from macro 'TVM_DECLARE_ATTRS'
node.h:244:3: note: expanded from macro 'TVM_DECLARE_NODE_TYPE_INFO'

transform.h:95:3: warning: extra ';' after member function definition
attrs.h:68:62: note: expanded from macro 'TVM_DECLARE_ATTRS'

