### PR TITLE
[AutoTVM] Fix database APIs

### DIFF
--- a/python/tvm/autotvm/database.py
+++ b/python/tvm/autotvm/database.py
@@ -122,7 +122,8 @@ class RedisDatabase(Database):
     def load(self, inp, get_all=False):
         current = self.get(measure_str_key(inp))
         if current is not None:
-            current = str(current)
+            if isinstance(current, bytes):
+                current = current.decode()
             records = [decode(x) for x in current.split(RedisDatabase.MAGIC_SPLIT)]
             results = [rec[1] for rec in records]
             if get_all:
@@ -132,6 +133,8 @@ class RedisDatabase(Database):
 
     def save(self, inp, res, extend=False):
         current = self.get(measure_str_key(inp))
+        if isinstance(current, bytes):
+                current = current.decode()
         if not extend or current is None:
             self.set(measure_str_key(inp),
                      RedisDatabase.MAGIC_SPLIT.join([encode(inp, res)]))
@@ -142,29 +145,33 @@ class RedisDatabase(Database):
 
     def filter(self, func):
         """
-        Dump all of the records for a particular target
+        Dump all of the records that match the given rule
 
         Parameters
         ----------
         func: callable
-            The signature of the function is bool (MeasureInput, Array of MeasureResult)
+            The signature of the function is (MeasureInput, [MeasureResult]) -> bool
 
         Returns
         -------
-        list of records (inp, result) matching the target
+        list of records in tuple (MeasureInput, MeasureResult) matching the rule
 
         Examples
         --------
         get records for a target
         >>> db.filter(lambda inp, resulst: "cuda" in inp.target.keys)
+        get records with errors
+        >>> db.filter(lambda inp, results: any(r.error_no != 0 for r in results))
         """
         matched_records = list()
         # may consider filtering in iterator in the future
-        for key in self.db:
+        for key in self.db.keys():
             current = self.get(key)
+            if isinstance(current, bytes):
+                current = current.decode()
             try:
-                records = [decode(x) for x in current.spilt(RedisDatabase.MAGIC_SPLIT)]
-            except TypeError:  # got a badly formatted/old format record
+                records = [decode(x) for x in current.split(RedisDatabase.MAGIC_SPLIT)]
+            except TypeError: # got a badly formatted/old format record
                 continue
 
             inps, results = zip(*records)
@@ -189,9 +196,6 @@ class DummyDatabase(RedisDatabase):
 
     def set(self, key, value):
         self.db[key] = value
-
-    def get(self, key):
-        return self.db.get(key)
 
     def flush(self):
         self.db = {}

--- a/tests/python/unittest/test_autotvm_database.py
+++ b/tests/python/unittest/test_autotvm_database.py
@@ -99,8 +99,20 @@ def test_db_latest_all():
     assert encode(inp1, load4[1]) == encode(inp1, res2)
     assert encode(inp1, load4[2]) == encode(inp1, res3)
 
+def test_db_filter():
+    logging.info("test db filter ...")
+    records = get_sample_records(5)
+    _db = database.DummyDatabase()
+    _db.flush()
+    for inp, result in records:
+        _db.save(inp, result)
+
+    records = _db.filter(lambda inp, ress: any(r.costs[0] <= 2 for r in ress))
+    assert len(records) == 2
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     test_save_load()
     test_db_hash()
     test_db_latest_all()
+    test_db_filter()


### PR DESCRIPTION
The database APIs designed in AutoTVM will throw exceptions with Redis database in Python 3. The main reason is that Python 3 package `redis` returns values in `bytes` format instead of `str` so it cannot be manipulated by builtin string methods like `split`.

The original code uses `str(result)` to convert `bytes` to `str`, but this is not the right way:
```python
bval = b"some strings" # type(bval) -> <class 'byte'>
sval = str(bval) # type(sval) -> <class 'str'>
print(sval)
'b\'some strings\''
```
As can be seen, `str` simply invokes `bytes.__str__()` and results in unnecessary `b\'...\'` characters. The right way to do so is using `decode` method:

```python
dval = bval.decode() # type(dval) -> <class 'str'>
print(dval)
'some strings'
```

This PR fixes the issue and creates a new unit test to cover `filer` method which wasn't covered before. With the changes, the unit test passes for both `DummyDatabase` and `RedisDatabase` locally.

One remain issue could be the lack of unit tests for Redis database, but this requires changes of CI environment.