### PR TITLE
Added repo for llvm-9 to fix missing dependency issue when building docker image

### DIFF
--- a/docker/install/ubuntu_install_llvm.sh
+++ b/docker/install/ubuntu_install_llvm.sh
@@ -35,6 +35,11 @@ echo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main\
 echo deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main\
      >> /etc/apt/sources.list.d/llvm.list
 
+echo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main\
+     >> /etc/apt/sources.list.d/llvm.list
+echo deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main\
+     >> /etc/apt/sources.list.d/llvm.list
+
 echo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main\
      >> /etc/apt/sources.list.d/llvm.list
 echo deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial main\


### PR DESCRIPTION
Resolves issue building ci_cpu docker image with llvm enabled
