### PR TITLE
Add build_create_shared_func to tvm/contrib/cc.py

### DIFF
--- a/python/tvm/contrib/cc.py
+++ b/python/tvm/contrib/cc.py
@@ -55,6 +55,29 @@ def create_shared(output,
 # assign so as default output format
 create_shared.output_format = "so" if sys.platform != "win32" else "dll"
 
+
+def build_create_shared_func(options=None, compile_cmd="g++"):
+    """Build create_shared function with particular default options and compile_cmd.
+
+    Parameters
+    ----------
+    options : List[str]
+        The list of additional options string.
+
+    compile_cmd : Optional[str]
+        The compiler command.
+
+    Returns
+    -------
+    create_shared_wrapper : Callable[[str, str, Optional[str]], None]
+        A compilation function that can be passed to export_library or to autotvm.LocalBuilder.
+    """
+    def create_shared_wrapper(output, objects, options=options, compile_cmd=compile_cmd):
+        create_shared(output, objects, options, compile_cmd)
+    create_shared_wrapper.output_format = create_shared.output_format
+    return create_shared_wrapper
+
+
 def cross_compiler(compile_func, base_options=None, output_format="so"):
     """Create a cross compiler function.
 
@@ -63,7 +86,7 @@ def cross_compiler(compile_func, base_options=None, output_format="so"):
     compile_func : Callable[[str, str, Optional[str]], None]
         Function that performs the actual compilation
 
-    options : Optional[List[str]]
+    base_options : Optional[List[str]]
         List of additional optional string.
 
     output_format : Optional[str]


### PR DESCRIPTION
This builder functions allows to build `create_shared` function with particular default `options` and `compile_cmd`.
Returned function can be used in `autotune.LocalBuilder`

Example:

```
# Create tuning_option for ARMv7 hf device (which does not have g++ installed)
from tvm.contrib import cc
build_func = cc.build_create_shared_func(compile_cmd="arm-linux-gnueabihf-g++")

tuning_option = {
    'tuner': 'xgb',
    'n_trial': 1500,
    'early_stopping': 800,

    'measure_option': autotvm.measure_option(
        builder=autotvm.LocalBuilder(
            build_func=build_func
        ),
        runner=autotvm.RPCRunner(
            device_key, host=tr_addr, port=tr_port,
            number=5,
            timeout=10,
        ),
    ),
}
```

The  `tuning_option` above can be used to tune models for ARMv7 hf devices which does not have g++ installed. [Auto-tuning a convolutional network for ARM CPU](https://docs.tvm.ai/tutorials/autotvm/tune_relay_arm.html)

Discussion - https://discuss.tvm.ai/t/lib-export-library-cc-param-was-renamed-to-compile-cmd/3644/3