### PR TITLE
[VTA] Infinite recursive device_api.ext_dev call fix.

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -84,7 +84,7 @@ elseif(PYTHON)
     # Rules for Zynq-class FPGAs with pynq OS support (see pynq.io)
     if(${VTA_TARGET} STREQUAL "pynq" OR
        ${VTA_TARGET} STREQUAL "ultra96")
-      file(GLOB FPGA_RUNTIME_SRCS vta/src/pynq/pynq_driver.cc)
+      list(APPEND FPGA_RUNTIME_SRCS vta/src/pynq/pynq_driver.cc)
     endif()
     # Target lib: vta
     add_library(vta SHARED ${FPGA_RUNTIME_SRCS})


### PR DESCRIPTION
Issue
    when try vta on fpga board, would see a Infinite recursive
    device_api.ext_dev issue that cause stack overflow and vta
    failed.

 Analysis:
    device_api.ext_dev function in rpc_server.py is use to load
    vta library, once vta library get load, device_api.ext_dev would
    get replaced with vta function by vta library, vta device_api.cc
    did such work, but because a logic issue in VTA.MAKE, the said file
    not get compiled, then vta would keep failing on rpc_server.py.

 Solution:
    fix the logic issue in VTA.MAKE.
