### PR TITLE
Add more cases to keras _convert_reshape

### DIFF
--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -193,10 +193,36 @@ def test_forward_upsample(interpolation='nearest'):
 
 
 def test_forward_reshape():
+    # input_shape len is 3, target_shape len is 3
     data = keras.layers.Input(shape=(32, 32, 3))
-    x = keras.layers.Reshape(target_shape=(32, 32, 3))(data)
+    x = keras.layers.Reshape(target_shape=(16, 64, 3))(data)
     keras_model = keras.models.Model(data, x)
     verify_keras_frontend(keras_model)
+    # input_shape len is 3, target_shape len is 2
+    data = keras.layers.Input(shape=(32, 8, 3))
+    x = keras.layers.Reshape(target_shape=(256, 3))(data)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+    # input_shape len is 2, target_shape len is 3
+    data = keras.layers.Input(shape=(256, 3))
+    x = keras.layers.Reshape(target_shape=(8, 32, 3))(data)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+    # input_shape len is 2, target_shape len is 1
+    data = keras.layers.Input(shape=(2, 8))
+    x = keras.layers.Reshape(target_shape=(16,))(data)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model, need_transpose=False)
+    # input_shape len is 1, target_shape len is 2
+    data = keras.layers.Input(shape=(16,))
+    x = keras.layers.Reshape(target_shape=(4, 4))(data)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model, need_transpose=False)
+    # input_shape len is 2, target_shape len is 2
+    data = keras.layers.Input(shape=(2, 8))
+    x = keras.layers.Reshape(target_shape=(4, 4))(data)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model, need_transpose=False)
 
 
 def test_forward_crop():


### PR DESCRIPTION
Currently Keras `_convert_reshape` only supports cases where Keras layer input channel and target shape channel are equal.
e.g. ?,4,4,256 -> ?,16,256

This PR supports additional cases 
1. target shape length is 1
?,2,8 -> ?,16

2. target shape length is 2 and shape is square, e.g.
?,2,8 -> ?,4,4
?,16 -> ?,4,4

I use this improvement in Keras `_convert_reshape` to support `Softmax(axis=[1,2])` (global Softmax).
Relay does not support array type for  Softmax axis (e.g. `axis=[1,2]`). This is why I reshape Softmax input to single axis and then reshape Softmax output back.
Subgraph example: https://www.dropbox.com/s/51rp0g7oul8vg4e/Screenshot%202019-08-27%2022.32.16.png?dl=0

Keras example:
```
#!/usr/bin/env python3
import keras
from keras.models import Sequential
from keras.optimizers import Nadam
from keras.layers import Dense, Activation, Input, Reshape, Softmax
import numpy as np

inputs = Input(shape=(8,8,4,))
l2=Reshape((16,16))(inputs)
outputs=Softmax(axis=[1,2])(l2)
model = keras.Model(inputs, outputs)
model.compile(optimizer=Nadam(), loss='categorical_crossentropy', metrics=['accuracy'])
model.summary()

dshape=(1,8,8,4)
x = np.full(dshape, 0.9903)
preds = model.predict(x)

print(preds)
print("Sum(output): {}".format(np.sum(preds)))
```