### PR TITLE
[Relay] Add new IR pass CombineParallelDense

### DIFF
--- a/docs/api/python/relay/transform.rst
+++ b/docs/api/python/relay/transform.rst
@@ -46,6 +46,8 @@ tvm.relay.transform
 
 .. autofunction:: tvm.relay.transform.CombineParallelConv2D
 
+.. autofunction:: tvm.relay.transform.CombineParallelDense
+
 .. autofunction:: tvm.relay.transform.AlterOpLayout
 
 .. autofunction:: tvm.relay.transform.Legalize

--- a/include/tvm/relay/transform.h
+++ b/include/tvm/relay/transform.h
@@ -483,6 +483,17 @@ TVM_DLL Pass EliminateCommonSubexpr(PackedFunc fskip = nullptr);
 TVM_DLL Pass CombineParallelConv2D(uint64_t min_num_branches = 3);
 
 /*!
+ * \brief Combine parallel dense ops into a single batch_matmul if the
+ * number of branches of this dense operator is not less than
+ * `min_num_branch`.
+ *
+ * \param min_num_branches The minimun number of branches.
+ *
+ * \return The pass.
+ */
+TVM_DLL Pass CombineParallelDense(uint64_t min_num_branches = 3);
+
+/*!
  * \brief Backward fold axis scaling into weights of conv/dense operators.
  *
  * \return The pass.

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -404,15 +404,17 @@ def CombineParallelConv2D(min_num_branches=3):
 def CombineParallelDense(min_num_branches=3):
     """Combine multiple dense operators into one. For example:
 
-             data
-          /       \
-     dense (2,2)  dense (2,2)
+                data
+          /              \
+     dense (2,2)         dense (2,2)
+         |                 |
+    elemwise/bcast (2,2)  elemwise/bcast (2,2)
 
     Would become:
 
              data
               |
-        batch_matmul (2,2,2)
+        batch_matmul+elemwise/bcast (2,2,2)
 
     Parameters
     ----------

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -402,7 +402,17 @@ def CombineParallelConv2D(min_num_branches=3):
 
 
 def CombineParallelDense(min_num_branches=3):
-    """Combine multiple dense operators into one.
+    """Combine multiple dense operators into one. For example:
+
+             data
+          /       \
+     dense (2,2)  dense (2,2)
+
+    Would become:
+
+             data
+              |
+        batch_matmul (2,2,2)
 
     Parameters
     ----------

--- a/python/tvm/relay/transform.py
+++ b/python/tvm/relay/transform.py
@@ -138,6 +138,7 @@ def build_config(opt_level=2,
                 "CanonicalizeCast": 3,
                 "EliminateCommonSubexpr": 3,
                 "CombineParallelConv2D": 4,
+                "CombineParallelDense": 4
             }
 
     fallback_device : int, str, or tvm.TVMContext, optional
@@ -398,6 +399,23 @@ def CombineParallelConv2D(min_num_branches=3):
         The registered pass that combines parallel conv2d operators.
     """
     return _transform.CombineParallelConv2D(min_num_branches)
+
+
+def CombineParallelDense(min_num_branches=3):
+    """Combine multiple dense operators into one.
+
+    Parameters
+    ----------
+    min_num_branches : int
+        The minimum number of required parallel branches for performing this
+        optimization.
+
+    Returns
+    -------
+    ret: tvm.relay.Pass
+        The registered pass that combines parallel dense operators.
+    """
+    return _transform.CombineParallelDense(min_num_branches)
 
 
 def AlterOpLayout():

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -299,6 +299,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     });
     pass_seqs.push_back(transform::EliminateCommonSubexpr(fskip));
     pass_seqs.push_back(transform::CombineParallelConv2D(3));
+    pass_seqs.push_back(transform::CombineParallelDense(3));
     pass_seqs.push_back(transform::FoldConstant());
     pass_seqs.push_back(transform::FoldScaleAxis());
     pass_seqs.push_back(transform::CanonicalizeCast());

--- a/src/relay/pass/combine_parallel_conv2d.cc
+++ b/src/relay/pass/combine_parallel_conv2d.cc
@@ -170,7 +170,7 @@ class ParallelConv2DCombiner : public ParallelOpCombiner {
   void UpdateGroupOutput(const Expr& data,
                          const Group& branches,
                          size_t depth,
-                         ExprSubstMap& subst_map) {
+                         ExprSubstMap* subst_map) {
     int64_t index = 0;
     for (const auto& branch : branches) {
       const CallNode* conv2d = branch[0];
@@ -185,7 +185,7 @@ class ParallelConv2DCombiner : public ParallelOpCombiner {
       index += channels;
       end.push_back(index);
       auto slice = MakeStridedSlice(data, std::move(begin), std::move(end), Array<Integer>{});
-      subst_map[GetRef<Expr>(branch[depth])] = slice;
+      subst_map->insert({GetRef<Expr>(branch[depth]), slice});
     }
   }
 

--- a/src/relay/pass/combine_parallel_conv2d.cc
+++ b/src/relay/pass/combine_parallel_conv2d.cc
@@ -61,7 +61,7 @@ class ParallelConv2DCombiner : public ParallelOpCombiner {
 
   bool CanOpsBeCombined(const CallNode* a, const CallNode* b) {
     AttrsEqual eq;
-    static const Layout kOIHW("OIHW");
+    const Layout kOIHW("OIHW");
     const auto* attrs_a = a->attrs.as<Conv2DAttrs>();
     const auto* attrs_b = b->attrs.as<Conv2DAttrs>();
     CHECK(attrs_a);
@@ -83,7 +83,7 @@ class ParallelConv2DCombiner : public ParallelOpCombiner {
   }
 
   Call MakeCombinedOp(const Group& branches) {
-    static const Op& conv2d = Op::Get("nn.conv2d");
+    const Op& conv2d = Op::Get("nn.conv2d");
     Expr data = branches[0][0]->args[0];
     Expr new_weight;
     IndexExpr new_channels;

--- a/src/relay/pass/combine_parallel_conv2d.cc
+++ b/src/relay/pass/combine_parallel_conv2d.cc
@@ -190,6 +190,7 @@ class ParallelConv2DCombiner : public ParallelOpCombiner {
   }
 
  private:
+  /* \brief index of channel dimension */
   size_t channel_pos_;
 
   std::tuple<Expr, IndexExpr> TransformWeight(const Group& branches) {

--- a/src/relay/pass/combine_parallel_conv2d.cc
+++ b/src/relay/pass/combine_parallel_conv2d.cc
@@ -18,7 +18,7 @@
  */
 
 /*!
- * Copyright (c) 2018 by Contributors
+ * Copyright (c) 2019 by Contributors
  *
  * \file combine_parallel_conv2d.cc
  * \brief Combine parallel 2d convolutions into a single convolution.
@@ -43,66 +43,22 @@
 #include <unordered_set>
 #include "./expr_subst.h"
 #include "./pattern_util.h"
-
+#include "./combine_parallel_op.h"
 
 namespace tvm {
 namespace relay {
 
-using Branch = std::vector<const CallNode*>;
-using Group = std::vector<Branch>;
-
-/*
-  Find parallel branches starting with conv2d as shown below and then group branches by kernel
-  shape and attributes of conv2d. Conv2d can be followed by zero or more elemwise or broadcast ops.
-  Intermediate nodes have exactly one successor. It is possible that branches meet at a point,
-  which should be handled in ParallelConv2DCombiner.
-
-         data
-        /    \
-    conv2d   conv2d
-      |        |
-      op       op
-      |        |
-*/
-class BranchGroupFinder : private ExprVisitor {
+class ParallelConv2DCombiner : public ParallelOpCombiner {
  public:
-  std::vector<Group> Find(const Expr& expr) {
-    static const Op& conv2d = Op::Get("nn.conv2d");
-
-    this->VisitExpr(expr);
-
-    std::vector<Group> groups;
-    for (const auto& root : conv_roots_) {
-      const auto& children = children_map_.at(root);
-      size_t ngroups = groups.size();
-      for (const CallNode* child : children) {
-        if (!child->op.same_as(conv2d)) continue;
-
-        auto&& branch = CreateBranch(child);
-        // add the branch to a group, or create a new group
-        auto it = std::find_if(groups.begin() + ngroups, groups.end(), [&](const Group& group) {
-          CHECK(!group.empty() && !group[0].empty());
-          return IsCompatibleConv2D(child, group[0][0]);
-        });
-        if (it != groups.end()) {
-          it->push_back(branch);
-        } else {
-          groups.emplace_back();
-          // each group has at least one branch
-          groups.back().push_back(branch);
-        }
-      }
-    }
-    return groups;
+  ParallelConv2DCombiner(uint64_t min_num_branches) : ParallelOpCombiner("nn.conv2d", min_num_branches) {
   }
 
- private:
-  std::unordered_set<Expr, NodeHash, NodeEqual> conv_roots_;
-  std::unordered_map<Expr, std::vector<const CallNode*>, NodeHash, NodeEqual> children_map_;
+ protected:
+  virtual bool IsSupportedOp(const CallNode* n) {
+    return n->attrs.as<Conv2DAttrs>()->groups == 1;
+  }
 
-  // Two 2d convolutions can be combined if they have the same attributes or
-  // only have different output channels.
-  bool IsCompatibleConv2D(const CallNode* a, const CallNode* b) {
+  virtual bool AreCompatibleOps(const CallNode* a, const CallNode* b) {
     AttrsEqual eq;
     static const Layout kOIHW("OIHW");
     const auto* attrs_a = a->attrs.as<Conv2DAttrs>();
@@ -125,59 +81,34 @@ class BranchGroupFinder : private ExprVisitor {
            eq(shape_a[3], shape_b[3]);
   }
 
-  // Create a branch starting from conv2d.
-  Branch CreateBranch(const CallNode* conv) {
-    static auto fpattern = Op::GetAttr<TOpPattern>("TOpPattern");
-    // each branch has at least one element, the first element is always conv2d
-    Branch branch{conv};
-    auto it = children_map_.find(GetRef<Expr>(branch.back()));
-    while (it != children_map_.end() && it->second.size() == 1) {
-      const CallNode* call = it->second[0];
-      auto pattern = fpattern[Downcast<Op>(call->op)];
-      if (pattern <= kBroadcast) {
-        branch.push_back(call);
-        it = children_map_.find(GetRef<Expr>(branch.back()));
-      } else {
-        break;
+  virtual void CombineBranches(const Group& branches, ExprSubstMap& subst_map) {
+    Call combined = MakeCombinedConv2D(branches);
+    auto conv_param = combined->attrs.as<Conv2DAttrs>();
+    const std::string& layout =
+        conv_param->out_layout == "" ? conv_param->data_layout : conv_param->out_layout;
+    size_t channel_pos = layout.find('C');
+    CHECK_NE(channel_pos, std::string::npos);
+    auto it = std::min_element(branches.begin(), branches.end(),
+                               [](const Branch& branch_a,
+                                  const Branch& branch_b) {
+                                    return branch_a.size() < branch_b.size();
+                                  });
+    size_t depth = it->size();
+    size_t i;
+    // starting from 1 to skip the conv2d
+    for (i = 1; i < depth; i++) {
+      size_t parent_index;
+      for (parent_index = 0; parent_index < branches[0][i]->args.size(); parent_index++) {
+        if (branches[0][i]->args[parent_index].get() == branches[0][i - 1]) break;
       }
+      CHECK_NE(parent_index, branches[0][i]->args.size());
+      if (!CheckLevel(branches, i, channel_pos, parent_index)) break;
+      combined = MakeCombinedCall(combined, branches, i, channel_pos, parent_index);
     }
-    return branch;
-  }
-
-  void VisitExpr_(const CallNode* n) final {
-    static const Op& conv2d = Op::Get("nn.conv2d");
-    ExprVisitor::VisitExpr_(n);
-    if (n->op.same_as(conv2d) && n->attrs.as<Conv2DAttrs>()->groups == 1) {
-      conv_roots_.insert(n->args[0]);
-      children_map_[n->args[0]].push_back(n);
-    } else {
-      for (size_t i = 0; i < n->args.size(); i++) {
-        children_map_[n->args[i]].push_back(n);
-      }
-    }
-  }
-};
-
-class ParallelConv2DCombiner {
- public:
-  explicit ParallelConv2DCombiner(uint64_t min_num_branches) : min_num_branches_(min_num_branches) {
-  }
-
-  Expr Combine(const Expr& expr) {
-    auto groups = BranchGroupFinder().Find(expr);
-    for (const Group& group : groups) {
-      if (group.size() < min_num_branches_) {
-        continue;
-      }
-      CombineBranches(group);
-    }
-    return ExprSubst(expr, std::move(subst_map_));
+    UpdateGroupOutput(combined, branches, i - 1, channel_pos, subst_map);
   }
 
  private:
-  std::unordered_map<Expr, Expr, NodeHash, NodeEqual> subst_map_;
-  uint64_t min_num_branches_;
-
   std::tuple<Expr, IndexExpr> TransformWeight(const Group& branches) {
     int64_t num_filters = 0;  // number of filters of the transformed weight
     Array<Expr> weights;
@@ -300,7 +231,7 @@ class ParallelConv2DCombiner {
 
   // Replace output of each branch with slices of the combined output
   void UpdateGroupOutput(const Expr& data, const Group& branches, size_t depth,
-                         size_t channel_pos) {
+                         size_t channel_pos, ExprSubstMap& subst_map) {
     int64_t index = 0;
     for (const auto& branch : branches) {
       const CallNode* conv2d = branch[0];
@@ -315,38 +246,8 @@ class ParallelConv2DCombiner {
       index += channels;
       end.push_back(index);
       auto slice = MakeStridedSlice(data, std::move(begin), std::move(end), Array<Integer>{});
-      subst_map_[GetRef<Expr>(branch[depth])] = slice;
+      subst_map[GetRef<Expr>(branch[depth])] = slice;
     }
-  }
-
-  // Combine branches in a group. Conv2d in different branches in the same group are safe to
-  // combine. Subsequent ops may or may not be combined. We start from conv2d and try to
-  // combine ops from all branches in the same depth.
-  void CombineBranches(const Group& branches) {
-    Call combined = MakeCombinedConv2D(branches);
-    auto conv_param = combined->attrs.as<Conv2DAttrs>();
-    const std::string& layout =
-        conv_param->out_layout == "" ? conv_param->data_layout : conv_param->out_layout;
-    size_t channel_pos = layout.find('C');
-    CHECK_NE(channel_pos, std::string::npos);
-    auto it = std::min_element(branches.begin(), branches.end(),
-                               [](const Branch& branch_a,
-                                  const Branch& branch_b) {
-                                    return branch_a.size() < branch_b.size();
-                                  });
-    size_t depth = it->size();
-    size_t i;
-    // starting from 1 to skip the conv2d
-    for (i = 1; i < depth; i++) {
-      size_t parent_index;
-      for (parent_index = 0; parent_index < branches[0][i]->args.size(); parent_index++) {
-        if (branches[0][i]->args[parent_index].get() == branches[0][i - 1]) break;
-      }
-      CHECK_NE(parent_index, branches[0][i]->args.size());
-      if (!CheckLevel(branches, i, channel_pos, parent_index)) break;
-      combined = MakeCombinedCall(combined, branches, i, channel_pos, parent_index);
-    }
-    UpdateGroupOutput(combined, branches, i - 1, channel_pos);
   }
 };
 

--- a/src/relay/pass/combine_parallel_dense.cc
+++ b/src/relay/pass/combine_parallel_dense.cc
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ *
+ * \file combine_parallel_dense.cc
+ * \brief Combine parallel dense ops into a single dense.
+ *
+ * This pass replaces dense ops that share the same input node, same shape,
+ * and don't have "units" defined with a single batch matrix multiplication. 
+ * The inputs of the new batch_matmul is the stack of the original inputs. 
+ * Elemwise and broadcast ops following dense are also combined if possible.
+ *
+ * This prevents launching multiple kernels in networks with multiple
+ * dense branches, such as BERT.
+ */
+
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/attrs/nn.h>
+#include <tvm/relay/attrs/transform.h>
+#include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
+#include <unordered_map>
+#include <unordered_set>
+#include "./expr_subst.h"
+#include "./pattern_util.h"
+#include "./combine_parallel_op.h"
+
+namespace tvm {
+namespace relay {
+
+class ParallelDenseCombiner : public ParallelOpCombiner {
+ public:
+  ParallelDenseCombiner(uint64_t min_num_branches) : ParallelOpCombiner("nn.dense", min_num_branches) {
+  }
+
+ protected:
+  virtual bool IsSupportedOp(const CallNode* n) {
+    const auto* attrs = n->attrs.as<DenseAttrs>();
+    return !attrs->units.defined();
+  }
+
+  virtual bool AreCompatibleOps(const CallNode* a, const CallNode* b) {
+    AttrsEqual eq;
+    const auto* attrs_a = a->attrs.as<DenseAttrs>();
+    const auto* attrs_b = b->attrs.as<DenseAttrs>();
+    CHECK(attrs_a);
+    CHECK(attrs_b);
+    const auto* weight_a = a->args[1]->type_as<TensorTypeNode>();
+    const auto* weight_b = b->args[1]->type_as<TensorTypeNode>();
+
+    return eq(attrs_a->out_dtype, attrs_b->out_dtype) &&
+           eq(weight_a->shape[0], weight_b->shape[0]) &&
+           eq(weight_a->shape[1], weight_b->shape[1]) &&
+           eq(attrs_a->units.defined(), attrs_b->units.defined());
+  }
+
+  virtual void CombineBranches(const Group& branches, ExprSubstMap& subst_map) {
+    Call combined = MakeCombinedDense(branches);
+    auto it = std::min_element(branches.begin(), branches.end(),
+                               [](const Branch& branch_a,
+                                  const Branch& branch_b) {
+                                    return branch_a.size() < branch_b.size();
+                                  });
+    size_t depth = it->size();
+    size_t i;
+    // starting from 1 to skip the dense
+    for (i = 1; i < depth; i++) {
+      size_t parent_index;
+      for (parent_index = 0; parent_index < branches[0][i]->args.size(); parent_index++) {
+        if (branches[0][i]->args[parent_index].get() == branches[0][i - 1]) break;
+      }
+      CHECK_NE(parent_index, branches[0][i]->args.size());
+      if (!CheckLevel(branches, i, parent_index)) break;
+      combined = MakeCombinedCall(combined, branches, i, parent_index);
+    }
+    UpdateGroupOutput(combined, branches, i - 1, subst_map);
+  }
+
+ private:
+  std::tuple<Expr, IndexExpr> TransformWeight(const Group& branches) {
+    int64_t num_filters = 0;  // number of filters of the transformed weight
+    Array<Expr> weights;
+    for (const auto& branch : branches) {
+      auto conv2d = branch[0];
+      weights.push_back(conv2d->args[1]);
+      auto channels = GetConv2DSuperChannelsDim(conv2d);
+      num_filters += channels;
+    }
+    auto index = branches[0][0]->attrs.as<Conv2DAttrs>()->kernel_layout.find('O');
+    CHECK_NE(index, std::string::npos);
+    return std::make_tuple(MakeConcatenate(TupleNode::make(weights), index),
+                           MakeConstScalar(Int(32), num_filters));
+  }
+
+  // Combine dense into batch matmul.
+  Call MakeCombinedDense(const Group& branches) {
+    static const Op& batch_matmul = Op::Get("nn.batch_matmul");
+    Array<Expr> datas;
+    Array<Expr> weights;
+    for (const auto& branch : branches) {
+      auto dense = branch[0];
+      auto data = dense->args[0];
+      auto weight = dense->args[1];
+      datas.push_back(data);
+      weights.push_back(weight);
+    }
+
+    Expr new_data = MakeStack(TupleNode::make(datas));
+    Expr new_weight = MakeStack(TupleNode::make(weights));
+    return CallNode::make(batch_matmul, {new_data, new_weight}, Attrs(), {});
+  }
+
+  bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) {
+    AttrsEqual eq;
+    auto ta = a->args[index]->type_as<TensorTypeNode>();
+    auto tb = b->args[index]->type_as<TensorTypeNode>();
+    auto toutput_a = a->type_as<TensorTypeNode>();
+    auto toutput_b = b->type_as<TensorTypeNode>();
+
+    if (!eq(ta->dtype, tb->dtype) || ta->shape.size() != tb->shape.size())
+      return false;
+
+    for (size_t i = 0; i < ta->shape.size(); i++) {
+      if (!eq(ta->shape[i], tb->shape[i]))
+        return false;
+    }
+    return true;
+  }
+
+  // Check if ops in depth-th level can be combined
+  bool CheckLevel(const Group& branches, size_t depth, size_t parent_index) {
+    const CallNode* call = branches[0][depth];
+    AttrsEqual attrs_equal;
+    // check if all branches in current depth can be combined
+    for (auto it = branches.begin() + 1; it != branches.end(); it++) {
+      const Branch& branch = *it;
+      if (!branch[depth]->op.same_as(call->op) ||
+          !attrs_equal(branch[depth]->attrs, call->attrs) ||
+          branch[depth]->args.size() != call->args.size()) {
+        return false;
+      }
+
+      if (branch[depth]->args[parent_index].get() != branch[depth - 1])
+        return false;
+
+      // Check args
+      for (size_t i = 0; i < call->args.size(); i++) {
+        if (i == parent_index) continue;
+
+        if (!IsArgCompatible(call, branch[depth], i) ||
+            !attrs_equal(call->attrs, branch[depth]->attrs)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  // Combine args and make the combined CallNode
+  Call MakeCombinedCall(const Expr& data, const Group& branches, size_t depth, size_t parent_index) {
+    Array<Expr> new_args;
+    const CallNode* call = branches[0][depth];
+
+    for (size_t i = 0; i < call->args.size(); i++) {
+      if (i == parent_index) {
+        new_args.push_back(data);
+        continue;
+      }
+
+      Array<Expr> tuple;
+      for (const auto& branch : branches) {
+        // if the shape of the arg is 1D, expand it to (1,j) so it can be properly broadcasted.
+        Expr arg = branch[depth]->args[i];
+        const TensorTypeNode* arg_tensor = arg->type_as<TensorTypeNode>();
+        if (arg_tensor->shape.size() == 1) {
+          Expr expanded_arg = ExpandBiasToMatchAxis(arg, 2, {0});
+          tuple.push_back(expanded_arg);
+        } else {
+          tuple.push_back(arg);
+        }
+      }
+
+      auto stack = MakeStack(TupleNode::make(tuple));
+      new_args.push_back(std::move(stack));
+    }
+
+    return CallNode::make(call->op, new_args, call->attrs, {});
+  }
+
+  // Replace output of each branch with slices of the combined output
+  void UpdateGroupOutput(const Expr& data, const Group& branches, size_t depth, ExprSubstMap& subst_map) {
+    int index = 0;
+    auto split = MakeSplit(data, branches.size(), 0);
+    for (const auto& branch : branches) {
+      const CallNode* dense = branch[0];
+      auto split_data = TupleGetItemNode::make(split, index);
+      subst_map[GetRef<Expr>(branch[depth])] = split_data;
+    }
+  }
+};
+
+/*! \brief Combine parallel conv2d if number of branches >= min_num_branches */
+Expr CombineParallelDense(const Expr& expr, uint64_t min_num_branches) {
+  return ParallelDenseCombiner(min_num_branches).Combine(expr);
+}
+
+namespace transform {
+
+Pass CombineParallelDense(uint64_t min_num_branches) {
+  runtime::TypedPackedFunc<Function(Function, Module, PassContext)> pass_func =
+    [=](Function f, Module m, PassContext pc) {
+      return Downcast<Function>(CombineParallelDense(f, min_num_branches));
+  };
+  return CreateFunctionPass(pass_func, 4, "CombineParallelDense",
+                            {ir::StringImm::make("InferType")});
+}
+
+TVM_REGISTER_API("relay._transform.CombineParallelDense")
+.set_body_typed(CombineParallelDense);
+
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/pass/combine_parallel_dense.cc
+++ b/src/relay/pass/combine_parallel_dense.cc
@@ -54,11 +54,6 @@ class ParallelDenseCombiner : public ParallelOpBatchCombiner {
   }
 
  protected:
-  virtual bool IsSupportedOp(const CallNode* n) {
-    const auto* attrs = n->attrs.as<DenseAttrs>();
-    return !attrs->units.defined();
-  }
-
   virtual bool CanOpsBeCombined(const CallNode* a, const CallNode* b) {
     AttrsEqual eq;
     const auto* attrs_a = a->attrs.as<DenseAttrs>();
@@ -70,8 +65,7 @@ class ParallelDenseCombiner : public ParallelOpBatchCombiner {
 
     return eq(attrs_a->out_dtype, attrs_b->out_dtype) &&
            eq(weight_a->shape[0], weight_b->shape[0]) &&
-           eq(weight_a->shape[1], weight_b->shape[1]) &&
-           eq(attrs_a->units.defined(), attrs_b->units.defined());
+           eq(weight_a->shape[1], weight_b->shape[1]);
   }
 };
 

--- a/src/relay/pass/combine_parallel_dense.cc
+++ b/src/relay/pass/combine_parallel_dense.cc
@@ -49,7 +49,7 @@ namespace relay {
 
 class ParallelDenseCombiner : public ParallelOpCombiner {
  public:
-  explicit ParallelDenseCombiner(uint64_t min_num_branches) 
+  explicit ParallelDenseCombiner(uint64_t min_num_branches)
     : ParallelOpCombiner("nn.dense", min_num_branches) {
   }
 
@@ -142,13 +142,13 @@ class ParallelDenseCombiner : public ParallelOpCombiner {
   void UpdateGroupOutput(const Expr& data,
                          const Group& branches,
                          size_t depth,
-                         ExprSubstMap& subst_map) {
+                         ExprSubstMap* subst_map) {
     int index = 0;
     auto split = MakeSplit(data, Integer(branches.size()), 0);
     for (const auto& branch : branches) {
       auto split_data = TupleGetItemNode::make(split, index++);
       auto squeezed_data = MakeSqueeze(split_data, {0});
-      subst_map[GetRef<Expr>(branch[depth])] = squeezed_data;
+      subst_map->insert({GetRef<Expr>(branch[depth]), squeezed_data});
     }
   }
 };

--- a/src/relay/pass/combine_parallel_op.cc
+++ b/src/relay/pass/combine_parallel_op.cc
@@ -151,7 +151,7 @@ void ParallelOpCombiner::CombineBranches(const Group& branches) {
     if (!CheckLevel(branches, i, parent_index)) break;
     combined = MakeCombinedCallFromFollowingOps(combined, branches, i, parent_index);
   }
-  UpdateGroupOutput(combined, branches, i - 1, std::move(subst_map_));
+  UpdateGroupOutput(combined, branches, i - 1, &subst_map_);
 }
 
 bool ParallelOpCombiner::CheckLevel(const Group& branches, size_t depth, size_t parent_index) {

--- a/src/relay/pass/combine_parallel_op.cc
+++ b/src/relay/pass/combine_parallel_op.cc
@@ -141,7 +141,7 @@ void ParallelOpCombiner::CombineBranches(const Group& branches) {
                                 });
   size_t depth = it->size();
   size_t i;
-  // starting from 1 to skip the dense
+  // starting from 1 to skip the op
   for (i = 1; i < depth; i++) {
     size_t parent_index;
     for (parent_index = 0; parent_index < branches[0][i]->args.size(); parent_index++) {

--- a/src/relay/pass/combine_parallel_op.cc
+++ b/src/relay/pass/combine_parallel_op.cc
@@ -49,7 +49,7 @@ BranchGroupFinder::BranchGroupFinder(const std::string& op_name,
 }
 
 std::vector<Group> BranchGroupFinder::Find(const Expr& expr) {
-  static const Op& op = Op::Get(op_name_);
+  const Op& op = Op::Get(op_name_);
 
   this->VisitExpr(expr);
 
@@ -80,7 +80,7 @@ std::vector<Group> BranchGroupFinder::Find(const Expr& expr) {
 
 // Create a branch starting from op.
 Branch BranchGroupFinder::CreateBranch(const CallNode* op) {
-  static auto fpattern = Op::GetAttr<TOpPattern>("TOpPattern");
+  auto fpattern = Op::GetAttr<TOpPattern>("TOpPattern");
   // each branch has at least one element, the first element is always op
   Branch branch{op};
   auto it = children_map_.find(GetRef<Expr>(branch.back()));
@@ -98,7 +98,7 @@ Branch BranchGroupFinder::CreateBranch(const CallNode* op) {
 }
 
 void BranchGroupFinder::VisitExpr_(const CallNode* n) {
-  static const Op& op = Op::Get(op_name_);
+  const Op& op = Op::Get(op_name_);
   ExprVisitor::VisitExpr_(n);
   if (n->op.same_as(op) && fis_supported_op_(n)) {
     op_roots_.insert(n->args[0]);

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -81,30 +81,32 @@ class BranchGroupFinder : private ExprVisitor {
 
   /*
     \brief Finds all groups that can be combined.
+    \param expr Relay expression that represents function
+                to look at for groups to be combined
     \return Vector of groups which can be combined.
    */
   std::vector<Group> Find(const Expr& expr);
 
  private:
-  /* name of op to find parallel branches for */
+  /* \brief name of op to find parallel branches for */
   std::string op_name_;
 
-  /* function to return true if op is eligible to be combined,
-     false otherwise 
+  /* \brief function to return true if op is eligible to be combined,
+            false otherwise 
    */
   FIsSupportedOp fis_supported_op_;
 
-  /* function to return true if two parallel ops are eligible
-     to be combined, false otherwise 
+  /* \brief function to return true if two parallel ops are eligible
+            to be combined, false otherwise 
    */
   FAreCompatibleOps fare_compatible_ops_;
 
-  /* ops that are on the first (logically, leftmost) branch
-     of parallel ops and are eligible to be combined
+  /* \brief ops that are on the first (logically, leftmost) branch
+            of parallel ops and are eligible to be combined
    */
   std::unordered_set<Expr, NodeHash, NodeEqual> op_roots_;
 
-  /* map of Expr to CallNodes that follow it  */
+  /* \brief map of Expr to CallNodes that follow it  */
   std::unordered_map<Expr, std::vector<const CallNode*>, NodeHash, NodeEqual> children_map_;
 
   /*
@@ -204,13 +206,13 @@ class ParallelOpCombiner {
                                  ExprSubstMap* subst_map) = 0;
 
  private:
-  /* name of op to be combined */
+  /* \brief name of op to be combined */
   std::string op_name_;
 
-  /* minimum number of parallel branches to combine */
+  /* \brief minimum number of parallel branches to combine */
   uint64_t min_num_branches_;
 
-  /* map of Expr to Expr to substitute it with after running pass */
+  /* \brief map of Expr to Expr to substitute it with after running pass */
   ExprSubstMap subst_map_;
 
   /*

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -50,40 +50,40 @@ using FAreCompatibleOps = std::function<bool (const CallNode* a, const CallNode*
 using ExprSubstMap = std::unordered_map<Expr, Expr, NodeHash, NodeEqual>;
 
 /*
-  Class to find parallel branches starting with op that are 
-  grouped if they are able to be combined. They are eligible to
-  be combined if they have the same input data.
-  Op can be followed by zero or more elemwise or broadcast ops,
-  which are included in the group.
-  Intermediate nodes have exactly one successor. It is possible that branches meet at a point,
-  which should be handled in ParallelOpCombiner.
-
-         data
-        /    \
-      op      op
-      |        |
-  elem-wise elem-wise
-      |        |
-*/
+ * Class to find parallel branches starting with op that are 
+ * grouped if they are able to be combined. They are eligible to
+ * be combined if they have the same input data.
+ * Op can be followed by zero or more elemwise or broadcast ops,
+ * which are included in the group.
+ * Intermediate nodes have exactly one successor. It is possible that branches meet at a point,
+ * which should be handled in ParallelOpCombiner.
+ *
+ *        data
+ *       /    \
+ *     op      op
+ *     |        |
+ * elem-wise elem-wise
+ *     |        |
+ */
 class BranchGroupFinder : private ExprVisitor {
  public:
   /*
-    \brief Constructor
-    \param op_name name of op to start each group
-    \param fis_supported_op function that returns true if op
-                            is supported for combining
-    \param fare_compatible_ops function that returns true if
-                               two ops are compatible for combining
+   * \brief Constructor
+   * \param op_name name of op to start each group
+   * \param fis_supported_op function that returns true if op
+   *                         is supported for combining
+   * \param fare_compatible_ops function that returns true if
+   *                            two ops are compatible for combining
    */
   BranchGroupFinder(const std::string& op_name,
                     FIsSupportedOp fis_supported_op,
                     FAreCompatibleOps fare_compatible_ops);
 
   /*
-    \brief Finds all groups that can be combined.
-    \param expr Relay expression that represents function
-                to look at for groups to be combined
-    \return Vector of groups which can be combined.
+   * \brief Finds all groups that can be combined.
+   * \param expr Relay expression that represents function
+   *             to look at for groups to be combined
+   * \return Vector of groups which can be combined.
    */
   std::vector<Group> Find(const Expr& expr);
 
@@ -92,17 +92,17 @@ class BranchGroupFinder : private ExprVisitor {
   std::string op_name_;
 
   /* \brief function to return true if op is eligible to be combined,
-            false otherwise 
+   *         false otherwise 
    */
   FIsSupportedOp fis_supported_op_;
 
   /* \brief function to return true if two parallel ops are eligible
-            to be combined, false otherwise 
+   *         to be combined, false otherwise 
    */
   FAreCompatibleOps fare_compatible_ops_;
 
   /* \brief ops that are on the first (logically, leftmost) branch
-            of parallel ops and are eligible to be combined
+   *         of parallel ops and are eligible to be combined
    */
   std::unordered_set<Expr, NodeHash, NodeEqual> op_roots_;
 
@@ -110,82 +110,82 @@ class BranchGroupFinder : private ExprVisitor {
   std::unordered_map<Expr, std::vector<const CallNode*>, NodeHash, NodeEqual> children_map_;
 
   /*
-    \brief Creates new branch from op and its children that have
-           elementwise or broadcast patterns
-    \return New branch
+   * \brief Creates new branch from op and its children that have
+   *        elementwise or broadcast patterns
+   * \return New branch
    */
   Branch CreateBranch(const CallNode* op);
 
   /*
-    \brief Expression visitor function
+   * \brief Expression visitor function
    */
   void VisitExpr_(const CallNode* n) final;
 };
 
 /*
-  Abstract class to find and combine parallel ops and the elementwise ops that follow.
-*/
+ * Abstract class to find and combine parallel ops and the elementwise ops that follow.
+ */
 class ParallelOpCombiner {
  public:
   /*
-    \brief Constructor.
-    \param op_name name of op to combine
-    \param min_num_branches min number of parallel branches beginning with op
-                            to start combining
+   * \brief Constructor.
+   * \param op_name name of op to combine
+   * \param min_num_branches min number of parallel branches beginning with op
+   *                         to start combining
    */
   explicit ParallelOpCombiner(const std::string& op_name, uint64_t min_num_branches);
 
   /*
-    \brief Combines ops and following elementwise or broadcast ops
-    \param expr function to modify
-    \return new function with combined ops
+   * \brief Combines ops and following elementwise or broadcast ops
+   * \param expr function to modify
+   * \return new function with combined ops
    */
   Expr Combine(const Expr& expr);
 
  protected:
   /*
-    \brief Checks if node is supported to be combined
-    \param n node in question
-    \return True if the op represented by n is supported to be the root of a branch
-            to be combined. False otherwise.
+   * \brief Checks if node is supported to be combined
+   * \param n node in question
+   * \return True if the op represented by n is supported to be the root of a branch
+   *         to be combined. False otherwise.
    */
   virtual bool IsSupportedOp(const CallNode* n) = 0;
 
   /*
-    \brief Checks if two ops can be combined
-    \param a node a
-    \param b node b
-    \return True if a and b can be combined. False otherwise.
+   * \brief Checks if two ops can be combined
+   * \param a node a
+   * \param b node b
+   * \return True if a and b can be combined. False otherwise.
    */
   virtual bool CanOpsBeCombined(const CallNode* a, const CallNode* b) = 0;
 
   /*
-    \brief Makes combined op from parallel ops in branches. This usually involves
-           concatenating or stacking inputs, then creating a new call.
-    \param branches branches that are to be combined
-    \return new call with branches combined.
+   * \brief Makes combined op from parallel ops in branches. This usually involves
+   *        concatenating or stacking inputs, then creating a new call.
+   * \param branches branches that are to be combined
+   * \return new call with branches combined.
    */
   virtual Call MakeCombinedOp(const Group& branches) = 0;
 
   /*
-    \brief Checks if argument of op following combined ops are able to be combined
-    \param a node a
-    \param b node b
-    \param index index of argument in question
-    \return True if argument of a and b and index can be combined
+   * \brief Checks if argument of op following combined ops are able to be combined
+   * \param a node a
+   * \param b node b
+   * \param index index of argument in question
+   * \return True if argument of a and b and index can be combined
    */
   virtual bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) = 0;
 
   /*
-    \brief Create combined call from ops that follow the initial combined op at the depth-th level.
-           This usually involves concatenating or stacking inputs, then creating a new call.
-           Only called if IsArgCompatbile returns true for each arg.
-    \param data combined op
-    \param branches branches of parallel ops to be combined
-    \param depth depth at which to combine ops
-    \param parent_index index of arg that corresponds to original input that was shared among
-                        all combined ops
-    \return new combined call
+   * \brief Create combined call from ops that follow the initial combined op at the depth-th level.
+   *        This usually involves concatenating or stacking inputs, then creating a new call.
+   *        Only called if IsArgCompatbile returns true for each arg.
+   * \param data combined op
+   * \param branches branches of parallel ops to be combined
+   * \param depth depth at which to combine ops
+   * \param parent_index index of arg that corresponds to original input that was shared among
+   *                     all combined ops
+   * \return new combined call
    */
   virtual Call MakeCombinedCallFromFollowingOps(const Expr& data,
                                                 const Group& branches,
@@ -193,12 +193,12 @@ class ParallelOpCombiner {
                                                 size_t parent_index) = 0;
 
   /*
-    \brief Updates map of expr to substitute with combined expr. This usually involves
-           slicing or splitting data.
-    \param data combined op
-    \param branches branches of parallel ops to be combined
-    \param depth depth at which to substitute
-    \param subst_map map of Expr to replace with Expr to replace it with
+   * \brief Updates map of expr to substitute with combined expr. This usually involves
+   *        slicing or splitting data.
+   * \param data combined op
+   * \param branches branches of parallel ops to be combined
+   * \param depth depth at which to substitute
+   * \param subst_map map of Expr to replace with Expr to replace it with
    */
   virtual void UpdateGroupOutput(const Expr& data,
                                  const Group& branches,
@@ -216,20 +216,20 @@ class ParallelOpCombiner {
   ExprSubstMap subst_map_;
 
   /*
-    \brief Combine parallel branches and updates subst_map_ with Exprs
-           to be substituted
-    \param branches branches to be combined
+   * \brief Combine parallel branches and updates subst_map_ with Exprs
+   *        to be substituted
+   * \param branches branches to be combined
    */
   void CombineBranches(const Group& branches);
 
   /*
-    \brief Combine parallel branches and updates subst_map_ with Exprs
-           to be substituted
-    \param branches parallel branches to potentially be combined
-    \param depth depth at which to look at op
-    \param parent_index index of arg that corresponds to original input that was shared among
-                        all combined ops
-    \return true if parallel ops at depth can be combined, false otherwise
+   * \brief Combine parallel branches and updates subst_map_ with Exprs
+   *        to be substituted
+   * \param branches parallel branches to potentially be combined
+   * \param depth depth at which to look at op
+   * \param parent_index index of arg that corresponds to original input that was shared among
+   *                     all combined ops
+   * \return true if parallel ops at depth can be combined, false otherwise
    */
   bool CheckLevel(const Group& branches, size_t depth, size_t parent_index);
 };

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -23,6 +23,8 @@
  * \file combine_parallel_op.h
  * \brief Abstract class to combine parallel ops and their successive element-wise ops.
  */
+#ifndef TVM_RELAY_PASS_COMBINE_PARALLEL_OP_H_
+#define TVM_RELAY_PASS_COMBINE_PARALLEL_OP_H_
 
 #include <tvm/relay/analysis.h>
 #include <tvm/relay/expr_functor.h>
@@ -107,7 +109,7 @@ class ParallelOpCombiner {
   // Returns true if arguments of a and b at index index can be combined.
   virtual bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) = 0;
 
-  // Create combined call of ops that follow initial combined op in depth-th level. 
+  // Create combined call of ops that follow initial combined op in depth-th level.
   // This usually involves concatenating or stacking inputs, then creating a new call.
   // Only called if IsArgCompatible returns true for each arg.
   virtual Call MakeCombinedCallFromFollowingOps(const Expr& data,
@@ -119,7 +121,7 @@ class ParallelOpCombiner {
   virtual void UpdateGroupOutput(const Expr& data,
                                  const Group& branches,
                                  size_t depth,
-                                 ExprSubstMap& subst_map) = 0;
+                                 ExprSubstMap* subst_map) = 0;
 
  private:
   std::string op_name_;
@@ -133,3 +135,4 @@ class ParallelOpCombiner {
 
 }  // namespace relay
 }  // namespace tvm
+#endif  // TVM_RELAY_PASS_COMBINE_PARALLEL_OP_H_

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ *
+ * \file combine_parallel_op.h
+ * \brief Abstract class to combine parallel ops and their successive element-wise ops.
+ */
+
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/attrs/nn.h>
+#include <tvm/relay/attrs/transform.h>
+#include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
+#include <unordered_map>
+#include <unordered_set>
+#include "./expr_subst.h"
+#include "./pattern_util.h"
+
+
+namespace tvm {
+namespace relay {
+
+using Branch = std::vector<const CallNode*>;
+using Group = std::vector<Branch>;
+using FIsSupportedOp = std::function<bool (const CallNode* n)>;
+using FAreCompatibleOps = std::function<bool (const CallNode* a, const CallNode* b)>;
+using ExprSubstMap = std::unordered_map<Expr, Expr, NodeHash, NodeEqual>;
+
+/*
+  Class to find parallel branches starting with op as shown below and then 
+  group branches by kernel shape and attributes of op. 
+  Op can be followed by zero or more elemwise or broadcast ops.
+  Intermediate nodes have exactly one successor. It is possible that branches meet at a point,
+  which should be handled in ParallelOpCombiner.
+
+         data
+        /    \
+      op      op
+      |        |
+  elem-wise elem-wise
+      |        |
+*/
+class BranchGroupFinder : private ExprVisitor {
+ public:
+  BranchGroupFinder(const std::string& op_name,
+                    FIsSupportedOp fis_supported_op,
+                    FAreCompatibleOps fare_compatible_ops);
+
+  std::vector<Group> Find(const Expr& expr);
+
+ private:
+  std::string op_name_;
+  FIsSupportedOp fis_supported_op_;
+  FAreCompatibleOps fare_compatible_ops_;
+  std::unordered_set<Expr, NodeHash, NodeEqual> op_roots_;
+  std::unordered_map<Expr, std::vector<const CallNode*>, NodeHash, NodeEqual> children_map_;
+
+  // Create a branch starting from op.
+  Branch CreateBranch(const CallNode* op);
+
+  void VisitExpr_(const CallNode* n) final;
+};
+
+/*
+  Abstract class to find and combine parallel ops and the element-wise ops that follow.
+*/
+class ParallelOpCombiner {
+ public:
+  explicit ParallelOpCombiner(const std::string& op_name, uint64_t min_num_branches);
+
+  Expr Combine(const Expr& expr);
+ 
+ protected:
+  // Returns true if the op represented by CallNode n is supported to be the
+  // root of a branch to be combined. Otherwise, returns false.
+  virtual bool IsSupportedOp(const CallNode* n) = 0;
+
+  // Returns true if ops represented by CallNodes a and b can be combined.
+  // Otherwise, returns false.
+  virtual bool AreCompatibleOps(const CallNode* a, const CallNode* b) = 0;
+
+  // Combine branches in a group. Ops in different branches in the same group are safe to
+  // combine. Subsequent ops may or may not be combined. Start from op and try to
+  // combine ops from all branches in the same depth.
+  // Ops should be updated by updating subst_map,
+  // which maps original Expr to Expr to substitute it with.
+  virtual void CombineBranches(const Group& branches, ExprSubstMap& subst_map) = 0;
+
+ private:
+  std::string op_name_;
+  uint64_t min_num_branches_;
+  ExprSubstMap subst_map_;
+};
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -51,7 +51,8 @@ using ExprSubstMap = std::unordered_map<Expr, Expr, NodeHash, NodeEqual>;
 
 /*
   Class to find parallel branches starting with op that are 
-  grouped if they are able to be combined. 
+  grouped if they are able to be combined. They are eligible to
+  be combined if they have the same input data.
   Op can be followed by zero or more elemwise or broadcast ops,
   which are included in the group.
   Intermediate nodes have exactly one successor. It is possible that branches meet at a point,
@@ -67,11 +68,11 @@ using ExprSubstMap = std::unordered_map<Expr, Expr, NodeHash, NodeEqual>;
 class BranchGroupFinder : private ExprVisitor {
  public:
   /*
-    @brief Constructor
-    @param op_name name of op to start each group
-    @param fis_supported_op function that returns true if op
+    \brief Constructor
+    \param op_name name of op to start each group
+    \param fis_supported_op function that returns true if op
                             is supported for combining
-    @param fare_compatible_ops function that returns true if
+    \param fare_compatible_ops function that returns true if
                                two ops are compatible for combining
    */
   BranchGroupFinder(const std::string& op_name,
@@ -79,20 +80,43 @@ class BranchGroupFinder : private ExprVisitor {
                     FAreCompatibleOps fare_compatible_ops);
 
   /*
-    @brief Finds all groups that can be combined.
-    @return Vector of groups which can be combined.
+    \brief Finds all groups that can be combined.
+    \return Vector of groups which can be combined.
    */
   std::vector<Group> Find(const Expr& expr);
 
  private:
+  /* name of op to find parallel branches for */
   std::string op_name_;
+
+  /* function to return true if op is eligible to be combined,
+     false otherwise 
+   */
   FIsSupportedOp fis_supported_op_;
+
+  /* function to return true if two parallel ops are eligible
+     to be combined, false otherwise 
+   */
   FAreCompatibleOps fare_compatible_ops_;
+
+  /* ops that are on the first (logically, leftmost) branch
+     of parallel ops and are eligible to be combined
+   */
   std::unordered_set<Expr, NodeHash, NodeEqual> op_roots_;
+
+  /* map of Expr to CallNodes that follow it  */
   std::unordered_map<Expr, std::vector<const CallNode*>, NodeHash, NodeEqual> children_map_;
 
+  /*
+    \brief Creates new branch from op and its children that have
+           elementwise or broadcast patterns
+    \return New branch
+   */
   Branch CreateBranch(const CallNode* op);
 
+  /*
+    \brief Expression visitor function
+   */
   void VisitExpr_(const CallNode* n) final;
 };
 
@@ -102,64 +126,64 @@ class BranchGroupFinder : private ExprVisitor {
 class ParallelOpCombiner {
  public:
   /*
-    @brief Constructor.
-    @param op_name name of op to combine
-    @param min_num_branches min number of parallel branches beginning with op
+    \brief Constructor.
+    \param op_name name of op to combine
+    \param min_num_branches min number of parallel branches beginning with op
                             to start combining
    */
   explicit ParallelOpCombiner(const std::string& op_name, uint64_t min_num_branches);
 
   /*
-    @brief Combines ops and following elementwise or broadcast ops
-    @param expr function to modify
-    @return new function with combined ops
+    \brief Combines ops and following elementwise or broadcast ops
+    \param expr function to modify
+    \return new function with combined ops
    */
   Expr Combine(const Expr& expr);
 
  protected:
   /*
-    @brief Checks if node is supported to be combined
-    @param n node in question
-    @return True if the op represented by n is supported to be the root of a branch
+    \brief Checks if node is supported to be combined
+    \param n node in question
+    \return True if the op represented by n is supported to be the root of a branch
             to be combined. False otherwise.
    */
   virtual bool IsSupportedOp(const CallNode* n) = 0;
 
   /*
-    @brief Checks if two ops can be combined
-    @param a node a
-    @param b node b
-    @return True if a and b can be combined. False otherwise.
+    \brief Checks if two ops can be combined
+    \param a node a
+    \param b node b
+    \return True if a and b can be combined. False otherwise.
    */
   virtual bool CanOpsBeCombined(const CallNode* a, const CallNode* b) = 0;
 
   /*
-    @brief Makes combined op from parallel ops in branches. This usually involves
+    \brief Makes combined op from parallel ops in branches. This usually involves
            concatenating or stacking inputs, then creating a new call.
-    @param branches branches that are to be combined
-    @return new call with branches combined.
+    \param branches branches that are to be combined
+    \return new call with branches combined.
    */
   virtual Call MakeCombinedOp(const Group& branches) = 0;
 
   /*
-    @brief Checks if argument of op following combined ops are able to be combined
-    @param a node a
-    @param b node b
-    @param index index of argument in question
-    @return True if argument of a and b and index can be combined
+    \brief Checks if argument of op following combined ops are able to be combined
+    \param a node a
+    \param b node b
+    \param index index of argument in question
+    \return True if argument of a and b and index can be combined
    */
   virtual bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) = 0;
 
   /*
-    @brief Create combined call from ops that follow the initial combined op at the depth-th level.
+    \brief Create combined call from ops that follow the initial combined op at the depth-th level.
            This usually involves concatenating or stacking inputs, then creating a new call.
            Only called if IsArgCompatbile returns true for each arg.
-    @param data combined op
-    @param branches branches of parallel ops to be combined
-    @param depth depth at which to combine ops
-    @param parent_index index of arg that corresponds to original input that was shared among
+    \param data combined op
+    \param branches branches of parallel ops to be combined
+    \param depth depth at which to combine ops
+    \param parent_index index of arg that corresponds to original input that was shared among
                         all combined ops
-    @return new combined call
+    \return new combined call
    */
   virtual Call MakeCombinedCallFromFollowingOps(const Expr& data,
                                                 const Group& branches,
@@ -167,13 +191,12 @@ class ParallelOpCombiner {
                                                 size_t parent_index) = 0;
 
   /*
-    @brief Updates map of expr to substitute with combined expr. This usually involves
+    \brief Updates map of expr to substitute with combined expr. This usually involves
            slicing or splitting data.
-    @param data combined op
-    @param branches branches of parallel ops to be combined
-    @param depth depth at which to substitute
-    @param subst_map map of Expr to replace with Expr to replace it with
-    Replace output of each branch with slices of the combined output
+    \param data combined op
+    \param branches branches of parallel ops to be combined
+    \param depth depth at which to substitute
+    \param subst_map map of Expr to replace with Expr to replace it with
    */
   virtual void UpdateGroupOutput(const Expr& data,
                                  const Group& branches,
@@ -181,12 +204,31 @@ class ParallelOpCombiner {
                                  ExprSubstMap* subst_map) = 0;
 
  private:
+  /* name of op to be combined */
   std::string op_name_;
+
+  /* minimum number of parallel branches to combine */
   uint64_t min_num_branches_;
+
+  /* map of Expr to Expr to substitute it with after running pass */
   ExprSubstMap subst_map_;
 
+  /*
+    \brief Combine parallel branches and updates subst_map_ with Exprs
+           to be substituted
+    \param branches branches to be combined
+   */
   void CombineBranches(const Group& branches);
 
+  /*
+    \brief Combine parallel branches and updates subst_map_ with Exprs
+           to be substituted
+    \param branches parallel branches to potentially be combined
+    \param depth depth at which to look at op
+    \param parent_index index of arg that corresponds to original input that was shared among
+                        all combined ops
+    \return true if parallel ops at depth can be combined, false otherwise
+   */
   bool CheckLevel(const Group& branches, size_t depth, size_t parent_index);
 };
 

--- a/src/relay/pass/combine_parallel_op.h
+++ b/src/relay/pass/combine_parallel_op.h
@@ -67,7 +67,7 @@ using ExprSubstMap = std::unordered_map<Expr, Expr, NodeHash, NodeEqual>;
 class BranchGroupFinder : private ExprVisitor {
  public:
   /*
-    @brief Constructor.
+    @brief Constructor
     @param op_name name of op to start each group
     @param fis_supported_op function that returns true if op
                             is supported for combining

--- a/src/relay/pass/combine_parallel_op_batch.cc
+++ b/src/relay/pass/combine_parallel_op_batch.cc
@@ -38,12 +38,10 @@
  *
  * Would become:
  * 
-*            data
-*              |
-*          add (2,2,2)
-*              |
-*         elemwise (2,2,2)
-*          /       \
+ *            data
+ *              |
+ *       add+elemwise (2,2,2)
+ *          /       \
  *
  */
 
@@ -58,147 +56,155 @@
 #include "./expr_subst.h"
 #include "./pattern_util.h"
 #include "./combine_parallel_op.h"
+#include "./combine_parallel_op_batch.h"
 
 namespace tvm {
 namespace relay {
 
-class ParallelOpBatchCombiner : public ParallelOpCombiner {
- public:
-  ParallelOpBatchCombiner(const std::string& op_name, uint64_t min_num_branches)
-    : ParallelOpBatchCombiner(op_name, op_name, min_num_branches) {
+ParallelOpBatchCombiner::ParallelOpBatchCombiner(const std::string& op_name,
+                                                 const std::string& batch_op_name,
+                                                 uint64_t min_num_branches)
+  : ParallelOpCombiner(op_name, min_num_branches),
+    batch_op_name_(batch_op_name) {
+}
+
+bool ParallelOpBatchCombiner::IsSupportedOp(const CallNode* n) {
+  return true;
+}
+
+bool ParallelOpBatchCombiner::CanOpsBeCombined(const CallNode* a, const CallNode* b) {
+  if (a->args.size() != b->args.size()) {
+    return false;
   }
 
-  ParallelOpBatchCombiner(const std::string& op_name, const std::string& batched_op_name, uint64_t min_num_branches)
-    : ParallelOpCombiner(op_name, min_num_branches),
-      batched_op_name_(batched_op_name) {
-  }
-
- protected:
-  bool IsSupportedOp(const CallNode* n) {
-    return true;
-  }
-
-  bool CanOpsBeCombined(const CallNode* a, const CallNode* b) {
-    if (!eq(a->args.size(), b->args.size())) {
+  AttrsEqual eq;
+  for (size_t i = 0; i < a->args.size(); i++) {
+    auto ta = a->args[i]->type_as<TensorTypeNode>();
+    auto tb = b->args[i]->type_as<TensorTypeNode>();
+    if (ta->shape.size() != tb->shape.size() || !eq(ta->dtype, tb->dtype)) {
       return false;
     }
 
-    for (size_t i = 0; i < a->args.size(); i++) {
-      const auto* ta = a->args[i]->type_as<TensorTypeNode>();
-      const auto* tb = b->args[i]->type_as<TensorTypeNode>();
-      if (!eq(ta->shape.size(), tb->shape.size()) || !eq(ta->dtype, tb->dtype)) {
+    for (size_t j = 0; j < ta->shape.size(); j++) {
+      if (!eq(ta->shape[j], tb->shape[j])) {
         return false;
       }
-
-      for (size_t j = 0; j < ta->shape.size(); j++) {
-        if (!eq(ta->shape[j], tb->shape[j])) {
-          return false;
-        }
-      }
     }
   }
 
-  Call MakeCombinedOp(const Group& branches) {
-    const Op& batch_op = Op::Get(batched_op_name_);
-    
-    Array<Expr> stacked_args;
-    size_t num_args = branches[0][0]->args.size();
-    for (size_t i = 0; i < num_args; i++) {
-      Array<Expr> new_arg;
-      for (const auto& branch : branches) {
-        new_arg.push_back(branch[0]->args[i]);
-      }
+  return true;
+}
 
-      Expr new_arg_stack = MakeStack(TupleNode::make(new_arg), 0);
-      stacked_args.push_back(new_arg_stack);
-    }
+Call ParallelOpBatchCombiner::MakeCombinedOp(const Group& branches) {
+  const Op& batch_op = Op::Get(batch_op_name_);
 
-    return CallNode::make(batch_op, stacked_args, Attrs(), {});
-  }
-
-  bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) {
-    AttrsEqual eq;
-    auto ta = a->args[index]->type_as<TensorTypeNode>();
-    auto tb = b->args[index]->type_as<TensorTypeNode>();
-
-    if (!eq(ta->dtype, tb->dtype) || ta->shape.size() != tb->shape.size())
-      return false;
-
-    for (size_t i = 0; i < ta->shape.size(); i++) {
-      if (!eq(ta->shape[i], tb->shape[i]))
-        return false;
-    }
-    return true;
-  }
-
-  Call MakeCombinedCallFromFollowingOps(const Expr& data,
-                                        const Group& branches,
-                                        size_t depth,
-                                        size_t parent_index) {
-    Array<Expr> new_args;
-    const CallNode* call = branches[0][depth];
-
-    for (size_t i = 0; i < call->args.size(); i++) {
-      if (i == parent_index) {
-        new_args.push_back(data);
-        continue;
-      }
-
-      Array<Expr> tuple;
-      for (const auto& branch : branches) {
-        // if the shape of the arg is 1D, expand it to (1,j) so it can be properly broadcasted.
-        Expr arg = branch[depth]->args[i];
-        const TensorTypeNode* arg_tensor = arg->type_as<TensorTypeNode>();
-        if (arg_tensor->shape.size() == 1) {
-          Expr expanded_arg = MakeExpandDims(arg, 0, 1);
-          tuple.push_back(expanded_arg);
-        } else {
-          tuple.push_back(arg);
-        }
-      }
-
-      auto stack = MakeStack(TupleNode::make(tuple), 0);
-      new_args.push_back(std::move(stack));
-    }
-
-    return CallNode::make(call->op, new_args, call->attrs, {});
-  }
-
-  void UpdateGroupOutput(const Expr& data,
-                         const Group& branches,
-                         size_t depth,
-                         ExprSubstMap* subst_map) {
-    int index = 0;
-    auto split = MakeSplit(data, Integer(branches.size()), 0);
+  Array<Expr> new_args;
+  size_t num_args = branches[0][0]->args.size();
+  for (size_t i = 0; i < num_args; i++) {
+    Array<Expr> arg_from_all_branches;
     for (const auto& branch : branches) {
-      auto split_data = TupleGetItemNode::make(split, index++);
-      auto squeezed_data = MakeSqueeze(split_data, {0});
-      subst_map->insert({GetRef<Expr>(branch[depth]), squeezed_data});
+      arg_from_all_branches.push_back(branch[0]->args[i]);
     }
+
+    new_args.push_back(MakeStack(TupleNode::make(arg_from_all_branches), 0));
   }
 
-private:
-  std::string batched_op_name_;
-};
+  return CallNode::make(batch_op, new_args, Attrs(), {});
+}
 
-/*! \brief Combine parallel dense if number of branches >= min_num_branches */
-Expr CombineParallelDense(const Expr& expr, uint64_t min_num_branches) {
-  return ParallelDenseCombiner(min_num_branches).Combine(expr);
+bool ParallelOpBatchCombiner::IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) {
+  AttrsEqual eq;
+  auto ta = a->args[index]->type_as<TensorTypeNode>();
+  auto tb = b->args[index]->type_as<TensorTypeNode>();
+
+  if (!eq(ta->dtype, tb->dtype) || ta->shape.size() != tb->shape.size())
+    return false;
+
+  for (size_t i = 0; i < ta->shape.size(); i++) {
+    if (!eq(ta->shape[i], tb->shape[i]))
+      return false;
+  }
+  return true;
+}
+
+Call ParallelOpBatchCombiner::MakeCombinedCallFromFollowingOps(const Expr& data,
+                                                               const Group& branches,
+                                                               size_t depth,
+                                                               size_t parent_index) {
+  Array<Expr> new_args;
+  const CallNode* call = branches[0][depth];
+  const Op& bias_add = Op::Get("nn.bias_add");
+
+  for (size_t i = 0; i < call->args.size(); i++) {
+    if (i == parent_index) {
+      new_args.push_back(data);
+      continue;
+    }
+
+    Array<Expr> tuple;
+    for (const auto& branch : branches) {
+      Expr arg = branch[depth]->args[i];
+      const TensorTypeNode* arg_tensor = arg->type_as<TensorTypeNode>();
+
+      // special case for bias_add: 1D data needs to be expanded to (1,size)
+      // for proper broadcasting.
+      //
+      // note that this can't be applied generally, as elementwise ops
+      // such as full have a valid 1D input.
+      if (call->op.same_as(bias_add)) {
+        Expr expanded_arg = MakeExpandDims(arg, 0, 1);
+        tuple.push_back(expanded_arg);
+      } else {
+        tuple.push_back(arg);
+      }
+    }
+
+    auto stack = MakeStack(TupleNode::make(tuple), 0);
+    new_args.push_back(std::move(stack));
+  }
+
+  return CallNode::make(call->op, new_args, call->attrs, {});
+}
+
+void ParallelOpBatchCombiner::UpdateGroupOutput(const Expr& data,
+                        const Group& branches,
+                        size_t depth,
+                        ExprSubstMap* subst_map) {
+  int index = 0;
+  auto split = MakeSplit(data, Integer(branches.size()), 0);
+  for (const auto& branch : branches) {
+    auto split_data = TupleGetItemNode::make(split, index++);
+    auto squeezed_data = MakeSqueeze(split_data, {0});
+    subst_map->insert({GetRef<Expr>(branch[depth]), squeezed_data});
+  }
+}
+
+/*! \brief Combine parallel op into batched op if number of branches >= min_num_branches */
+Expr CombineParallelOpBatch(const Expr& expr,
+                            const std::string& op_name,
+                            const std::string& batch_op_name,
+                            uint64_t min_num_branches) {
+  return ParallelOpBatchCombiner(op_name, batch_op_name, min_num_branches).Combine(expr);
 }
 
 namespace transform {
 
-Pass CombineParallelDense(uint64_t min_num_branches) {
+Pass CombineParallelOpBatch(const std::string& op_name,
+                            const std::string& batch_op_name,
+                            uint64_t min_num_branches) {
   runtime::TypedPackedFunc<Function(Function, Module, PassContext)> pass_func =
     [=](Function f, Module m, PassContext pc) {
-      return Downcast<Function>(CombineParallelDense(f, min_num_branches));
+      return Downcast<Function>(CombineParallelOpBatch(f,
+                                                       op_name,
+                                                       batch_op_name,
+                                                       min_num_branches));
   };
-  return CreateFunctionPass(pass_func, 4, "CombineParallelDense",
+  return CreateFunctionPass(pass_func, 4, "CombineParallelOpBatch",
                             {ir::StringImm::make("InferType")});
 }
 
-TVM_REGISTER_API("relay._transform.CombineParallelDense")
-.set_body_typed(CombineParallelDense);
+TVM_REGISTER_API("relay._transform.CombineParallelOpBatch")
+.set_body_typed(CombineParallelOpBatch);
 
 }  // namespace transform
 

--- a/src/relay/pass/combine_parallel_op_batch.cc
+++ b/src/relay/pass/combine_parallel_op_batch.cc
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ *
+ * \file combine_parallel_op_batch.cc
+ * \brief Combine parallel ops into a single batch op.
+ * 
+ * This pass replaces ops that share the same input node and same shape
+ * with a single op that takes in batched input. The inputs of the new
+ * batched op are the stack of the original inputs. Elementwise and
+ * broadcast ops following the original op are also stacked
+ * and fused if possible. For example:
+ * 
+ *            data
+ *         /         \
+ *    add (2,2)     add (2,2)
+ *      |            |
+ * elemwise (2,2)   elemwise (2,2)
+ *      |            |
+ *
+ * Would become:
+ * 
+*            data
+*              |
+*          add (2,2,2)
+*              |
+*         elemwise (2,2,2)
+*          /       \
+ *
+ */
+
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/attrs/nn.h>
+#include <tvm/relay/attrs/transform.h>
+#include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
+#include <unordered_map>
+#include <unordered_set>
+#include "./expr_subst.h"
+#include "./pattern_util.h"
+#include "./combine_parallel_op.h"
+
+namespace tvm {
+namespace relay {
+
+class ParallelOpBatchCombiner : public ParallelOpCombiner {
+ public:
+  ParallelOpBatchCombiner(const std::string& op_name, uint64_t min_num_branches)
+    : ParallelOpBatchCombiner(op_name, op_name, min_num_branches) {
+  }
+
+  ParallelOpBatchCombiner(const std::string& op_name, const std::string& batched_op_name, uint64_t min_num_branches)
+    : ParallelOpCombiner(op_name, min_num_branches),
+      batched_op_name_(batched_op_name) {
+  }
+
+ protected:
+  bool IsSupportedOp(const CallNode* n) {
+    return true;
+  }
+
+  bool CanOpsBeCombined(const CallNode* a, const CallNode* b) {
+    if (!eq(a->args.size(), b->args.size())) {
+      return false;
+    }
+
+    for (size_t i = 0; i < a->args.size(); i++) {
+      const auto* ta = a->args[i]->type_as<TensorTypeNode>();
+      const auto* tb = b->args[i]->type_as<TensorTypeNode>();
+      if (!eq(ta->shape.size(), tb->shape.size()) || !eq(ta->dtype, tb->dtype)) {
+        return false;
+      }
+
+      for (size_t j = 0; j < ta->shape.size(); j++) {
+        if (!eq(ta->shape[j], tb->shape[j])) {
+          return false;
+        }
+      }
+    }
+  }
+
+  Call MakeCombinedOp(const Group& branches) {
+    const Op& batch_op = Op::Get(batched_op_name_);
+    
+    Array<Expr> stacked_args;
+    size_t num_args = branches[0][0]->args.size();
+    for (size_t i = 0; i < num_args; i++) {
+      Array<Expr> new_arg;
+      for (const auto& branch : branches) {
+        new_arg.push_back(branch[0]->args[i]);
+      }
+
+      Expr new_arg_stack = MakeStack(TupleNode::make(new_arg), 0);
+      stacked_args.push_back(new_arg_stack);
+    }
+
+    return CallNode::make(batch_op, stacked_args, Attrs(), {});
+  }
+
+  bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) {
+    AttrsEqual eq;
+    auto ta = a->args[index]->type_as<TensorTypeNode>();
+    auto tb = b->args[index]->type_as<TensorTypeNode>();
+
+    if (!eq(ta->dtype, tb->dtype) || ta->shape.size() != tb->shape.size())
+      return false;
+
+    for (size_t i = 0; i < ta->shape.size(); i++) {
+      if (!eq(ta->shape[i], tb->shape[i]))
+        return false;
+    }
+    return true;
+  }
+
+  Call MakeCombinedCallFromFollowingOps(const Expr& data,
+                                        const Group& branches,
+                                        size_t depth,
+                                        size_t parent_index) {
+    Array<Expr> new_args;
+    const CallNode* call = branches[0][depth];
+
+    for (size_t i = 0; i < call->args.size(); i++) {
+      if (i == parent_index) {
+        new_args.push_back(data);
+        continue;
+      }
+
+      Array<Expr> tuple;
+      for (const auto& branch : branches) {
+        // if the shape of the arg is 1D, expand it to (1,j) so it can be properly broadcasted.
+        Expr arg = branch[depth]->args[i];
+        const TensorTypeNode* arg_tensor = arg->type_as<TensorTypeNode>();
+        if (arg_tensor->shape.size() == 1) {
+          Expr expanded_arg = MakeExpandDims(arg, 0, 1);
+          tuple.push_back(expanded_arg);
+        } else {
+          tuple.push_back(arg);
+        }
+      }
+
+      auto stack = MakeStack(TupleNode::make(tuple), 0);
+      new_args.push_back(std::move(stack));
+    }
+
+    return CallNode::make(call->op, new_args, call->attrs, {});
+  }
+
+  void UpdateGroupOutput(const Expr& data,
+                         const Group& branches,
+                         size_t depth,
+                         ExprSubstMap* subst_map) {
+    int index = 0;
+    auto split = MakeSplit(data, Integer(branches.size()), 0);
+    for (const auto& branch : branches) {
+      auto split_data = TupleGetItemNode::make(split, index++);
+      auto squeezed_data = MakeSqueeze(split_data, {0});
+      subst_map->insert({GetRef<Expr>(branch[depth]), squeezed_data});
+    }
+  }
+
+private:
+  std::string batched_op_name_;
+};
+
+/*! \brief Combine parallel dense if number of branches >= min_num_branches */
+Expr CombineParallelDense(const Expr& expr, uint64_t min_num_branches) {
+  return ParallelDenseCombiner(min_num_branches).Combine(expr);
+}
+
+namespace transform {
+
+Pass CombineParallelDense(uint64_t min_num_branches) {
+  runtime::TypedPackedFunc<Function(Function, Module, PassContext)> pass_func =
+    [=](Function f, Module m, PassContext pc) {
+      return Downcast<Function>(CombineParallelDense(f, min_num_branches));
+  };
+  return CreateFunctionPass(pass_func, 4, "CombineParallelDense",
+                            {ir::StringImm::make("InferType")});
+}
+
+TVM_REGISTER_API("relay._transform.CombineParallelDense")
+.set_body_typed(CombineParallelDense);
+
+}  // namespace transform
+
+}  // namespace relay
+}  // namespace tvm

--- a/src/relay/pass/combine_parallel_op_batch.cc
+++ b/src/relay/pass/combine_parallel_op_batch.cc
@@ -144,7 +144,6 @@ Call ParallelOpBatchCombiner::MakeCombinedCallFromFollowingOps(const Expr& data,
     Array<Expr> tuple;
     for (const auto& branch : branches) {
       Expr arg = branch[depth]->args[i];
-      const TensorTypeNode* arg_tensor = arg->type_as<TensorTypeNode>();
 
       // special case for bias_add: 1D data needs to be expanded to (1,size)
       // for proper broadcasting.

--- a/src/relay/pass/combine_parallel_op_batch.h
+++ b/src/relay/pass/combine_parallel_op_batch.h
@@ -41,32 +41,105 @@
 namespace tvm {
 namespace relay {
 
+/*
+  Class to find and combine parallel ops and following element-wise
+  and broadcast ops into a single batch op. Ops can be combined
+  if they have the same input data. Batch op is formed by
+  stacking inputs. Final results are retrieved by splitting output.
+  For example:
+
+                data
+          /              \
+     dense (2,2)         dense (2,2)
+         |                 |
+    elemwise/bcast (2,2)  elemwise/bcast (2,2)
+
+    Would become:
+
+             data
+              |
+      batch_matmul+elemwise/bcast (2,2,2)
+*/
 class ParallelOpBatchCombiner : public ParallelOpCombiner {
  public:
+  /*
+    \brief Constructor.
+    \param op_name name of op to combine
+    \param batch_op_name name of op that combined branches will be joined into
+    \param min_num_branches min number of parallel branches beginning with op
+                            to start combining
+   */
   ParallelOpBatchCombiner(const std::string& op_name,
                           const std::string& batch_op_name,
                           uint64_t min_num_branches);
 
  protected:
+  /*
+    \brief Checks if node is supported to be combined
+    \param n node in question
+    \return True by default
+   */
   virtual bool IsSupportedOp(const CallNode* n);
 
+  /*
+    \brief Checks if two ops can be combined
+    \param a node a
+    \param b node b
+    \return True if shapes and dtypes of all args of a and b are the same
+   */
   virtual bool CanOpsBeCombined(const CallNode* a, const CallNode* b);
 
+  /*
+    \brief Makes combined op from parallel ops in branches. This usually involves
+           concatenating or stacking inputs, then creating a new call.
+    \param branches branches that are to be combined
+    \return new call with branches combined as batch op by stacking args
+   */
   Call MakeCombinedOp(const Group& branches) final;
 
+  /*
+    \brief Checks if argument of op following combined ops are able to be combined
+    \param a node a
+    \param b node b
+    \param index index of argument in question
+    \return True if shapes and dtypes of args[index] a and b are the same
+   */
   bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) final;
 
+  /*
+    \brief Create combined call from ops that follow the initial combined op at the depth-th level.
+           This usually involves concatenating or stacking inputs, then creating a new call.
+           Only called if IsArgCompatbile returns true for each arg.
+    \param data combined op
+    \param branches branches of parallel ops to be combined
+    \param depth depth at which to combine ops
+    \param parent_index index of arg that corresponds to original input that was shared among
+                        all combined ops
+    \return new combined call as batch op by stacking args
+   */
   Call MakeCombinedCallFromFollowingOps(const Expr& data,
                                         const Group& branches,
                                         size_t depth,
                                         size_t parent_index) final;
 
+  /*
+    \brief Updates map of expr to substitute with combined expr. This usually involves
+           slicing or splitting data.
+    \param data combined op
+    \param branches branches of parallel ops to be combined
+    \param depth depth at which to substitute
+    \param subst_map map of Expr to replace with Expr to replace it with
+   */
   void UpdateGroupOutput(const Expr& data,
                          const Group& branches,
                          size_t depth,
                          ExprSubstMap* subst_map) final;
 
  private:
+  /* name of op to replace combined ops with. for example,
+     for combining parallel dense, this will will be set to
+     nn.batch_matmul 
+    */
   std::string batch_op_name_;
 };
 

--- a/src/relay/pass/combine_parallel_op_batch.h
+++ b/src/relay/pass/combine_parallel_op_batch.h
@@ -136,9 +136,9 @@ class ParallelOpBatchCombiner : public ParallelOpCombiner {
                          ExprSubstMap* subst_map) final;
 
  private:
-  /* name of op to replace combined ops with. for example,
-     for combining parallel dense, this will will be set to
-     nn.batch_matmul 
+  /* \brief name of op to replace combined ops with. for example,
+            for combining parallel dense, this will will be set to
+            nn.batch_matmul 
     */
   std::string batch_op_name_;
 };

--- a/src/relay/pass/combine_parallel_op_batch.h
+++ b/src/relay/pass/combine_parallel_op_batch.h
@@ -42,32 +42,32 @@ namespace tvm {
 namespace relay {
 
 /*
-  Class to find and combine parallel ops and following element-wise
-  and broadcast ops into a single batch op. Ops can be combined
-  if they have the same input data. Batch op is formed by
-  stacking inputs. Final results are retrieved by splitting output.
-  For example:
-
-                data
-          /              \
-     dense (2,2)         dense (2,2)
-         |                 |
-    elemwise/bcast (2,2)  elemwise/bcast (2,2)
-
-    Would become:
-
-             data
-              |
-      batch_matmul+elemwise/bcast (2,2,2)
-*/
+ * Class to find and combine parallel ops and following element-wise
+ * and broadcast ops into a single batch op. Ops can be combined
+ * if they have the same input data. Batch op is formed by
+ * stacking inputs. Final results are retrieved by splitting output.
+ * For example:
+ *
+ *               data
+ *         /              \
+ *    dense (2,2)         dense (2,2)
+ *        |                 |
+ *   elemwise/bcast (2,2)  elemwise/bcast (2,2)
+ *
+ *   Would become:
+ *
+ *            data
+ *             |
+ *     batch_matmul+elemwise/bcast (2,2,2)
+ */
 class ParallelOpBatchCombiner : public ParallelOpCombiner {
  public:
   /*
-    \brief Constructor.
-    \param op_name name of op to combine
-    \param batch_op_name name of op that combined branches will be joined into
-    \param min_num_branches min number of parallel branches beginning with op
-                            to start combining
+   * \brief Constructor.
+   * \param op_name name of op to combine
+   * \param batch_op_name name of op that combined branches will be joined into
+   * \param min_num_branches min number of parallel branches beginning with op
+   *                         to start combining
    */
   ParallelOpBatchCombiner(const std::string& op_name,
                           const std::string& batch_op_name,
@@ -75,47 +75,47 @@ class ParallelOpBatchCombiner : public ParallelOpCombiner {
 
  protected:
   /*
-    \brief Checks if node is supported to be combined
-    \param n node in question
-    \return True by default
+   * \brief Checks if node is supported to be combined
+   * \param n node in question
+   * \return True by default
    */
   virtual bool IsSupportedOp(const CallNode* n);
 
   /*
-    \brief Checks if two ops can be combined
-    \param a node a
-    \param b node b
-    \return True if shapes and dtypes of all args of a and b are the same
+   * \brief Checks if two ops can be combined
+   * \param a node a
+   * \param b node b
+   * \return True if shapes and dtypes of all args of a and b are the same
    */
   virtual bool CanOpsBeCombined(const CallNode* a, const CallNode* b);
 
   /*
-    \brief Makes combined op from parallel ops in branches. This usually involves
-           concatenating or stacking inputs, then creating a new call.
-    \param branches branches that are to be combined
-    \return new call with branches combined as batch op by stacking args
+   * \brief Makes combined op from parallel ops in branches. This usually involves
+   *        concatenating or stacking inputs, then creating a new call.
+   * \param branches branches that are to be combined
+   * \return new call with branches combined as batch op by stacking args
    */
   Call MakeCombinedOp(const Group& branches) final;
 
   /*
-    \brief Checks if argument of op following combined ops are able to be combined
-    \param a node a
-    \param b node b
-    \param index index of argument in question
-    \return True if shapes and dtypes of args[index] a and b are the same
+   * \brief Checks if argument of op following combined ops are able to be combined
+   * \param a node a
+   * \param b node b
+   * \param index index of argument in question
+   * \return True if shapes and dtypes of args[index] a and b are the same
    */
   bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) final;
 
   /*
-    \brief Create combined call from ops that follow the initial combined op at the depth-th level.
-           This usually involves concatenating or stacking inputs, then creating a new call.
-           Only called if IsArgCompatbile returns true for each arg.
-    \param data combined op
-    \param branches branches of parallel ops to be combined
-    \param depth depth at which to combine ops
-    \param parent_index index of arg that corresponds to original input that was shared among
-                        all combined ops
-    \return new combined call as batch op by stacking args
+   * \brief Create combined call from ops that follow the initial combined op at the depth-th level.
+   *        This usually involves concatenating or stacking inputs, then creating a new call.
+   *        Only called if IsArgCompatbile returns true for each arg.
+   * \param data combined op
+   * \param branches branches of parallel ops to be combined
+   * \param depth depth at which to combine ops
+   * \param parent_index index of arg that corresponds to original input that was shared among
+   *                     all combined ops
+   * \return new combined call as batch op by stacking args
    */
   Call MakeCombinedCallFromFollowingOps(const Expr& data,
                                         const Group& branches,
@@ -123,12 +123,12 @@ class ParallelOpBatchCombiner : public ParallelOpCombiner {
                                         size_t parent_index) final;
 
   /*
-    \brief Updates map of expr to substitute with combined expr. This usually involves
-           slicing or splitting data.
-    \param data combined op
-    \param branches branches of parallel ops to be combined
-    \param depth depth at which to substitute
-    \param subst_map map of Expr to replace with Expr to replace it with
+   * \brief Updates map of expr to substitute with combined expr. This usually involves
+   *        slicing or splitting data.
+   * \param data combined op
+   * \param branches branches of parallel ops to be combined
+   * \param depth depth at which to substitute
+   * \param subst_map map of Expr to replace with Expr to replace it with
    */
   void UpdateGroupOutput(const Expr& data,
                          const Group& branches,
@@ -137,9 +137,9 @@ class ParallelOpBatchCombiner : public ParallelOpCombiner {
 
  private:
   /* \brief name of op to replace combined ops with. for example,
-            for combining parallel dense, this will will be set to
-            nn.batch_matmul 
-    */
+   *         for combining parallel dense, this will will be set to
+   *         nn.batch_matmul 
+   */
   std::string batch_op_name_;
 };
 

--- a/src/relay/pass/combine_parallel_op_batch.h
+++ b/src/relay/pass/combine_parallel_op_batch.h
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file combine_parallel_op_batch.cc
+ * \brief Combine parallel ops into a single batch op.
+ */
+#ifndef TVM_RELAY_PASS_COMBINE_PARALLEL_OP_BATCH_H_
+#define TVM_RELAY_PASS_COMBINE_PARALLEL_OP_BATCH_H_
+
+#include <tvm/relay/analysis.h>
+#include <tvm/relay/expr_functor.h>
+#include <tvm/relay/attrs/nn.h>
+#include <tvm/relay/attrs/transform.h>
+#include <tvm/relay/op_attr_types.h>
+#include <tvm/relay/transform.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+#include "./expr_subst.h"
+#include "./pattern_util.h"
+#include "./combine_parallel_op.h"
+
+namespace tvm {
+namespace relay {
+
+class ParallelOpBatchCombiner : public ParallelOpCombiner {
+ public:
+  ParallelOpBatchCombiner(const std::string& op_name,
+                          const std::string& batch_op_name,
+                          uint64_t min_num_branches);
+
+ protected:
+  virtual bool IsSupportedOp(const CallNode* n);
+
+  virtual bool CanOpsBeCombined(const CallNode* a, const CallNode* b);
+
+  Call MakeCombinedOp(const Group& branches) final;
+
+  bool IsArgCompatible(const CallNode* a, const CallNode* b, size_t index) final;
+
+  Call MakeCombinedCallFromFollowingOps(const Expr& data,
+                                        const Group& branches,
+                                        size_t depth,
+                                        size_t parent_index) final;
+
+  void UpdateGroupOutput(const Expr& data,
+                         const Group& branches,
+                         size_t depth,
+                         ExprSubstMap* subst_map) final;
+
+ private:
+  std::string batch_op_name_;
+};
+
+}  // namespace relay
+}  // namespace tvm
+
+#endif  // TVM_RELAY_PASS_COMBINE_PARALLEL_OP_BATCH_H_

--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -419,6 +419,10 @@ Expr MakeConcatenate(Expr data, int axis);
 
 Expr MakeStridedSlice(Expr data, Array<Integer> begin, Array<Integer> end, Array<Integer> strides);
 
+Expr MakeStack(Expr data);
+
+Expr MakeSplit(Expr data, int indices_or_sections, int axis);
+
 Expr StopFusion(Expr data);
 
 Expr CastHint(Expr data, DataType dtype);

--- a/src/relay/pass/pattern_util.h
+++ b/src/relay/pass/pattern_util.h
@@ -419,9 +419,13 @@ Expr MakeConcatenate(Expr data, int axis);
 
 Expr MakeStridedSlice(Expr data, Array<Integer> begin, Array<Integer> end, Array<Integer> strides);
 
-Expr MakeStack(Expr data);
+Expr MakeStack(Expr data, int axis);
 
-Expr MakeSplit(Expr data, int indices_or_sections, int axis);
+Expr MakeSplit(Expr data, NodeRef indices_or_sections, int axis);
+
+Expr MakeSqueeze(Expr data, Array<Integer> axis);
+
+Expr MakeExpandDims(Expr data, int axis, int num_newaxis);
 
 Expr StopFusion(Expr data);
 

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -31,7 +31,7 @@ def run_opt_pass(expr, opt_pass):
 
 
 def test_combine_parallel_dense():
-    """Simple testcase. One dense cannot be combined because of shape mismatch"""
+    """Simple testcase. One dense cannot be combined due to shape mismatch"""
     def before(x, w1, w2, w3, w4):
         args = [x, w1, w2, w3, w4]
         y1 = relay.nn.dense(x, w1)

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -31,7 +31,7 @@ def run_opt_pass(expr, opt_pass):
 
 
 def test_combine_parallel_dense():
-    """Simple testcase. Three can be combined, either because of mismatched shapes or units"""
+    """Simple testcase. One dense cannot be combined because of mismatched shapes or units"""
     def before(x, w1, w2, w3, w4, units):
         args = [x, w1, w2, w3, w4]
         y1 = relay.nn.dense(x, w1)
@@ -147,7 +147,7 @@ def test_combine_parallel_dense_biasadd():
     check(100, 200, 300, True)
 
 def test_combine_parallel_dense_biasadd_scale_reshape():
-    """Testcase of combining dense + 1d biasadd"""
+    """Testcase of combining dense + 1d biasadd + multiply with non-fused reshape"""
     def before(x, w1, w2, b1, b2, scale1, scale2, newshape):
         args = [x, w1, w2, b1, b2, scale1, scale2]
         y1 = relay.nn.dense(x, w1)

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -31,7 +31,7 @@ def run_opt_pass(expr, opt_pass):
 
 
 def test_combine_parallel_dense():
-    """Simple testcase. One dense cannot be combined because of mismatched shapes"""
+    """Simple testcase. One dense cannot be combined because of shape mismatch"""
     def before(x, w1, w2, w3, w4):
         args = [x, w1, w2, w3, w4]
         y1 = relay.nn.dense(x, w1)

--- a/tests/python/relay/test_pass_combine_parallel_dense.py
+++ b/tests/python/relay/test_pass_combine_parallel_dense.py
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from tvm import relay
+from tvm.relay import transform
+
+
+def run_combine_parallel(expr, min_num_branches=3):
+    mod = relay.Module.from_expr(expr)
+    mod = transform.CombineParallelDense(min_num_branches)(mod)
+    return mod["main"]
+
+def run_opt_pass(expr, opt_pass):
+    assert isinstance(opt_pass, transform.Pass)
+    mod = relay.Module.from_expr(expr)
+    mod = opt_pass(mod)
+    return mod["main"]
+
+
+def test_combine_parallel_dense():
+    """Simple testcase."""
+    def before(x, w1, w2, w3, w4):
+        args = [x, w1, w2, w3, w4]
+        y1 = relay.nn.dense(x, w1)
+        y2 = relay.nn.dense(x, w2)
+        # y3 cannot be combined
+        y3 = relay.nn.dense(x, w3)
+        y4 = relay.nn.dense(x, w4)
+        y = relay.Tuple((y1, y2, y3, y4))
+        return relay.Function(args, y)
+
+    def expected(x, w1, w2, w3, w4, channels1, channels2, channels3, channels4):
+        # use a fixed order of args so alpha equal check can pass
+        args = [x, w1, w2, w3, w4]
+        w = relay.concatenate((w1, w2, w4), axis=0)
+        y = relay.nn.conv2d(x, w, channels=channels1 + channels2 + channels4)
+        y1 = relay.strided_slice(y, [0, 0], [None, channels1])
+        y2 = relay.strided_slice(y, [0, channels1], [None, channels1 + channels2])
+        y3 = relay.nn.conv2d(x, w3)
+        y4 = relay.strided_slice(y, [0, channels1 + channels2],
+                                 [None, channels1 + channels2 + channels4])
+        y5 = relay.nn.max_pool2d(x)
+        y = relay.Tuple((y1, y2, y3, y4, y5))
+        return relay.Function(args, y)
+
+    def check(x_shape, channels1, channels2, channels3, channels4):
+        x =  relay.var("x", shape=x_shape)
+        in_c = x_shape[1]
+        w1 = relay.var("w1", shape=(channels1, in_c, 1, 1))
+        w2 = relay.var("w2", shape=(channels2, in_c, 1, 1))
+        w3 = relay.var("w3", shape=(channels3, in_c, 3, 3))
+        w4 = relay.var("w4", shape=(channels4, in_c, 1, 1))
+
+        y_before = before(x, w1, w2, w3, w4)
+        y = run_opt_pass(y_before,
+                         transform.CombineParallelConv2D(min_num_branches=2))
+        y_expected = expected(x, w1, w2, w3, w4, channels1, channels2, channels3, channels4)
+        y_expected = run_opt_pass(y_expected, transform.InferType())
+        assert relay.analysis.alpha_equal(y, y_expected)
+
+    check((1, 4, 16, 16), 4, 4, 4, 4)
+    check((1, 4, 16, 16), 4, 8, 4, 7)
+
+
+def test_combine_parallel_conv2d_scale_relu():
+    """Testcase of combining conv2d + scale + relu"""
+    def before(x, w1, w2, scale1, scale2, bias):
+        args = [x, w1, w2, scale1, scale2, bias]
+        y1 = relay.nn.conv2d(x, w1)
+        y1 = relay.multiply(y1, scale1)
+        y1 = relay.nn.relu(y1)
+        y2 = relay.nn.conv2d(x, w2)
+        y2 = relay.multiply(y2, scale2)
+        y2 = relay.nn.relu(y2)
+        y2 = relay.add(y2, bias)
+        y = relay.Tuple((y1, y2))
+        return relay.Function(args, y)
+
+    def expected(x, w1, w2, scale1, scale2, bias, channels1, channels2):
+        args = [x, w1, w2, scale1, scale2, bias]
+        w = relay.concatenate((w1, w2), axis=0)
+        scale = relay.concatenate((scale1, scale2), axis=0)
+        y = relay.nn.conv2d(x, w, channels=channels1 + channels2)
+        y = relay.multiply(y, scale)
+        y = relay.nn.relu(y)
+        y1 = relay.strided_slice(y, [0, 0], [None, channels1])
+        y2 = relay.strided_slice(y, [0, channels1], [None, channels1 + channels2])
+        y2 = relay.add(y2, bias)
+        y = relay.Tuple((y1, y2))
+        return relay.Function(args, y)
+
+    def check(x_shape, channels1, channels2):
+        x = relay.var("x", shape=x_shape)
+        in_c = x_shape[1]
+        w1 = relay.var("w1", shape=(channels1, in_c, 1, 1))
+        w2 = relay.var("w2", shape=(channels2, in_c, 1, 1))
+        scale1 = relay.var("scale1", shape=(channels1, 1, 1))
+        scale2 = relay.var("scale2", shape=(channels2, 1, 1))
+        bias = relay.var("bias", shape=(channels2, 1, 1))
+        y_before = before(x, w1, w2, scale1, scale2, bias)
+        y = run_opt_pass(y_before,
+                         transform.CombineParallelConv2D(min_num_branches=2))
+        y_expected = expected(x, w1, w2, scale1, scale2, bias, channels1, channels2)
+        y_expected = run_opt_pass(y_expected, transform.InferType())
+        assert relay.analysis.alpha_equal(y, y_expected)
+
+    check((1, 4, 16, 16), 4, 8)
+
+
+def test_combine_parallel_conv2d_scale():
+    """Testcase of un-combinable scale"""
+    def before(x, w1, w2, scale1, scale2):
+        args = [x, w1, w2, scale1, scale2]
+        y1 = relay.nn.conv2d(x, w1)
+        y1 = relay.multiply(y1, scale1)
+        y2 = relay.nn.conv2d(x, w2)
+        y2 = relay.multiply(y2, scale2)
+        y = relay.Tuple((y1, y2))
+        return relay.Function(args, y)
+
+    def expected(x, w1, w2, scale1, scale2, channels1, channels2):
+        args = [x, w1, w2, scale1, scale2]
+        w = relay.concatenate((w1, w2), axis=0)
+        y = relay.nn.conv2d(x, w, channels=channels1 + channels2)
+        y1 = relay.strided_slice(y, [0, 0], [None, channels1])
+        y2 = relay.strided_slice(y, [0, channels1], [None, channels1 + channels2])
+        y1 = relay.multiply(y1, scale1)
+        y2 = relay.multiply(y2, scale2)
+        y = relay.Tuple((y1, y2))
+        return relay.Function(args, y)
+
+    def check(x_shape, channels1, channels2):
+        x = relay.var("x", shape=x_shape)
+        in_c = x_shape[1]
+        w1 = relay.var("w1", shape=(channels1, in_c, 1, 1))
+        w2 = relay.var("w2", shape=(channels2, in_c, 1, 1))
+        scale1 = relay.var("scale1", shape=(1,))
+        scale2 = relay.var("scale2", shape=(1,))
+        y_before = before(x, w1, w2, scale1, scale2)
+        y = run_opt_pass(y_before,
+                         transform.CombineParallelConv2D(min_num_branches=2))
+        y_expected = expected(x, w1, w2, scale1, scale2, channels1, channels2)
+        y_expected = run_opt_pass(y_expected, transform.InferType())
+        assert relay.analysis.alpha_equal(y, y_expected)
+
+    check((1, 4, 16, 16), 4, 8)
+
+
+def test_combine_parallel_conv2d_multiple_blocks():
+    def before(x, w, repeat):
+        args = [x, w]
+        y = x
+        for i in range(repeat):
+            y1 = relay.nn.conv2d(y, w)
+            y2 = relay.nn.conv2d(y, w)
+            y = relay.concatenate((y1, y2), axis=1)
+        return relay.Function(args, y)
+
+    def expected(x, w, channels, repeat):
+        args = [x, w]
+        y = x
+        for i in range(repeat):
+            w_concat = relay.concatenate((w, w), axis=0)
+            y = relay.nn.conv2d(y, w_concat, channels=channels*2)
+            y1 = relay.strided_slice(y, [0, 0], [None, channels])
+            y2 = relay.strided_slice(y, [0, channels], [None, channels * 2])
+            y = relay.concatenate((y1, y2), axis=1)
+        return relay.Function(args, y)
+
+    def check(x_shape, repeat):
+        x = relay.var("x", shape=x_shape)
+        in_c = x_shape[1]
+        out_c = in_c // 2
+        w = relay.var("w", shape=(out_c, in_c, 1, 1))
+        y_before = before(x, w, repeat)
+        y = run_opt_pass(y_before,
+                         transform.CombineParallelConv2D(min_num_branches=2))
+        y_expected = expected(x, w, out_c, repeat)
+        y_expected = run_opt_pass(y_expected, transform.InferType())
+        assert relay.analysis.alpha_equal(y, y_expected)
+
+    check((1, 4, 16, 16), 4)
+
+
+if __name__ == "__main__":
+    test_combine_parallel_dense()
+    #test_combine_parallel_dense_biasadd()


### PR DESCRIPTION
This IR pass is similar to CombineParallelConv2D, but with the Dense operator. The pass takes multiple parallel dense operators and combines them into one batch_matmul operator. Element-wise operations  after dense are also stacked and fused. 

The code is refactored so CombineParallelConv2D and CombineParallelDense can share code, and make it easier to write a new "combine" pass later.

This is in opt level 4. In another PR, we can add tuning to decide whether or not to apply this pass.

This will help models like BERT, which have parallel Dense + BiasAdd at the start of each layer.

Discussed in this RFC: https://discuss.tvm.ai/t/discussion-new-ir-pass-proposal-combineparalleldense/3813

@vinx13 @icemelon9 would you be able to take a look?