### PR TITLE
[VTA][Chisel] rename USE_TSIM macro with USE_VTA64 and cleanup runtime

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -71,8 +71,6 @@ elseif(PYTHON)
       target_compile_definitions(vta_tsim PUBLIC ${__strip_def})
     endforeach()
     include_directories("vta/include")
-    # Set USE_TSIM macro
-    target_compile_definitions(vta_tsim PUBLIC USE_TSIM)
     if(APPLE)
       set_target_properties(vta_tsim PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
     endif(APPLE)

--- a/vta/hardware/chisel/Makefile
+++ b/vta/hardware/chisel/Makefile
@@ -32,7 +32,7 @@ ifeq (, $(VERILATOR_INC_DIR))
   endif
 endif
 
-CONFIG = DefaultF1Config
+CONFIG = DefaultPynqConfig
 TOP = VTA
 TOP_TEST = Test
 BUILD_NAME = build

--- a/vta/include/vta/driver.h
+++ b/vta/include/vta/driver.h
@@ -53,7 +53,7 @@ extern "C" {
 typedef void * VTADeviceHandle;
 
 /*! \brief physical address */
-#ifdef USE_TSIM
+#ifdef USE_VTA64
 typedef uint64_t vta_phy_addr_t;
 #else
 typedef uint32_t vta_phy_addr_t;
@@ -80,22 +80,10 @@ void VTADeviceFree(VTADeviceHandle handle);
  *
  * \return 0 if running is successful, 1 if timeout.
  */
-#ifdef USE_TSIM
-int VTADeviceRun(VTADeviceHandle device,
-                 vta_phy_addr_t insn_phy_addr,
-                 vta_phy_addr_t uop_phy_addr,
-                 vta_phy_addr_t inp_phy_addr,
-                 vta_phy_addr_t wgt_phy_addr,
-                 vta_phy_addr_t acc_phy_addr,
-                 vta_phy_addr_t out_phy_addr,
-                 uint32_t insn_count,
-                 uint32_t wait_cycles);
-#else
 int VTADeviceRun(VTADeviceHandle device,
                  vta_phy_addr_t insn_phy_addr,
                  uint32_t insn_count,
                  uint32_t wait_cycles);
-#endif
 
 /*!
  * \brief Allocates physically contiguous region in memory readable/writeable by FPGA.

--- a/vta/src/tsim/tsim_driver.cc
+++ b/vta/src/tsim/tsim_driver.cc
@@ -116,20 +116,10 @@ class Device {
   }
 
   int Run(vta_phy_addr_t insn_phy_addr,
-          vta_phy_addr_t uop_phy_addr,
-          vta_phy_addr_t inp_phy_addr,
-          vta_phy_addr_t wgt_phy_addr,
-          vta_phy_addr_t acc_phy_addr,
-          vta_phy_addr_t out_phy_addr,
           uint32_t insn_count,
           uint32_t wait_cycles) {
     this->Init();
     this->Launch(insn_phy_addr,
-                 uop_phy_addr,
-                 inp_phy_addr,
-                 wgt_phy_addr,
-                 acc_phy_addr,
-                 out_phy_addr,
                  insn_count,
                  wait_cycles);
     this->WaitForCompletion(wait_cycles);
@@ -143,27 +133,15 @@ class Device {
   }
 
   void Launch(vta_phy_addr_t insn_phy_addr,
-              vta_phy_addr_t uop_phy_addr,
-              vta_phy_addr_t inp_phy_addr,
-              vta_phy_addr_t wgt_phy_addr,
-              vta_phy_addr_t acc_phy_addr,
-              vta_phy_addr_t out_phy_addr,
               uint32_t insn_count,
               uint32_t wait_cycles) {
-    dpi_->WriteReg(0x04, 0);
     dpi_->WriteReg(0x08, insn_count);
     dpi_->WriteReg(0x0c, insn_phy_addr);
-    dpi_->WriteReg(0x10, insn_phy_addr >> 32);
+    dpi_->WriteReg(0x10, 0);
     dpi_->WriteReg(0x14, 0);
-    dpi_->WriteReg(0x18, uop_phy_addr >> 32);
+    dpi_->WriteReg(0x18, 0);
     dpi_->WriteReg(0x1c, 0);
-    dpi_->WriteReg(0x20, inp_phy_addr >> 32);
-    dpi_->WriteReg(0x24, 0);
-    dpi_->WriteReg(0x28, wgt_phy_addr >> 32);
-    dpi_->WriteReg(0x2c, 0);
-    dpi_->WriteReg(0x30, acc_phy_addr >> 32);
-    dpi_->WriteReg(0x34, 0);
-    dpi_->WriteReg(0x38, out_phy_addr >> 32);
+    dpi_->WriteReg(0x20, 0);
     // start
     dpi_->WriteReg(0x00, 0x1);
   }
@@ -247,20 +225,10 @@ void VTADeviceFree(VTADeviceHandle handle) {
 
 int VTADeviceRun(VTADeviceHandle handle,
                  vta_phy_addr_t insn_phy_addr,
-                 vta_phy_addr_t uop_phy_addr,
-                 vta_phy_addr_t inp_phy_addr,
-                 vta_phy_addr_t wgt_phy_addr,
-                 vta_phy_addr_t acc_phy_addr,
-                 vta_phy_addr_t out_phy_addr,
                  uint32_t insn_count,
                  uint32_t wait_cycles) {
   return static_cast<vta::tsim::Device*>(handle)->Run(
       insn_phy_addr,
-      uop_phy_addr,
-      inp_phy_addr,
-      wgt_phy_addr,
-      acc_phy_addr,
-      out_phy_addr,
       insn_count,
       wait_cycles);
 }


### PR DESCRIPTION
Hey @tmoreau89 @liangfu,

The following PR removes `USE_TSIM` from runtime, since now we have a virtual memory manager that can handle 32-bit addresses. I kept only the switch on the driver but renamed as `USE_VTA64` for 64-bit address systems. I am also making the `Pynq` as default configuration for testing in Chisel. I modified the `tsim_driver.cc` to reflect that.

Let me know if I am missing anything else.