### PR TITLE
[VTA] Fix TSIM compile error in Linux (add missing -fPIC flag)

### DIFF
--- a/vta/hardware/chisel/Makefile
+++ b/vta/hardware/chisel/Makefile
@@ -82,7 +82,7 @@ cxx_flags += -I$(tvm_dir)/3rdparty/dlpack/include
 ld_flags = -fPIC -shared
 
 cxx_objs = $(verilator_build_dir)/verilated.o $(verilator_build_dir)/verilated_dpi.o $(verilator_build_dir)/tsim_device.o
-cxx_objs += $(patsubst %.cpp,%.o,$(wildcard $(verilator_build_dir)/*.cpp))
+## cxx_objs += $(patsubst %.cpp,%.o,$(wildcard $(verilator_build_dir)/*.cpp))
 
 ifneq ($(USE_TRACE), 0)
   verilator_opt += --trace
@@ -108,13 +108,16 @@ default: lib
 lib: $(lib_path)
 
 $(verilator_build_dir)/%.o: %.cpp
-	$(CXX) -c $(cxx_flags) $^ -o $@
+	$(CXX) -fPIC $(cxx_flags) -c $^ -o $@
 
 $(verilator_build_dir)/tsim_device.o: tsim_device.cc
-	$(CXX) -c $(cxx_flags) $^ -o $@
+	$(CXX) -fPIC $(cxx_flags) -c $^ -o $@
 
 $(lib_path): $(verilator_build_dir)/V$(TOP_TEST).cpp $(cxx_objs)
-	$(CXX) $(cxx_flags) $(ld_flags) $(cxx_objs) -o $@
+	for f in $(shell find $(verilator_build_dir)/*.cpp); do \
+    $(CXX) -fPIC $(cxx_flags) -c $${f} -o $${f}.o ; \
+  done
+	$(CXX) $(ld_flags) $(cxx_flags) $(cxx_objs) $(patsubst %.cpp,%.cpp.o,$(shell find $(verilator_build_dir)/*.cpp)) -o $@
 
 verilator: $(verilator_build_dir)/V$(TOP_TEST).cpp
 $(verilator_build_dir)/V$(TOP_TEST).cpp: $(chisel_build_dir)/$(TOP_TEST).$(CONFIG).v

--- a/vta/hardware/chisel/Makefile
+++ b/vta/hardware/chisel/Makefile
@@ -114,8 +114,8 @@ $(verilator_build_dir)/tsim_device.o: tsim_device.cc
 
 $(lib_path): $(verilator_build_dir)/V$(TOP_TEST).cpp $(cxx_objs)
 	for f in $(shell find $(verilator_build_dir)/*.cpp); do \
-    $(CXX) -fPIC $(cxx_flags) -c $${f} -o $${f}.o ; \
-  done
+		$(CXX) -fPIC $(cxx_flags) -c $${f} -o $${f}.o ; \
+	done
 	$(CXX) $(ld_flags) $(cxx_flags) $(cxx_objs) $(patsubst %.cpp,%.cpp.o,$(shell find $(verilator_build_dir)/*.cpp)) -o $@
 
 verilator: $(verilator_build_dir)/V$(TOP_TEST).cpp

--- a/vta/hardware/chisel/Makefile
+++ b/vta/hardware/chisel/Makefile
@@ -82,7 +82,6 @@ cxx_flags += -I$(tvm_dir)/3rdparty/dlpack/include
 ld_flags = -fPIC -shared
 
 cxx_objs = $(verilator_build_dir)/verilated.o $(verilator_build_dir)/verilated_dpi.o $(verilator_build_dir)/tsim_device.o
-## cxx_objs += $(patsubst %.cpp,%.o,$(wildcard $(verilator_build_dir)/*.cpp))
 
 ifneq ($(USE_TRACE), 0)
   verilator_opt += --trace


### PR DESCRIPTION
This PR fixed the compilation issue raised in #3797 , which requires running `make` command twice to compile the generated .cpp files into the shared library. In addition, the missing `-fPIC` flag has also been added for fixing the compile error in Linux;

@vegaluisjose Please review.