### PR TITLE
Remove extern C warpper for cuBLAS

### DIFF
--- a/src/contrib/cublas/cublas_utils.h
+++ b/src/contrib/cublas/cublas_utils.h
@@ -27,9 +27,7 @@
 
 #include <dmlc/logging.h>
 
-extern "C" {
 #include <cublas_v2.h>
-}
 
 namespace tvm {
 namespace contrib {


### PR DESCRIPTION
cuBLAS has its own way to deal with C++ compilers. Also see https://github.com/dmlc/tvm/issues/3869