### PR TITLE
[TOPI] Add proper scheduling for dense on CUDA

### DIFF
--- a/topi/python/topi/cuda/dense.py
+++ b/topi/python/topi/cuda/dense.py
@@ -113,7 +113,8 @@ def schedule_dense(cfg, outs):
         _, in_dim = get_const_tuple(A.shape)
         cfg.define_split('tile_k', in_dim, num_outputs=2)
         if cfg.is_fallback:
-            cfg["tile_k"] = SplitEntity([1, in_dim])
+            cfg["tile_k"] = SplitEntity(
+                [in_dim // 64, 64] if in_dim > 64 else [1, 64])
 
         ko, kf = cfg['tile_k'].apply(s, C, C.op.reduce_axis[0])
         CF = s.rfactor(C, kf)
@@ -166,7 +167,7 @@ def schedule_dense(cfg, outs):
         if cfg.is_fallback:
             cfg['tile_x'] = SplitEntity([batch // 64, 2, 16, 2])
             cfg['tile_y'] = SplitEntity([out_dim // 64, 2, 16, 2])
-            cfg['tile_k'] = SplitEntity([in_dim, 1, 1])
+            cfg['tile_k'] = SplitEntity([in_dim // 8, 8, 1] if in_dim > 8 else [in_dim, 1, 1])
 
         # scheduling template
         # memory access

--- a/topi/tests/python/test_topi_dense.py
+++ b/topi/tests/python/test_topi_dense.py
@@ -117,8 +117,9 @@ def verify_dense_int8(batch, in_dim, out_dim, use_bias=True):
 def test_dense():
     verify_dense(1, 1024, 1000, use_bias=True)
     verify_dense(1, 1024, 1000, use_bias=False)
-
     verify_dense(2, 1024, 1000, use_bias=True)
+    verify_dense(128, 1024, 1000, use_bias=False)
+    verify_dense(128, 1024, 1000, use_bias=True)
 
 
 def test_dense_int8():


### PR DESCRIPTION
@icemelon9 please review this PR that adds scheduling for dense OP on CUDA since the original scheduling was too basic to achieve reasonable performance.

The added scheduling was modified from topi/recipe/gemm/cuda_gemm_square.py to achieve high performance (6TFlop/s for 2048x2048 dense matrix after AutoTVM tuning). For small batch (<64) dense, we are still based on the original scheduling but just added a parameter (tile_k) for AutoTVM to tune (~370 GFlop/s for batch size 1 dense computation).

One reason to have separate scheduling for different batch size is that I encountered invalid CUDA kernel errors when applying the high performance scheduling to small batch. I think that may be due to invalid splits, but I am not quite sure. You are welcome to comment and suggest improvements.