### PR TITLE
[VTA] RPC path update.

### DIFF
--- a/docs/vta/install.md
+++ b/docs/vta/install.md
@@ -128,7 +128,7 @@ cmake ..
 make runtime vta -j2
 # Build VTA RPC server (takes 1 min)
 cd ..
-sudo ./apps/pynq_rpc/start_rpc_server.sh # pw is 'xilinx'
+sudo ./apps/vta_rpc/start_rpc_server.sh # pw is 'xilinx'
 ```
 
 You should see the following being displayed when starting the RPC server. In order to run the next examples, you'll need to leave the RPC server running in an `ssh` session.

--- a/vta/python/vta/testing/util.py
+++ b/vta/python/vta/testing/util.py
@@ -37,7 +37,7 @@ def run(run_func):
         # Compile vta on your host with make at the root.
         # Make sure TARGET is set to "sim" in the config.json file.
         # Then launch the RPC server on the host machine
-        # with ./apps/pynq_rpc/start_rpc_server.sh
+        # with ./apps/vta_rpc/start_rpc_server.sh
         # Set your VTA_LOCAL_SIM_RPC environment variable to
         # the port it's listening to, e.g. 9090
         local_rpc = int(os.environ.get("VTA_LOCAL_SIM_RPC", "0"))


### PR DESCRIPTION
Issue:
RPC path get changed into "vta_rpc" from "pynq_rpc", but related
document still use old informaiton.

Solution:
Update RPC path information.