### PR TITLE
[Relay] Keras frontend upsample and 1 channel conv2d fixes

### DIFF
--- a/python/tvm/relay/frontend/keras.py
+++ b/python/tvm/relay/frontend/keras.py
@@ -395,7 +395,7 @@ def _convert_pooling(inexpr, keras_layer, etab):
 def _convert_upsample(inexpr, keras_layer, _):
     _check_data_format(keras_layer)
     upsample_type = type(keras_layer).__name__
-    params = {'layout': 'NHWC'}
+    params = {}
     if upsample_type == 'UpSampling1D':
         h = keras_layer.size
         params['scale'] = h

--- a/src/relay/op/nn/convolution.h
+++ b/src/relay/op/nn/convolution.h
@@ -71,7 +71,7 @@ bool Conv2DRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     CHECK_EQ(param->dilation.size(), 2);
     Array<IndexExpr> wshape;
 
-    if (tvm::ir::Equal(param->channels, param->groups)) {
+    if (tvm::ir::Equal(param->channels, param->groups) && !tvm::ir::Equal(param->channels, 1)) {
       // infer weight's shape for depthwise convolution
       wshape = {{dshape_nchw[1], param->groups / dshape_nchw[1], param->kernel_size[0],
                  param->kernel_size[1]}};

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -181,6 +181,7 @@ def test_forward_conv():
                                       strides=(2, 2), padding='same'),
                   keras.layers.Conv2D(filters=10, kernel_size=(3, 3),
                                       dilation_rate=(2, 2), padding='same'),
+                  keras.layers.Conv2D(filters=1, kernel_size=(3, 3), padding='same'),
                   keras.layers.DepthwiseConv2D(kernel_size=(3, 3), padding='same'),
                   keras.layers.Conv2DTranspose(filters=10, kernel_size=(3, 3), padding='valid'),
                   keras.layers.SeparableConv2D(filters=10, kernel_size=(3, 3), padding='same')]

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -194,7 +194,7 @@ def test_forward_upsample(interpolation='nearest'):
     data = keras.layers.Input(shape=(32, 32, 3))
     x = keras.layers.UpSampling2D(size=(3, 3), interpolation=interpolation)(data)
     keras_model = keras.models.Model(data, x)
-    verify_keras_frontend(keras_model, need_transpose=False)
+    verify_keras_frontend(keras_model)
 
 
 def test_forward_reshape():


### PR DESCRIPTION
[This Discussion post](https://discuss.tvm.ai/t/keras-import-dimensions-dont-match-in-3-layer-example/3974) found two bugs in Relay. The first was a silly mistake I introduced with the Resize rework (#3788 ) caused by defaulting to the wrong layout for upsample in the Keras frontend. I've resolved this issue and fixed the corresponding test. The second bug occurs when a convolution with 1 filter attempts to determine the shape of its weights. Relay checks for group convolutions by seeing if the number of channels equals the group size, however we obviously shouldn't if the number of channels is 1. I've added a new test to check for this failure in the future.
