### PR TITLE
Clamp int64 input to tvm::Integer to [INT32_MIN, INT32_MAX]

### DIFF
--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -193,9 +193,13 @@ class Integer : public Expr {
    */
   Integer(int value) : Expr(value) {}  // NOLINT(*)
   /*!
-  /* \brief Construct integer from int64 value, clamp to INT32_MAX/MIN.
-  */
+   * \brief Construct integer from int64_t value, clamp to INT32_MAX/MIN.
+   */
   Integer(int64_t value) : Integer(int(value > INT32_MAX ? INT32_MAX : (value < INT32_MIN ? INT32_MIN : value))) {}  // NOLINT(*)
+  /*!
+   * \brief Construct integer from uint64_t value, clamp to INT32_MAX.
+   */
+  Integer(uint64_t value) : Integer(int(value > INT32_MAX ? INT32_MAX : value)) {}  // NOLINT(*)
   /*!
    * \brief Assign an expression to integer.
    * \param other another expression.

--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -193,6 +193,10 @@ class Integer : public Expr {
    */
   Integer(int value) : Expr(value) {}  // NOLINT(*)
   /*!
+  /* \brief Construct integer from int64 value, clamp to INT32_MAX/MIN.
+  */
+  Integer(int64_t value) : Integer(int(value > INT32_MAX ? INT32_MAX : (value < INT32_MIN ? INT32_MIN : value))) {}  // NOLINT(*)
+  /*!
    * \brief Assign an expression to integer.
    * \param other another expression.
    */


### PR DESCRIPTION
This change fixes a bug when passing tvm::Integer to [strided_slice](https://github.com/dmlc/tvm/blob/master/topi/include/topi/transform.h#L492), using int64_t. 

The bug is that when end is INT64_MAX, in tvm::Integer it becomes -1. This resulted in the sliced shape to be 1 off in that dimension. For example, with input dim of 100, slice end being INT32_MAX would return output dim of 100, while slice end being INT64_MAX returns output dim of 99.

Clamping int64_t inputs to the range of int32_t fixed the issue. It is arguable whether the clamp should happen silently or throw error when input is outside of int32_t range, or even upgrade tvm::Integer to be based on int64_t entirely. However, the silent overflow to -1 is wrong and needs to be fixed anyway IMO.
