### PR TITLE
[tvm][codegen] Make buffer auto broadcast independent to the order of input args

### DIFF
--- a/python/tvm/api.py
+++ b/python/tvm/api.py
@@ -582,7 +582,7 @@ def decl_buffer(shape,
     buffer_type: str, optional, {"", "auto_broadcast"}
         auto_broadcast buffer allows one to implement broadcast computation
         without considering whether dimension size equals to one.
-        TVM maps buffer[i][j][k] -> buffer[i][0][k] if dimension i's shape equals 1.
+        TVM maps buffer[i][j][k] -> buffer[i][0][k] if dimension j's shape equals 1.
 
     Returns
     -------
@@ -601,8 +601,8 @@ def decl_buffer(shape,
         A = tvm.placeholder((m0, m1, m2), name='A')
         B = tvm.placeholder((n0, n1, n2), name='B')
         C = tvm.compute((o0, o1, o2), lambda i, j, k: A[i, j, k] + B[i, j, k], name='C')
-        Ab = tvm.decl_buffer(A.shape, A.dtype, name="Ab", buffer_type="broadcast")
-        Bb = tvm.decl_buffer(B.shape, B.dtype, name="Bb", buffer_type="broadcast")
+        Ab = tvm.decl_buffer(A.shape, A.dtype, name="Ab", buffer_type="auto_broadcast")
+        Bb = tvm.decl_buffer(B.shape, B.dtype, name="Bb", buffer_type="auto_broadcast")
         s = tvm.create_schedule(C.op)
         fadd = tvm.build(s, [A, B, C], target='llvm', name='bcast_add', binds={A:Ab, B:Bb})
         ctx = tvm.cpu(0)

--- a/src/pass/make_api.cc
+++ b/src/pass/make_api.cc
@@ -164,8 +164,8 @@ LoweredFunc MakeAPI(Stmt body,
   }
 
   for (const auto& buf_arg : buf_defs) {
-     binder.BindDLTensor(buf_arg.first, device_type, device_id,
-                         buf_arg.second, buf_arg.second->name_hint);
+    binder.BindDLTensor(buf_arg.first, device_type, device_id,
+                        buf_arg.second, buf_arg.second->name_hint);
   }
 
   NodePtr<LoweredFuncNode> n = make_node<LoweredFuncNode>();

--- a/src/pass/make_api.cc
+++ b/src/pass/make_api.cc
@@ -102,6 +102,10 @@ LoweredFunc MakeAPI(Stmt body,
     seq_init.emplace_back(
         MakeAssertEQ(v_num_packed_args, num_packed_args, os.str()));
   }
+
+  // Save the input variables and buffers that will be bound later.
+  std::vector<std::pair<Var, Var> > var_defs;
+  std::vector<std::pair<Buffer, Var> > buf_defs;
   for (int i = 0; i < static_cast<int>(api_args.size()); ++i) {
     Var v_arg = f_arg_decl(i);
     if (i < num_packed_args) {
@@ -139,15 +143,29 @@ LoweredFunc MakeAPI(Stmt body,
     }
     // add checks for functions.
     if (api_args[i].as<Variable>()) {
-      binder.Bind(Var(api_args[i].node_), v_arg, v_arg->name_hint, true);
+      var_defs.emplace_back(std::make_pair(Var(api_args[i].node_), v_arg));
     } else {
       // Buffer checks
       CHECK(api_args[i].as<BufferNode>())
           << "api_args can only be Buffer or Var";
-      Buffer buf(api_args[i].node_);
-      binder.BindDLTensor(
-          buf, device_type, device_id, v_arg, v_arg->name_hint);
+      buf_defs.emplace_back(std::make_pair(Buffer(api_args[i].node_), v_arg));
     }
+  }
+
+  // Arg definitions are defined before buffer binding to avoid the use before
+  // def errors.
+  //
+  // For example, for auto broadcasting, checks are required to guarantee that
+  // either 0 or the original stride will be correctly used. Checks here have
+  // to use the args that may have no let bining yet. Therefore, hoisting let
+  // binding for args before buffer declaration is needed.
+  for (const auto& arg : var_defs) {
+    binder.Bind(arg.first, arg.second, arg.second->name_hint, true);
+  }
+
+  for (const auto& buf_arg : buf_defs) {
+     binder.BindDLTensor(buf_arg.first, device_type, device_id,
+                         buf_arg.second, buf_arg.second->name_hint);
   }
 
   NodePtr<LoweredFuncNode> n = make_node<LoweredFuncNode>();


### PR DESCRIPTION
Currently auto_broadcast of buffer may cause a problem when it hoists the `if` guard, as the lifted expression may use the arg before it is defined through let binding.

For example, the following code will cause problems during codege, because we will have something like `if (o1/x == 1) ... ` because `o1` and `x` are bound.

```python
    n0, m0, x = tvm.var('n0'), tvm.var('m0'), tvm.var('x')
    n1, m1 = tvm.var('n1'), tvm.var('m1')
    o0, o1 = tvm.var('o0'), tvm.var('o1')

    A = tvm.placeholder((m0, n0), name='A')
    B = tvm.placeholder((m1, n1), name='B')
    C = tvm.compute((o0, o1/x), lambda i, j: A[i, j] + B[i, j], name='C')

    Ab = tvm.decl_buffer(A.shape, A.dtype, name="Ab", buffer_type="auto_broadcast")
    Bb = tvm.decl_buffer(B.shape, B.dtype, name="Bb", buffer_type="auto_broadcast")
    Cc = tvm.decl_buffer(C.shape, C.dtype, name="Cc", buffer_type="auto_broadcast")
    s = tvm.create_schedule(C.op)
```

This fix hoist the let binding before the uses of the assert/if statements.

Another problem we might need to solve is the the current input arg can only be a single variable instead of an expression, i.e. `A = tvm.placeholder((m/x, n), name='A')` would fail, @yzhliu has also observed this. We can probably solve this in a follow-up PR. This PR will feed all these args directly in the build statement so that they can be correctly bound.

CC @yzhliu, @icemelon9, @tqchen 


