### PR TITLE
[Rust] Fixes "common" sub crate using nightly and master

### DIFF
--- a/rust/common/src/array.rs
+++ b/rust/common/src/array.rs
@@ -97,7 +97,7 @@ pub struct TVMContext {
 impl<'a> From<&'a TVMContext> for DLContext {
     fn from(ctx: &'a TVMContext) -> Self {
         Self {
-            device_type: ctx.device_type as u32,
+            device_type: ctx.device_type as i32,
             device_id: ctx.device_id as i32,
         }
     }

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -20,7 +20,7 @@
 //! This crate contains the refactored basic components required
 //! for `runtime` and `frontend` TVM crates.
 
-#![feature(box_syntax, type_alias_enum_variants, trait_alias)]
+#![feature(box_syntax, trait_alias)]
 
 #[macro_use]
 extern crate failure;

--- a/rust/common/src/packed_func.rs
+++ b/rust/common/src/packed_func.rs
@@ -83,7 +83,7 @@ macro_rules! TVMPODValue {
                 use $name::*;
                 #[allow(non_upper_case_globals)]
                 unsafe {
-                    match type_code {
+                    match type_code as i32 {
                         DLDataTypeCode_kDLInt => Int($value.v_int64),
                         DLDataTypeCode_kDLUInt => UInt($value.v_int64),
                         DLDataTypeCode_kDLFloat => Float($value.v_float64),

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! Checkout the `examples` repository for more details.
 
-#![feature(box_syntax, type_alias_enum_variants)]
+#![feature(box_syntax)]
 
 #[macro_use]
 extern crate failure;

--- a/rust/macros/src/lib.rs
+++ b/rust/macros/src/lib.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#![feature(bind_by_move_pattern_guards, proc_macro_span)]
+#![feature(proc_macro_span)]
 
 extern crate proc_macro;
 


### PR DESCRIPTION
Fixes [3964](https://github.com/dmlc/tvm/issues/3964).

Also, removes warning for stabilized feature [type_alias_enum_variants](https://github.com/rust-lang/rust/pull/61682)
