### PR TITLE
[tvm][any] broadcast with values other than one

### DIFF
--- a/include/tvm/ir_pass.h
+++ b/include/tvm/ir_pass.h
@@ -206,6 +206,14 @@ Stmt StorageFlatten(Stmt stmt,
                     Map<Tensor, Buffer> extern_buffer,
                     int cache_line_size,
                     bool create_bound_attribute = false);
+/*!
+ * \brief Verify if there is any argument bound to compact buffer.
+ *
+ * \param stmt The stmt to be verified.
+ * \return true if there is any buffer_bind_scope attribute found,
+ *        otherwise, false.
+ */
+bool VerifyCompactBuffer(Stmt stmt);
 
 /*!
  * \brief Remove No Op from the Stmt.

--- a/python/tvm/build_module.py
+++ b/python/tvm/build_module.py
@@ -264,13 +264,16 @@ def build_config(**kwargs):
 
     return config
 
-def get_binds(args, binds=None):
+def get_binds(args, compact=False, binds=None):
     """Internal function to get binds and arg_list given arguments.
 
     Parameters
     ----------
     args : list of Buffer or Tensor or Var
         The argument lists to the function.
+
+    compact : bool
+        If the statement has already bound to a compact buffer.
 
     binds : dict of :any:`Tensor` to :any:`Buffer`, optional
         Dictionary that maps the Tensor to Buffer which specified the data layout
@@ -290,12 +293,15 @@ def get_binds(args, binds=None):
     arg_list = []
     for x in args:
         if isinstance(x, tensor.Tensor):
+            any_dim = any(isinstance(i, expr.Var) for i in x.shape)
+            buffer_type = "auto_broadcast" if any_dim and not compact else ""
             if x not in binds:
                 buf = api.decl_buffer(x.shape,
                                       dtype=x.dtype,
                                       name=x.name,
                                       data_alignment=cfg.data_alignment,
-                                      offset_factor=cfg.offset_factor)
+                                      offset_factor=cfg.offset_factor,
+                                      buffer_type=buffer_type)
                 binds[x] = buf
                 arg_list.append(buf)
             else:
@@ -361,7 +367,6 @@ def lower(sch,
        The result function, if with_api_wrapper=False
        Then the Stmt before make api is returned.
     """
-    binds, arg_list = get_binds(args, binds)
     cfg = current_build_config()
     add_lower_pass = cfg.add_lower_pass if cfg.add_lower_pass else []
     if cfg.dump_pass_ir:
@@ -377,11 +382,16 @@ def lower(sch,
 
     for f in lower_phase0:
         stmt = f(stmt)
+
+    compact = ir_pass.VerifyCompactBuffer(stmt)
+    binds, arg_list = get_binds(args, compact, binds)
+
     # Phase 1
     stmt = ir_pass.StorageFlatten(stmt, binds, 64, cfg.instrument_bound_checkers)
     stmt = ir_pass.CanonicalSimplify(stmt)
     for f in lower_phase1:
         stmt = f(stmt)
+
     # Phase 2
     if not simple_mode:
         stmt = ir_pass.LoopPartition(stmt, cfg.partition_const_loop)
@@ -400,6 +410,7 @@ def lower(sch,
         cfg.unroll_explicit)
     for f in lower_phase2:
         stmt = f(stmt)
+
     # Phase 3
     stmt = ir_pass.Simplify(stmt)
     stmt = ir_pass.LowerStorageAccessInfo(stmt)
@@ -413,6 +424,7 @@ def lower(sch,
         stmt = ir_pass.InstrumentBoundCheckers(stmt)
     if simple_mode:
         return stmt
+
     return ir_pass.MakeAPI(stmt, name, arg_list, 0, cfg.restricted_func)
 
 

--- a/src/api/api_pass.cc
+++ b/src/api/api_pass.cc
@@ -159,5 +159,6 @@ REGISTER_PASS(VerifyMemory);
 REGISTER_PASS(VerifyGPUCode);
 REGISTER_PASS(DecorateDeviceScope);
 REGISTER_PASS(InstrumentBoundCheckers);
+REGISTER_PASS(VerifyCompactBuffer);
 }  // namespace ir
 }  // namespace tvm

--- a/src/op/hybrid_op.cc
+++ b/src/op/hybrid_op.cc
@@ -180,31 +180,6 @@ Stmt HybridOpNode::BuildProvide(
     bool debug_keep_trivial_loop) const {
   CHECK_EQ(stage->op.operator->(), this);
   Stmt ret = AttrStmt::make(make_zero(Int(32)), attr::extern_scope, 0, this->body);
-  auto f_push_bind = [&ret](Buffer buffer, Tensor tensor) {
-    Array<NodeRef> bind_spec;
-    Array<Expr> tuple;
-    bind_spec.push_back(buffer);
-    bind_spec.push_back(tensor);
-    for (size_t k = 0; k < buffer->shape.size(); ++k) {
-      tuple.push_back(make_const(buffer->shape[k].type(), 0));
-      tuple.push_back(buffer->shape[k]);
-    }
-    ret = AttrStmt::make(
-        bind_spec, attr::buffer_bind_scope,
-        Call::make(Handle(), intrinsic::tvm_tuple, tuple, Call::Intrinsic), ret);
-  };
-  for (int i = static_cast<int>(outputs.size()) - 1; i >= 0; --i) {
-    Buffer buffer = decl_buffer(
-      outputs[i]->shape,
-      outputs[i]->dtype);
-    f_push_bind(buffer, stage->op.output(i));
-  }
-  auto curr_inputs = InputTensors();
-  for (int i = static_cast<int>(curr_inputs.size()) - 1; i >= 0; --i) {
-    Buffer buffer = decl_buffer(curr_inputs[i]->shape, curr_inputs[i]->dtype);
-    f_push_bind(buffer, curr_inputs[i]);
-  }
-
   std::unordered_map<Tensor, Tensor> rmap;
   for (int i = 0; i < this->num_outputs(); ++i) {
     rmap[outputs[i]] = stage->op.output(i);

--- a/src/pass/verify_compact_buffer.cc
+++ b/src/pass/verify_compact_buffer.cc
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file verify_compact_buffer.cc
+ * \brief Verify if there was any compact buffer bound to a statement.
+ */
+#include <tvm/buffer.h>
+#include <tvm/expr.h>
+#include <tvm/ir.h>
+#include <tvm/ir_visitor.h>
+#include <tvm/tensor.h>
+
+#include <unordered_map>
+
+namespace tvm {
+namespace ir {
+
+class VerifyBuffer : public IRVisitor {
+ public:
+  bool Verify(const Stmt& stmt) {
+    this->Visit(stmt);
+    return is_compact_;
+  }
+
+  void Visit_(const AttrStmt* op) final {
+    IRVisitor::Visit_(op);
+    if (op->attr_key == attr::buffer_bind_scope) {
+      is_compact_ = true;
+    }
+  }
+
+ private:
+  bool is_compact_{false};
+};
+
+bool VerifyCompactBuffer(Stmt stmt) {
+  VerifyBuffer verifier;
+  return verifier.Verify(stmt);
+}
+
+}  // namespace ir
+}  // namespace tvm

--- a/tests/python/integration/test_reduce.py
+++ b/tests/python/integration/test_reduce.py
@@ -37,7 +37,7 @@ def test_reduce_prims():
         s[R].compute_inline()
 
         # one line to build the function.
-        def check_device(device, host="stackvm"):
+        def check_device(device, host="llvm"):
             ctx = tvm.context(device, 0)
             if not tvm.module.enabled(host):
                 return

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -58,6 +58,25 @@ def test_any_broadcast():
     verify_any_broadcast((relay.Any(),), (3, 2), (2,), (3, 2), relay.add, np.add)
     verify_any_broadcast((relay.Any(), 2), (3, 2), (3, 2), (3, 2), relay.add, np.add)
 
+
+def test_any_broadcast_fail():
+    # Test broadcast with incompatible values at runtime
+    def check_fail(x_shape, y_shape, x_np_shape, y_np_shape, op, np_op):
+        try:
+            verify_any_broadcast(
+                x_shape, y_shape, x_np_shape, y_np_shape, op, np_op)
+        except tvm._ffi.base.TVMError:
+            pass
+        else:
+            assert False
+
+    check_fail((relay.Any(),), (3, 2), (1,), (4, 2), relay.add, np.add)
+    check_fail((relay.Any(), 2), (3, 2), (4, 2), (4, 2), relay.add, np.add)
+    check_fail((relay.Any(), 2), (3, relay.Any()), (1, 2), (4, 1), relay.add, np.add)
+    check_fail((relay.Any(), 2), (3, 3), (1, 3), (3, 3), relay.add, np.add)
+    check_fail((relay.Any(),), (3, 2), (2), (4, 2), relay.add, np.add)
+
+
 def test_any_concat():
     x = relay.var('x', shape=(relay.Any(), 2), dtype="float32")
     y = relay.var('y', shape=(1, 2), dtype="float32")
@@ -254,6 +273,7 @@ def test_recursive_concat_with_wrong_annotation():
 
 if __name__ == "__main__":
     test_any_broadcast()
+    test_any_broadcast_fail()
     test_any_concat()
     test_any_reshape()
     test_any_take()

--- a/tests/python/relay/test_any.py
+++ b/tests/python/relay/test_any.py
@@ -47,17 +47,16 @@ def verify_any_broadcast(x_shape, y_shape, x_np_shape, y_np_shape, op, np_op):
         tvm.testing.assert_allclose(result.asnumpy(), np_op(x_np, y_np))
 
 def test_any_broadcast():
+    # Test broadcast with 1s
     verify_any_broadcast((relay.Any(),), (3, 2), (1,), (3, 2), relay.add, np.add)
     verify_any_broadcast((relay.Any(), 2), (1, 2), (1, 2), (1, 2), relay.add, np.add)
     verify_any_broadcast((relay.Any(), 2), (1, 2), (3, 2), (1, 2), relay.add, np.add)
     verify_any_broadcast((relay.Any(), 2), (3, 2), (1, 2), (3, 2), relay.add, np.add)
     verify_any_broadcast((relay.Any(), 2), (3, relay.Any()), (1, 2), (3, 1), relay.add, np.add)
 
-    # The following currently fail because topi compute treats Any as 1
-    # will requires auto_broadcast buffer to solve the problem
-    # TODO(@zhiics): Fix this
-    # verify_any_broadcast((relay.Any(),), (3, 2), (2,), (3, 2), relay.add, np.add)
-    # verify_any_broadcast((relay.Any(), 2), (3, 2), (3, 2), (3, 2), relay.add, np.add)
+    # Test broadcast with values other than 1
+    verify_any_broadcast((relay.Any(),), (3, 2), (2,), (3, 2), relay.add, np.add)
+    verify_any_broadcast((relay.Any(), 2), (3, 2), (3, 2), (3, 2), relay.add, np.add)
 
 def test_any_concat():
     x = relay.var('x', shape=(relay.Any(), 2), dtype="float32")

--- a/tests/python/unittest/test_codegen_arm.py
+++ b/tests/python/unittest/test_codegen_arm.py
@@ -42,13 +42,14 @@ def test_popcount():
     check_correct_assembly('uint32', 2, 2)
     check_correct_assembly('uint64', 2, 3)
 
+
 def test_vmlal_s16():
     target = 'llvm -target=armv7l-none-linux-gnueabihf -mcpu=cortex-a53 -mattr=+neon'
 
     def check_correct_assembly(N):
         K = tvm.var("K")
         A = tvm.placeholder((K, N), dtype="int8", name='A')
-        B = tvm.placeholder((K, N), dtype="int8", name='A')
+        B = tvm.placeholder((K, N), dtype="int8", name='B')
         k = tvm.reduce_axis((0, K))
         C = tvm.compute((N, ), lambda n: tvm.sum(
             A[k, n].astype("int32") * B[k, n].astype("int32"), axis=[k]), name='C')
@@ -60,14 +61,15 @@ def test_vmlal_s16():
         assembly = f.get_source('asm')
         matches = re.findall("vmlal.s16", assembly)
         assert (len(matches) == N // 4)
-    check_correct_assembly(4)
     check_correct_assembly(8)
     check_correct_assembly(16)
+    check_correct_assembly(32)
+    check_correct_assembly(64)
 
     def check_broadcast_correct_assembly(N):
         K = tvm.var("K")
         A = tvm.placeholder((K, N), dtype="int8", name='A')
-        B = tvm.placeholder((K,), dtype="int8", name='A')
+        B = tvm.placeholder((K,), dtype="int8", name='B')
         k = tvm.reduce_axis((0, K))
         C = tvm.compute((N, ), lambda n: tvm.sum(
             A[k, n].astype("int32") * B[k].astype("int32"),
@@ -84,6 +86,7 @@ def test_vmlal_s16():
     check_broadcast_correct_assembly(16)
     check_broadcast_correct_assembly(32)
     check_broadcast_correct_assembly(64)
+
 
 if __name__ == "__main__":
     test_popcount()

--- a/tests/python/unittest/test_lang_buffer.py
+++ b/tests/python/unittest/test_lang_buffer.py
@@ -188,8 +188,21 @@ def test_buffer_broadcast_expr():
         fadd(a, b, c, 4, 1)
         tvm.testing.assert_allclose(c.asnumpy(), a.asnumpy() + b.asnumpy())
 
+    def check_auto_bind():
+        if not tvm.module.enabled("llvm"):
+            return
+        # Let build bind buffers
+        fadd = tvm.build(s, [A, B, C, o1, x], target='llvm', name='bcast_add')
+        ctx = tvm.cpu(0)
+        a = tvm.nd.array(np.random.uniform(size=(1, 4)).astype(A.dtype), ctx)
+        b = tvm.nd.array(np.random.uniform(size=(2, 4)).astype(B.dtype), ctx)
+        c = tvm.nd.array(np.zeros((2, 4), dtype=C.dtype), ctx)
+        fadd(a, b, c, 4, 1)
+        tvm.testing.assert_allclose(c.asnumpy(), a.asnumpy() + b.asnumpy())
+
     check_stride()
     check_no_stride()
+    check_auto_bind()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes relay Any type broadcast with values other than one, i.e.:

```python
x = relay.var('x', shape=(3, 2), dtype="float32")
y = relay.var('y', shape=(relay.Any(), 2), dtype="float32")
relay.add(x, y)
```

It makes all symbolic vars as `auto_broadcast` if they haven't been bound to compact buffer before.

@icemelon9 @yzhliu @tqchen @jroesch 