### PR TITLE
[TVM][AutoTVM] cast filepath arguments to string

### DIFF
--- a/python/tvm/autotvm/task/dispatcher.py
+++ b/python/tvm/autotvm/task/dispatcher.py
@@ -41,6 +41,7 @@ from .space import FallbackConfigEntity
 
 logger = logging.getLogger('autotvm')
 
+
 class DispatchContext(object):
     """
     Base class of dispatch context.
@@ -281,7 +282,11 @@ class ApplyHistoryBest(DispatchContext):
                        Each row of this file is an encoded record pair.
             Otherwise, it is an iterator.
         """
+        from pathlib import Path
         from ..record import load_from_file
+
+        if isinstance(records, Path):
+            records = str(records)
 
         if isinstance(records, str):
             records = load_from_file(records)
@@ -404,7 +409,9 @@ class FallbackContext(DispatchContext):
         key = (str(target), workload)
         self.memory[key] = cfg
 
+
 DispatchContext.current = FallbackContext()
+
 
 def clear_fallback_cache(target, workload):
     """Clear fallback cache. Pass the same argument as _query_inside to this function
@@ -425,6 +432,7 @@ def clear_fallback_cache(target, workload):
     while not isinstance(context, FallbackContext):
         context = context._old_ctx
     context.clear_cache(target, workload)
+
 
 class ApplyGraphBest(DispatchContext):
     """Load the graph level tuning optimal schedules.

--- a/python/tvm/autotvm/tuner/callback.py
+++ b/python/tvm/autotvm/tuner/callback.py
@@ -26,6 +26,7 @@ from .. import record
 
 logger = logging.getLogger('autotvm')
 
+
 def log_to_file(file_out, protocol='json'):
     """Log the tuning records into file.
     The rows of the log are stored in the format of autotvm.record.encode.
@@ -51,6 +52,11 @@ def log_to_file(file_out, protocol='json'):
         else:
             for inp, result in zip(inputs, results):
                 file_out.write(record.encode(inp, result, protocol) + "\n")
+
+    from pathlib import Path
+    if isinstance(file_out, Path):
+        file_out = str(file_out)
+
     return _callback
 
 

--- a/python/tvm/module.py
+++ b/python/tvm/module.py
@@ -107,6 +107,10 @@ class Module(ModuleBase):
         kwargs : dict, optional
             Additional arguments passed to fcompile
         """
+        from pathlib import Path
+        if isinstance(file_name, Path):
+            file_name = str(file_name)
+
         if self.type_key == "stackvm":
             if not file_name.endswith(".stackvm"):
                 raise ValueError("Module[%s]: can only be saved as stackvm format."


### PR DESCRIPTION
@obust @tqchen 

Following the [issue](https://github.com/dmlc/tvm/issues/2222) we discussed, I add the check to cast the `Path` object to string type in case they are `Path`.