### PR TITLE
[ARITH] Explicitly state truncdiv/mod in pattern matching.

### DIFF
--- a/include/tvm/expr_operator.h
+++ b/include/tvm/expr_operator.h
@@ -333,6 +333,20 @@ TVM_DLL Expr operator||(Expr a, Expr b);
  */
 TVM_DLL Expr operator!(Expr a);
 /*!
+ * \brief compute division in C semantics.
+ *
+ * a / b as in C/C++.
+ *
+ * When operands are integers, it directly corresponds to truncdiv.
+ *
+ * \param a left operand
+ * \param b right operand
+ * \return The result expression.
+ * \note this function does eager constant folding for
+ *       index types(int32, int64) when possible.
+ */
+TVM_DLL Expr div(Expr a, Expr b);
+/*!
  * \brief compute trunc(a / b)
  *
  * This is the default integer division behavior in C.
@@ -634,6 +648,21 @@ inline Expr make_zero(Type t) {
   return make_const(t, 0);
 }
 
+/*!
+ * \brief Helper function to raise a compiler error about division ambiguity.
+ * \note The call to this function will always results in a compiler error.
+ * \tparam TA Any class type.
+ */
+template<typename TA>
+inline void DivAmbiguityError(const TA& a) {
+  constexpr bool div_ambiguity = !std::is_class<TA>::value;
+  static_assert(div_ambiguity,
+                "TVM supports multiple types of integer divisions, "
+                "please call div, floordiv/floormod or truncdiv/truncmod directly "
+                "to avoid ambiguity in the code. "
+                "Checkout these functions in expr_operator.h.");
+}
+
 // additional const expression overloading
 #define TVM_DEFINE_ASSIGN_OP_OVERLOAD(Name, OpFunc)            \
   inline Expr Name(Expr& a, Expr b) {                          \
@@ -682,12 +711,17 @@ TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(operator*);
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(operator/);
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(max);
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(min);
+TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(div);
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(operator>);  // NOLINT(*)
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(operator>=);
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(operator<);  // NOLINT(*)
 TVM_DEFINE_BINOP_CONST_VAL_OVERLOAD(operator<=);
 // integer related ops
 TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(operator%);
+TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(truncmod);
+TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(floordiv);
+TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(floormod);
+TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(truncdiv);
 TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(operator>>); // NOLINT(*)
 TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(operator<<); // NOLINT(*)
 TVM_DEFINE_INT_OP_CONST_VAL_OVERLOAD(operator&);

--- a/src/arithmetic/canonical_simplify.cc
+++ b/src/arithmetic/canonical_simplify.cc
@@ -67,7 +67,7 @@ enum DivMode {
 
 inline Expr ModImpl(Expr a, Expr b, DivMode mode) {
   if (mode == kTruncDiv) {
-    return a % b;
+    return truncmod(a, b);
   } else {
     CHECK_EQ(mode, kFloorDiv);
     return floormod(a, b);
@@ -76,7 +76,7 @@ inline Expr ModImpl(Expr a, Expr b, DivMode mode) {
 
 inline Expr DivImpl(Expr a, Expr b, DivMode mode) {
   if (mode == kTruncDiv) {
-    return a / b;
+    return truncdiv(a, b);
   } else {
     CHECK_EQ(mode, kFloorDiv);
     return floordiv(a, b);

--- a/src/arithmetic/int_operator.h
+++ b/src/arithmetic/int_operator.h
@@ -93,6 +93,26 @@ inline bool WillOverflow<ir::Mod>(int64_t x,
 }
 
 /*!
+ * \brief Peform trunc division of two integers.
+ * \param x The left operand.
+ * \param y The right operand.
+ * \return the result.
+ */
+inline int64_t truncdiv(int64_t x, int64_t y) {
+  return x / y;
+}
+
+/*!
+ * \brief Compute the truncdiv remainder of two integers.
+ * \param x The left operand.
+ * \param y The right operand.
+ * \return the result.
+ */
+inline int64_t truncmod(int64_t x, int64_t y) {
+  return x % y;
+}
+
+/*!
  * \brief Peform floor division of two integers.
  * \param x The left operand.
  * \param y The right operand.

--- a/src/arithmetic/modular_set.cc
+++ b/src/arithmetic/modular_set.cc
@@ -18,7 +18,6 @@
  */
 
 /*!
- *  Copyright (c) 2019 by Contributors
  * \file modular_set.cc
  * \brief Modular set analysis
  */
@@ -111,7 +110,8 @@ class ModularSetAnalyzer::Impl :
     PVar<Var> var;
     PVar<Integer> coeff, base;
     // pattern match interesting constraints
-    if (((var % coeff) == base).Match(constraint)) {
+    if ((truncmod(var, coeff) == base).Match(constraint) ||
+        (floormod(var, coeff) == base).Match(constraint)) {
       Entry entry(coeff.Eval()->value, base.Eval()->value);
       return UpdateByIntersect(var.Eval(), entry);
     }

--- a/src/arithmetic/rewrite_simplify.cc
+++ b/src/arithmetic/rewrite_simplify.cc
@@ -194,7 +194,7 @@ Mutate_(const Add* op, const Expr& self) {
 
     // DivMod rules
     // truc div
-    TVM_TRY_REWRITE((x / c1) * c1 + x % c1, x);
+    TVM_TRY_REWRITE(truncdiv(x, c1) * c1 + truncmod(x, c1), x);
     // floor div
     TVM_TRY_REWRITE(floordiv(x, c1) * c1 + floormod(x, c1), x);
 
@@ -208,7 +208,7 @@ Mutate_(const Add* op, const Expr& self) {
 
     // DivMod rules
     // truc div
-    TVM_TRY_RECURSIVE_REWRITE((y % c1) + x * c1, x * c1 + (y % c1));
+    TVM_TRY_RECURSIVE_REWRITE(truncmod(y, c1) + x * c1, x * c1 + truncmod(y, c1));
     // floor div
     TVM_TRY_RECURSIVE_REWRITE(floormod(y, c1) + x * c1, x * c1 + floormod(y, c1));
   }
@@ -314,48 +314,49 @@ Mutate_(const Sub* op, const Expr& self) {
     // DivMod rules
     // trucdiv
     // NOTE: c*(x/c) + x % c == x is true all division mode.
-    TVM_TRY_REWRITE_IF(x - (x / c1) * c1, x % c1,
+    TVM_TRY_REWRITE_IF(x - truncdiv(x, c1) * c1, truncmod(x, c1),
                        c1.Eval()->value != 0);
-    TVM_TRY_REWRITE_IF((x / c1) * c1 - x, 0 - (x % c1),
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) * c1 - x, 0 - truncmod(x, c1),
                        c1.Eval()->value != 0);
-    TVM_TRY_REWRITE_IF(x - ((x + y) / c1) * c1, (x + y) % c1 - y,
+    TVM_TRY_REWRITE_IF(x - (truncdiv(x + y, c1)) * c1, truncmod(x + y, c1) - y,
                        c1.Eval()->value != 0);
-    TVM_TRY_REWRITE_IF(((x + y) / c1) * c1 - x, y - ((x + y) % c1),
+    TVM_TRY_REWRITE_IF((truncdiv(x + y, c1)) * c1 - x, y - truncmod(x + y, c1),
                        c1.Eval()->value != 0);
-    TVM_TRY_REWRITE_IF(x - ((x - y) / c1) * c1, (x - y) % c1 + y,
+    TVM_TRY_REWRITE_IF(x - truncdiv(x - y, c1) * c1, truncmod(x - y, c1) + y,
                        c1.Eval()->value != 0);
-    TVM_TRY_REWRITE_IF(((x - y) / c1) * c1 - x, 0 - (x - y) % c1 - y,
+    TVM_TRY_REWRITE_IF(truncdiv(x - y, c1) * c1 - x, 0 - truncmod(x - y, c1) - y,
                        c1.Eval()->value != 0);
 
-    TVM_TRY_REWRITE_IF(x * c2 - (x / c1) * c3, (x % c1) * c2,
+    TVM_TRY_REWRITE_IF(x * c2 - truncdiv(x, c1) * c3, truncmod(x, c1) * c2,
                        c1.Eval()->value != 0 &&
                        c3.Eval()->value == c1.Eval()->value * c2.Eval()->value);
-    TVM_TRY_REWRITE_IF((x / c1) * c3 - x * c2, 0 - (x % c1) * c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) * c3 - x * c2, 0 - truncmod(x, c1) * c2,
                        c1.Eval()->value != 0 &&
                        c3.Eval()->value == c1.Eval()->value * c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(x * c2 - ((x + y) / c1) * c3, ((x + y) % c1 - y) * c2,
+    TVM_TRY_REWRITE_IF(x * c2 - truncdiv(x + y, c1) * c3, (truncmod(x + y, c1) - y) * c2,
                        c1.Eval()->value != 0 &&
                        c3.Eval()->value == c1.Eval()->value * c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(((x + y) / c1) * c3 - x * c2, (y - ((x + y) % c1)) * c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x + y, c1) * c3 - x * c2, (y - truncmod(x + y, c1)) * c2,
                        c1.Eval()->value != 0 &&
                        c3.Eval()->value == c1.Eval()->value * c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(x * c2 - ((x - y) / c1) * c3, ((x - y) % c1 + y) * c2,
+    TVM_TRY_REWRITE_IF(x * c2 - truncdiv(x - y, c1) * c3, (truncmod(x - y, c1) + y) * c2,
                        c1.Eval()->value != 0 &&
                        c3.Eval()->value == c1.Eval()->value * c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(((x - y) / c1) * c3 - x * c2, (0 - (x - y) % c1 - y) * c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x - y, c1) * c3 - x * c2, (0 - truncmod(x - y, c1) - y) * c2,
                        c1.Eval()->value != 0 &&
                        c3.Eval()->value == c1.Eval()->value * c2.Eval()->value);
 
     // Proof in the case of floordiv, need positive condition.
     // let x = a * c3 + r
     // (x + c1) / c3 - x / c3 => (r + c1) / c3
-    TVM_TRY_REWRITE_IF((x + c1) / c3  - (x + c2) / c3,
-                       ((x + ((c2 % c3) + c3) % c3) % c3 + (c1 - c2)) / c3,
+    // NOTE: the use of floormod(c2, c3) was intentional to simplify the const.
+    TVM_TRY_REWRITE_IF(truncdiv(x + c1, c3)  - truncdiv(x + c2, c3),
+                       truncdiv(truncmod(x + floormod(c2, c3), c3) + (c1 - c2), c3),
                        CanProveGreaterEqual(x.Eval(), -c2.Eval()->value) &&
                        c1.Eval()->value >= c2.Eval()->value &&
                        c3.Eval()->value > 0);
-    TVM_TRY_REWRITE_IF((x + c1) / c3  - x / c3,
-                       (x % c3 + c1) / c3,
+    TVM_TRY_REWRITE_IF(truncdiv(x + c1, c3)  - truncdiv(x, c3),
+                       truncdiv(truncmod(x, c3) + c1, c3),
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        c1.Eval()->value >= 0 &&
                        c3.Eval()->value > 0);
@@ -478,14 +479,15 @@ Mutate_(const Div* op, const Expr& self) {
 
   // Vector rules
   if (op->type.lanes() != 1) {
-    TVM_TRY_REWRITE(broadcast(x, lanes) / broadcast(y, lanes),
-                    broadcast(x / y, lanes));
+    // NOTE: use div as the pattern also works for float.
+    TVM_TRY_REWRITE(div(broadcast(x, lanes), broadcast(y, lanes)),
+                    broadcast(div(x, y), lanes));
     // ramp / bcast
-    if ((ramp(b1, c1, lanes) / broadcast(c2, lanes)).Match(ret)) {
+    if ((div(ramp(b1, c1, lanes), broadcast(c2, lanes))).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
       if (c1val % c2val == 0) {
-        return ramp(b1 / c2, c1 / c2, lanes).Eval();
+        return ramp(div(b1, c2), div(c1, c2), lanes).Eval();
       }
       // If all possible indices in ramp are the same.
       if (CanProveGreaterEqual(b1.Eval(), 0)) {
@@ -493,7 +495,7 @@ Mutate_(const Div* op, const Expr& self) {
         int64_t ramp_min = bmod->base / c2val;
         int64_t ramp_max = (bmod->base + (lanes.Eval() - 1) * c1val) / c2val;
         if (bmod->coeff % c2val == 0 && ramp_min == ramp_max) {
-          return broadcast(b1 / c2, lanes).Eval();
+          return broadcast(div(b1, c2), lanes).Eval();
         }
       }
     }
@@ -508,73 +510,79 @@ Mutate_(const Div* op, const Expr& self) {
     // parts of tvm which still assume euclidean div. In this simplifier we assume that the division
     // is truncated, so perform const folding again.
     // NOTE: trunc div required
-    if ((c1 / c2).Match(ret)) {
+    if (truncdiv(c1, c2).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
-      return make_const(op->type, c1val / c2val);
+      return make_const(op->type, truncdiv(c1val, c2val));
     }
 
     // while it is always true for trunc div
     // restrict to common case(positive div)
-    TVM_TRY_REWRITE_IF((x / c1) / c2, x / (c1 * c2),
+    TVM_TRY_REWRITE_IF(truncdiv(truncdiv(x, c1), c2), truncdiv(x, c1 * c2),
                        c1.Eval()->value > 0 && c2.Eval()->value > 0);
 
-    TVM_TRY_REWRITE_IF((x / c1 + c2) / c3, (x + c1 * c2) / (c1 * c3),
+    TVM_TRY_REWRITE_IF(truncdiv(truncdiv(x, c1) + c2, c3), truncdiv(x + c1 * c2, c1 * c3),
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value >= 0 &&
                        c3.Eval()->value > 0 &&
                        CanProveGreaterEqual(x.Eval(), 0));
 
-    if (((x * c1) / c2).Match(ret)) {
+    if (truncdiv(x * c1, c2).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
       if (c1val > 0 && c2val > 0) {
-        if (c1val % c2val == 0) return (x * (c1 / c2)).Eval();
-        if (c2val % c1val == 0) return (x / (c2 / c1)).Eval();
+        if (c1val % c2val == 0) return (x * truncdiv(c1, c2)).Eval();
+        if (c2val % c1val == 0) return truncdiv(x, truncdiv(c2, c1)).Eval();
       }
     }
 
-    TVM_TRY_REWRITE(x / x, OneWithTypeLike(x));
-    TVM_TRY_REWRITE(x * c1 / x, c1);
-    TVM_TRY_REWRITE(c1 * x / x, c1);
+    TVM_TRY_REWRITE(truncdiv(x, x), OneWithTypeLike(x));
+    TVM_TRY_REWRITE(truncdiv(x * c1, x), c1);
+    TVM_TRY_REWRITE(truncdiv(c1 * x, x), c1);
 
     // Rules involving 2-operands.
-    TVM_TRY_REWRITE_IF((x * c1 + y) / c2, x * (c1 / c2) + y / c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x * c1 + y, c2),
+                       x * truncdiv(c1, c2) + truncdiv(y, c2),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF(min(x * c1, y) / c2, min(x * (c1 / c2), y / c2),
+    TVM_TRY_REWRITE_IF(truncdiv(min(x * c1, y), c2),
+                       min(x * truncdiv(c1, c2), truncdiv(y, c2)),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF(max(x * c1, y) / c2, max(x * (c1 / c2), y / c2),
+    TVM_TRY_REWRITE_IF(truncdiv(max(x * c1, y), c2),
+                       max(x * truncdiv(c1, c2), truncdiv(y, c2)),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((y + x * c1) / c2, y / c2 + x * (c1 / c2),
+    TVM_TRY_REWRITE_IF(truncdiv(y + x * c1, c2),
+                       truncdiv(y, c2) + x * truncdiv(c1, c2),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF(min(y, x * c1) / c2, min(y / c2, x * (c1 / c2)),
+    TVM_TRY_REWRITE_IF(truncdiv(min(y, x * c1), c2),
+                       min(truncdiv(y, c2), x * truncdiv(c1, c2)),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF(max(y, x * c1) / c2, max(y / c2, x * (c1 / c2)),
+    TVM_TRY_REWRITE_IF(truncdiv(max(y, x * c1), c2),
+                       max(truncdiv(y, c2), x * truncdiv(c1, c2)),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
@@ -582,80 +590,89 @@ Mutate_(const Div* op, const Expr& self) {
                        CanProveGreaterEqual(y.Eval(), 0));
 
     // Rules involving 3-operands.
-    TVM_TRY_REWRITE_IF((x * c1 + y + z) / c2, x * (c1 / c2) + (y + z)/ c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x * c1 + y + z, c2),
+                       x * truncdiv(c1, c2) + truncdiv(y + z, c2),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual((y + z).Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x * c1 - y + z) / c2, x * (c1 / c2) + (z - y)/ c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x * c1 - y + z, c2),
+                       x * truncdiv(c1, c2) + truncdiv(z - y, c2),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual((z - y).Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x * c1 + y - z) / c2, x * (c1 / c2) + (y - z)/ c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x * c1 + y - z, c2),
+                       x * truncdiv(c1, c2) + truncdiv(y - z, c2),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual((y - z).Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((y + x * c1 + z) / c2, x * (c1 / c2) + (y + z) / c2,
+    TVM_TRY_REWRITE_IF(truncdiv(y + x * c1 + z, c2),
+                       x * truncdiv(c1, c2) + truncdiv(y + z, c2),
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual((y + z).Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x + c1) / c2, x / c2 + c1 / c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x + c1, c2),
+                       truncdiv(x, c2) + truncdiv(c1, c2),
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x + y) / x, y / x + 1,
+    TVM_TRY_REWRITE_IF(truncdiv(x + y, x), truncdiv(y, x) + 1,
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
-    TVM_TRY_REWRITE_IF((y + x) / x, y / x + 1,
-                       CanProveGreaterEqual(x.Eval(), 0) &&
-                       CanProveGreaterEqual(y.Eval(), 0));
-
-    TVM_TRY_REWRITE_IF(((x + y) + z) / x, (y + z) / x + 1,
-                       CanProveGreaterEqual(x.Eval(), 0) &&
-                       CanProveGreaterEqual((y + z).Eval(), 0));
-    TVM_TRY_REWRITE_IF(((y + x) + z) / x, (y + z) / x + 1,
-                       CanProveGreaterEqual(x.Eval(), 0) &&
-                       CanProveGreaterEqual((y + z).Eval(), 0));
-    TVM_TRY_REWRITE_IF((y + (z + x)) / x, (y + z) / x + 1,
-                       CanProveGreaterEqual(x.Eval(), 0) &&
-                       CanProveGreaterEqual((y + z).Eval(), 0));
-    TVM_TRY_REWRITE_IF((y + (x + z)) / x, (y + z) / x + 1,
-                       CanProveGreaterEqual(x.Eval(), 0) &&
-                       CanProveGreaterEqual((y + z).Eval(), 0));
-
-    TVM_TRY_REWRITE_IF((x * y) / y, x,
-                       CanProveGreaterEqual(x.Eval(), 0) &&
-                       CanProveGreaterEqual(y.Eval(), 0));
-    TVM_TRY_REWRITE_IF((y * x) / y, x,
+    TVM_TRY_REWRITE_IF(truncdiv(y + x, x), truncdiv(y, x) + 1,
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x * z + y) / z, x + y / z,
+    TVM_TRY_REWRITE_IF(truncdiv((x + y) + z, x),
+                       truncdiv(y + z, x) + 1,
+                       CanProveGreaterEqual(x.Eval(), 0) &&
+                       CanProveGreaterEqual((y + z).Eval(), 0));
+    TVM_TRY_REWRITE_IF(truncdiv((y + x) + z, x),
+                       truncdiv(y + z, x) + 1,
+                       CanProveGreaterEqual(x.Eval(), 0) &&
+                       CanProveGreaterEqual((y + z).Eval(), 0));
+    TVM_TRY_REWRITE_IF(truncdiv(y + (z + x), x),
+                       truncdiv(y + z, x) + 1,
+                       CanProveGreaterEqual(x.Eval(), 0) &&
+                       CanProveGreaterEqual((y + z).Eval(), 0));
+    TVM_TRY_REWRITE_IF(truncdiv(y + (x + z), x),
+                       truncdiv(y + z, x) + 1,
+                       CanProveGreaterEqual(x.Eval(), 0) &&
+                       CanProveGreaterEqual((y + z).Eval(), 0));
+
+    TVM_TRY_REWRITE_IF(truncdiv(x * y, y), x,
+                       CanProveGreaterEqual(x.Eval(), 0) &&
+                       CanProveGreaterEqual(y.Eval(), 0));
+    TVM_TRY_REWRITE_IF(truncdiv(y * x, y), x,
+                       CanProveGreaterEqual(x.Eval(), 0) &&
+                       CanProveGreaterEqual(y.Eval(), 0));
+
+    TVM_TRY_REWRITE_IF(truncdiv(x * z + y, z), x + truncdiv(y, z),
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0) &&
                        CanProveGreaterEqual(z.Eval(), 0));
-    TVM_TRY_REWRITE_IF((z * x + y) / z, x + y / z,
+    TVM_TRY_REWRITE_IF(truncdiv(z * x + y, z), x + truncdiv(y, z),
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0) &&
                        CanProveGreaterEqual(z.Eval(), 0));
-    TVM_TRY_REWRITE_IF((y + x * z) / z, y / z + x,
+    TVM_TRY_REWRITE_IF(truncdiv(y + x * z, z), truncdiv(y, z) + x,
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0) &&
                        CanProveGreaterEqual(z.Eval(), 0));
-    TVM_TRY_REWRITE_IF((y + z * x) / z, y / z + x,
+    TVM_TRY_REWRITE_IF(truncdiv(y + z * x, z), truncdiv(y, z) + x,
                        CanProveGreaterEqual(x.Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0) &&
                        CanProveGreaterEqual(z.Eval(), 0));
@@ -679,15 +696,15 @@ Mutate_(const Mod* op, const Expr& self) {
 
   // Vector rules
   if (op->type.lanes() != 1) {
-    TVM_TRY_REWRITE(broadcast(x, lanes) % broadcast(y, lanes),
-                    broadcast(x % y, lanes));
+    TVM_TRY_REWRITE(truncmod(broadcast(x, lanes), broadcast(y, lanes)),
+                    broadcast(truncmod(x, y), lanes));
 
     // ramp % bcast
-    if ((ramp(b1, c1, lanes) % broadcast(c2, lanes)).Match(ret)) {
+    if (truncmod(ramp(b1, c1, lanes), broadcast(c2, lanes)).Match(ret)) {
       int64_t c1val = c1.Eval()->value;
       int64_t c2val = c2.Eval()->value;
       if (c1val % c2val == 0) {
-        return broadcast(b1 % c2, lanes).Eval();
+        return broadcast(truncmod(b1, c2), lanes).Eval();
       }
       // If all possible indices in ramp are the same.
       if (CanProveGreaterEqual(b1.Eval(), 0)) {
@@ -696,9 +713,10 @@ Mutate_(const Mod* op, const Expr& self) {
         int64_t ramp_max = (bmod->base + (lanes.Eval() - 1) * c1val) / c2val;
         if (bmod->coeff % c2val == 0) {
           if (ramp_min == ramp_max) {
-            return ramp(bmod->base % c2, c1, lanes).Eval();
+            return ramp(truncmod(bmod->base, c2), c1, lanes).Eval();
           } else {
-            return (ramp(bmod->base % c2, c1, lanes) % broadcast(c2, lanes)).Eval();
+            return truncmod(ramp(truncmod(bmod->base, c2), c1, lanes),
+                            broadcast(c2, lanes)).Eval();
           }
         }
       }
@@ -709,23 +727,23 @@ Mutate_(const Mod* op, const Expr& self) {
     // Be-aware of the division rules:
     // We adopt the default C division uses truncation instead of floordiv.
     // This means most rules need to check non-negativeness of the operands.
-    TVM_TRY_REWRITE_IF((x * c1) % c2, ZeroWithTypeLike(x),
+    TVM_TRY_REWRITE_IF(truncmod(x * c1, c2), ZeroWithTypeLike(x),
                        c2.Eval()->value != 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0);
 
-    TVM_TRY_REWRITE_IF((x * c1 + y) % c2, y % c2,
+    TVM_TRY_REWRITE_IF(truncmod(x * c1 + y, c2), truncmod(y, c2),
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual((x * c1).Eval(), 0) &&
                        CanProveGreaterEqual(y.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x + c1) % c2, x % c2,
+    TVM_TRY_REWRITE_IF(truncmod(x + c1, c2), truncmod(x, c2),
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value >= 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF((x + y * c1) % c2, x % c2,
+    TVM_TRY_REWRITE_IF(truncmod(x + y * c1, c2), truncmod(x, c2),
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value % c2.Eval()->value == 0 &&
                        CanProveGreaterEqual(x.Eval(), 0) &&
@@ -733,18 +751,18 @@ Mutate_(const Mod* op, const Expr& self) {
 
     // canonicalization: x % c == x % (-c) for truncated division
     // NOTE: trunc div required
-    TVM_TRY_RECURSIVE_REWRITE_IF(x % c1,
-                                 x % PConst<Expr>(make_const(op->type, -c1.Eval()->value)),
+    TVM_TRY_RECURSIVE_REWRITE_IF(truncmod(x, c1),
+                                 truncmod(x, PConst<Expr>(make_const(op->type, -c1.Eval()->value))),
                                  c1.Eval()->value < 0);
 
     // try modular analysis
-    if ((x % c1).Match(ret)) {
+    if (truncmod(x, c1).Match(ret)) {
       ModularSet mod = analyzer_->modular_set(x.Eval());
       int64_t c1val = c1.Eval()->value;
       if (mod->coeff % c1val == 0 &&
           c1val > 0 &&
           CanProveGreaterEqual(x.Eval(), 0)) {
-        return (mod->base % c1).Eval();
+        return truncmod(mod->base, c1).Eval();
       }
     }
   }
@@ -798,7 +816,7 @@ Mutate_(const FloorDiv* op, const Expr& self) {
       int64_t c2val = c2.Eval()->value;
       if (c1val > 0 && c2val > 0) {
         if (c1val % c2val == 0) return (x * floordiv(c1, c2)).Eval();
-        if (c2val % c1val == 0) return (floordiv(x, floordiv(c2, c1))).Eval();
+        if (c2val % c1val == 0) return floordiv(x, floordiv(c2, c1)).Eval();
       }
     }
 
@@ -1025,18 +1043,18 @@ Mutate_(const Min* op, const Expr& self) {
     // DivMod rules
     // Divide up rounding: truc div
     // NOTE: trucdiv(x, y) >= floordiv(x, y)
-    TVM_TRY_REWRITE_IF(min(((x + c1) / c2) * c2, x), x,
+    TVM_TRY_REWRITE_IF(min(truncdiv(x + c1, c2) * c2, x), x,
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value + 1 == c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(min(((x + c1) / c2) * c2, max(x, c2)), max(x, c2),
+    TVM_TRY_REWRITE_IF(min(truncdiv(x + c1, c2) * c2, max(x, c2)), max(x, c2),
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value + 1 == c2.Eval()->value &&
                        CanProveGreaterEqual(x.Eval(), 0));
 
-    TVM_TRY_REWRITE_IF(min(x, ((x + c1) / c2) * c2), x,
+    TVM_TRY_REWRITE_IF(min(x, truncdiv(x + c1, c2) * c2), x,
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value + 1 == c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(min(max(x, c2), ((x + c1) / c2) * c2), max(x, c2),
+    TVM_TRY_REWRITE_IF(min(max(x, c2), truncdiv(x + c1, c2) * c2), max(x, c2),
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value + 1 == c2.Eval()->value &&
                        CanProveGreaterEqual(x.Eval(), 0));
@@ -1104,11 +1122,11 @@ Mutate_(const Min* op, const Expr& self) {
     TVM_TRY_REWRITE(min(min(x, c1), c2), min(x, min(c1, c2)));
 
     // scaling rule
-    if (min(x / c1, y / c1).Match(ret)) {
+    if (min(truncdiv(x, c1), truncdiv(y, c1)).Match(ret)) {
       if (c1.Eval()->value > 0) {
-        return (min(x, y) / c1).Eval();
+        return truncdiv(min(x, y), c1).Eval();
       } else {
-        return (max(x, y) / c1).Eval();
+        return truncdiv(max(x, y), c1).Eval();
       }
     }
     if (min(floordiv(x, c1), floordiv(y, c1)).Match(ret)) {
@@ -1210,10 +1228,12 @@ Mutate_(const Max* op, const Expr& self) {
     // DivMod rules
     // Divide up rounding: truc div
     // NOTE: trucdiv(x, y) >= floordiv(x, y)
-    TVM_TRY_REWRITE_IF(max(((x + c1) / c2) * c2, x), ((x + c1) / c2) * c2,
+    TVM_TRY_REWRITE_IF(max(truncdiv(x + c1, c2) * c2, x),
+                       truncdiv(x + c1, c2) * c2,
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value + 1 == c2.Eval()->value);
-    TVM_TRY_REWRITE_IF(max(x, ((x + c1) / c2) * c2), ((x + c1) / c2) * c2,
+    TVM_TRY_REWRITE_IF(max(x, truncdiv(x + c1, c2) * c2),
+                       truncdiv(x + c1, c2) * c2,
                        c2.Eval()->value > 0 &&
                        c1.Eval()->value + 1 == c2.Eval()->value);
 
@@ -1276,11 +1296,11 @@ Mutate_(const Max* op, const Expr& self) {
     TVM_TRY_REWRITE(max(max(x, c1), c2), max(x, max(c1, c2)));
 
     // scaling rule
-    if (max(x / c1, y / c1).Match(ret)) {
+    if (max(truncdiv(x, c1), truncdiv(y, c1)).Match(ret)) {
       if (c1.Eval()->value > 0) {
-        return (max(x, y) / c1).Eval();
+        return truncdiv(max(x, y), c1).Eval();
       } else {
-        return (min(x, y) / c1).Eval();
+        return truncdiv(min(x, y), c1).Eval();
       }
     }
     if (max(floordiv(x, c1), floordiv(y, c1)).Match(ret)) {
@@ -1425,70 +1445,70 @@ Mutate_(const LT* op, const Expr& self) {
 
     // constant cancelation: only need to make use of one mod
     // truc div
-    TVM_TRY_REWRITE_IF(x * c2 < c1, x < (c1 - 1) / c2 + 1,
+    TVM_TRY_REWRITE_IF(x * c2 < c1, x < truncdiv(c1 - 1, c2) + 1,
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value > 0);
     // NOTE: trunc div required
-    TVM_TRY_REWRITE_IF(x * c2 < c1, x < c1 / c2,
+    TVM_TRY_REWRITE_IF(x * c2 < c1, x < truncdiv(c1, c2),
                        c1.Eval()->value <= 0 &&
                        c2.Eval()->value > 0);
     // NOTE: trunc div required (euclidean is ok too, floored is not)
-    TVM_TRY_REWRITE_IF(x * c2 < c1, (c1 - 1) / c2 - 1 < x,
+    TVM_TRY_REWRITE_IF(x * c2 < c1, truncdiv(c1 - 1, c2) - 1 < x,
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value < 0);
     // NOTE: trunc div required (floored is ok too, euclidean is not)
-    TVM_TRY_REWRITE_IF(x * c2 < c1, c1 / c2 < x,
+    TVM_TRY_REWRITE_IF(x * c2 < c1, truncdiv(c1, c2) < x,
                        c1.Eval()->value <= 0 &&
                        c2.Eval()->value < 0);
     // NOTE: trunc div required
-    TVM_TRY_REWRITE_IF(c1 < x * c2, (c1 + 1) / c2 - 1 < x,
+    TVM_TRY_REWRITE_IF(c1 < x * c2, truncdiv(c1 + 1, c2) - 1 < x,
                        c1.Eval()->value < 0 &&
                        c2.Eval()->value > 0);
-    TVM_TRY_REWRITE_IF(c1 < x * c2, c1 / c2 < x,
+    TVM_TRY_REWRITE_IF(c1 < x * c2, truncdiv(c1, c2) < x,
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0);
     // NOTE: trunc div required (floored is ok too, euclidean is not)
-    TVM_TRY_REWRITE_IF(c1 < x * c2, x < (c1 + 1) / c2 + 1,
+    TVM_TRY_REWRITE_IF(c1 < x * c2, x < truncdiv(c1 + 1, c2) + 1,
                        c1.Eval()->value < 0 &&
                        c2.Eval()->value < 0);
     // NOTE: trunc div required (euclidean is ok too, floored is not)
-    TVM_TRY_REWRITE_IF(c1 < x * c2, x < c1 / c2,
+    TVM_TRY_REWRITE_IF(c1 < x * c2, x < truncdiv(c1, c2),
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value < 0);
     // DivMod rules
     // trucdiv
-    TVM_TRY_REWRITE_IF(x / c1 < c2, x < c1 * c2,
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) < c2, x < c1 * c2,
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value > 0);
     // NOTE: trunc div required
-    TVM_TRY_REWRITE_IF(x / c1 < c2, x < c1 * (c2 - 1) + 1,
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) < c2, x < c1 * (c2 - 1) + 1,
                        c1.Eval()->value > 0 &&
                        c2.Eval()->value <= 0);
 
-    TVM_TRY_REWRITE_IF(c1 < x / c2, (c1 + 1) * c2 - 1 < x,
+    TVM_TRY_REWRITE_IF(c1 < truncdiv(x, c2), (c1 + 1) * c2 - 1 < x,
                        c1.Eval()->value >= 0 &&
                        c2.Eval()->value > 0);
     // NOTE: trunc div required
-    TVM_TRY_REWRITE_IF(c1 < x / c2, c1 * c2 < x,
+    TVM_TRY_REWRITE_IF(c1 < truncdiv(x, c2), c1 * c2 < x,
                        c1.Eval()->value < 0 &&
                        c2.Eval()->value > 0);
 
     // invariance for any div mod: x - (x / c1) * c1 == x % c1
-    TVM_TRY_REWRITE_IF((x / c1) * c1 < x, 0 < x % c1,
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) * c1 < x, 0 < truncmod(x, c1),
                        c1.Eval()->value > 0);
-    TVM_TRY_REWRITE_IF((x / c1) * c1 < x + y, 0 < x % c1 + y,
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) * c1 < x + y, 0 < truncmod(x, c1) + y,
                        c1.Eval()->value > 0);
-    TVM_TRY_REWRITE_IF((x / c1) * c1 < x - y, y < x % c1,
+    TVM_TRY_REWRITE_IF(truncdiv(x, c1) * c1 < x - y, y < truncmod(x, c1),
                        c1.Eval()->value > 0);
 
-    TVM_TRY_REWRITE_IF(((x + c2) / c1) * c1 < x,
-                       c2 < (x + c2) % c1,
+    TVM_TRY_REWRITE_IF(truncdiv(x + c2, c1) * c1 < x,
+                       c2 < truncmod(x + c2, c1),
                        c1.Eval()->value > 0);
-    TVM_TRY_REWRITE_IF(((x + c2) / c1) * c1 < x + y,
-                       c2 < (x + c2) % c1 + y,
+    TVM_TRY_REWRITE_IF(truncdiv(x + c2, c1) * c1 < x + y,
+                       c2 < truncmod(x + c2, c1) + y,
                        c1.Eval()->value > 0);
-    TVM_TRY_REWRITE_IF(((x + c2) / c1) * c1 < x - y,
-                       y < (x + c2) % c1 + (0 - c2),
+    TVM_TRY_REWRITE_IF(truncdiv(x + c2, c1) * c1 < x - y,
+                       y < truncmod(x + c2, c1) + (0 - c2),
                        c1.Eval()->value > 0);
 
     // floordiv

--- a/src/lang/expr_operator.cc
+++ b/src/lang/expr_operator.cc
@@ -178,11 +178,17 @@ Expr operator*(Expr a, Expr b) {
   return ir::Mul::make(a, b);
 }
 
-Expr truncdiv(Expr a, Expr b) {
+Expr div(Expr a, Expr b) {
   BinaryOpMatchTypes(a, b);
   Expr ret = arith::TryConstFold<ir::Div>(a, b);
   if (ret.defined()) return ret;
   return ir::Div::make(a, b);
+}
+
+Expr truncdiv(Expr a, Expr b) {
+  CHECK(a.type().is_int() || a.type().is_uint());
+  CHECK(b.type().is_int() || b.type().is_uint());
+  return div(a, b);
 }
 
 Expr truncmod(Expr a, Expr b) {
@@ -193,7 +199,7 @@ Expr truncmod(Expr a, Expr b) {
 }
 
 Expr operator/(Expr a, Expr b) {
-  return truncdiv(a, b);
+  return div(a, b);
 }
 
 Expr operator%(Expr a, Expr b) {

--- a/tests/cpp/pattern_match_test.cc
+++ b/tests/cpp/pattern_match_test.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,9 +47,9 @@ TEST(Pattern, Basic) {
   }
   CHECK(!(px + min(py, px)).Match((x + 1) + max(y, (x + 1))));
   CHECK((px + min(py, px)).Match(z + min(y, z)));
-  CHECK((px + py / (px * py)).Match(x + 2 / (x * 2)));
-  CHECK((px - py % (px * pz)).Match(x - 2 % (x * 2)));
-  CHECK((px - py % (px * PConst<Expr>(2))).Match(x - 2 % (x * 2)));
+  CHECK((px + truncdiv(py, px * py)).Match(x + truncdiv(2, x * 2)));
+  CHECK((px - truncmod(py, px * pz)).Match(x - truncmod(2, x * 2)));
+  CHECK((px - floormod(py, px * PConst<Expr>(2))).Match(x - floormod(2, x * 2)));
 
   // logicals
   CHECK((px == pz).Match(x == 1));


### PR DESCRIPTION
Background #3977 #3479 

Now that we have multiple integer division modes, it would be helpful to force our developers to be aware of multiple division mode and think about them when writing code. Eventually we might encourage the developers to use one over another. This PR makes all the pattern rewriting of truncdiv/mod explicit by removing the operator/ % overload, and add a clear error message when a developer attempt to declare a pattern using / % operator to redirect them to the use the explicit methods.

 