### PR TITLE
[TOPI][CUDA] Remove FLOP computation when calling 3rd party library

### DIFF
--- a/topi/python/topi/cuda/dense.py
+++ b/topi/python/topi/cuda/dense.py
@@ -92,10 +92,6 @@ def schedule_dense(cfg, outs):
 
     outs = [outs] if isinstance(outs, tvm.tensor.Tensor) else outs
     if target.target_name == "cuda" and "cublas" in target.libs:
-        A, B = outs[0].op.input_tensors
-        b, i = get_const_tuple(A.shape)
-        o, _ = get_const_tuple(B.shape)
-        cfg.add_flop(2 * i * b * o)
         return generic.schedule_extern(outs)
 
     s = tvm.create_schedule([x.op for x in outs])


### PR DESCRIPTION
This is a quick fix to solve the crash problem when computing the flop of fused ops.

As pointed out by @soiferj, the added flop computation for 3rd party library such as cuBLAS deos not deal with the fusion ops. Although it can be resolved by traversing the graph and add all flops together, I prefer to remove it. The reason is that the flop information is only used by AutoTVM, but AutoTVM has nothing to do with cuBLAS. In addition, traversing the graph may introduce more unnecessary overhead when calling cuBLAS.