### PR TITLE
Exposed lowered func to c++ API.

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -143,6 +143,10 @@ class RelayBuildModule : public runtime::ModuleNode {
           this->SetParam(kv.first, kv.second->data);
         }
       });
+    } else if (name == "get_lowered_funcs") {
+      return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+          *rv = this->graph_codegen_->GetLoweredFunc();
+      });
     } else {
       LOG(FATAL) << "Unknown packed function: " << name;
       return PackedFunc([sptr_to_self, name](TVMArgs args, TVMRetValue* rv) {});


### PR DESCRIPTION
So that you can use: `build_mod_.GetFunction("get_lowered_funcs", false);`
to get lowered_funcs.

For our use case, it is used mostly for perf debug from C++ runtime.