### PR TITLE
Hide `import psutil`

### DIFF
--- a/python/tvm/rpc/server.py
+++ b/python/tvm/rpc/server.py
@@ -39,7 +39,6 @@ import subprocess
 import time
 import sys
 import signal
-import psutil
 
 from .._ffi.function import register_func
 from .._ffi.base import py_str
@@ -211,6 +210,7 @@ def _listen_loop(sock, port, rpc_key, tracker_addr, load_library, custom_addr):
         server_proc.join(opts.get("timeout", None))
         if server_proc.is_alive():
             logger.info("Timeout in RPC session, kill..")
+            import psutil
             parent = psutil.Process(server_proc.pid)
             # terminate worker childs
             for child in parent.children(recursive=True):


### PR DESCRIPTION
Hide `import psutil` from global, so that `mxnet`, which depends on `tvm`, can build without `psutil`.

Thank @yzhliu for guidance and review.