### PR TITLE
[Relay][TopHub] Add switch to disable TopHub download

### DIFF
--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -30,6 +30,16 @@ from .task import ApplyHistoryBest
 from .. import target as _target
 from ..contrib.download import download
 from .record import load_from_file
+from .util import EmptyContext
+
+# environment variable to read TopHub location
+AUTOTVM_TOPHUB_LOCATION_VAR = "TOPHUB_LOCATION"
+
+# default location of TopHub
+AUTOTVM_TOPHUB_DEFAULT_LOCATION = "https://raw.githubusercontent.com/uwsampl/tvm-distro/master/tophub"
+
+# value of AUTOTVM_TOPHUB_LOCATION_VAR to specify to not read from TopHub
+AUTOTVM_TOPHUB_NONE_LOCATION = "NONE"
 
 # root path to store TopHub files
 AUTOTVM_TOPHUB_ROOT_PATH = os.path.join(os.path.expanduser('~'), ".tvm", "tophub")
@@ -61,6 +71,9 @@ def _alias(name):
     }
     return table.get(name, name)
 
+def _get_tophub_location():
+    location = os.getenv(AUTOTVM_TOPHUB_LOCATION_VAR, None)
+    return AUTOTVM_TOPHUB_DEFAULT_LOCATION if location is None else location
 
 def context(target, extra_files=None):
     """Return the dispatch context with pre-tuned parameters.
@@ -75,6 +88,10 @@ def context(target, extra_files=None):
     extra_files: list of str, optional
         Extra log files to load
     """
+    tophub_location = _get_tophub_location()
+    if tophub_location == AUTOTVM_TOPHUB_NONE_LOCATION:
+        return EmptyContext()
+
     best_context = ApplyHistoryBest([])
 
     targets = target if isinstance(target, (list, tuple)) else [target]
@@ -94,7 +111,7 @@ def context(target, extra_files=None):
         for name in possible_names:
             name = _alias(name)
             if name in all_packages:
-                if not check_backend(name):
+                if not check_backend(tophub_location, name):
                     continue
 
                 filename = "%s_%s.log" % (name, PACKAGE_VERSION[name])
@@ -108,7 +125,7 @@ def context(target, extra_files=None):
     return best_context
 
 
-def check_backend(backend):
+def check_backend(tophub_location, backend):
     """Check whether have pre-tuned parameters of the certain target.
     If not, will download it.
 
@@ -135,18 +152,21 @@ def check_backend(backend):
     else:
         import urllib2
     try:
-        download_package(package_name)
+        download_package(tophub_location, package_name)
         return True
     except urllib2.URLError as e:
         logging.warning("Failed to download tophub package for %s: %s", backend, e)
         return False
 
 
-def download_package(package_name):
+def download_package(tophub_location, package_name):
     """Download pre-tuned parameters of operators for a backend
 
     Parameters
     ----------
+    tophub_location: str
+        The location to download TopHub parameters from
+
     package_name: str
         The name of package
     """
@@ -160,9 +180,9 @@ def download_package(package_name):
             if not os.path.isdir(path):
                 os.mkdir(path)
 
-    logger.info("Download pre-tuned parameters package %s", package_name)
-    download("https://raw.githubusercontent.com/uwsampl/tvm-distro/master/tophub/%s"
-             % package_name, os.path.join(rootpath, package_name), True, verbose=0)
+    download_url = "{0}/{1}".format(tophub_location, package_name)
+    logger.info("Download pre-tuned parameters package from %s", download_url)
+    download(download_url, os.path.join(rootpath, package_name), True, verbose=0)
 
 
 # global cache for load_reference_log

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -33,13 +33,13 @@ from .record import load_from_file
 from .util import EmptyContext
 
 # environment variable to read TopHub location
-AUTOTVM_TOPHUB_LOCATION_VAR = "TOPHUB_LOCATION"
+AUTOTVM_TOPHUB_LOC_VAR = "TOPHUB_LOCATION"
 
 # default location of TopHub
-AUTOTVM_TOPHUB_DEFAULT_LOCATION = "https://raw.githubusercontent.com/uwsampl/tvm-distro/master/tophub"
+AUTOTVM_TOPHUB_DEFAULT_LOC = "https://raw.githubusercontent.com/uwsampl/tvm-distro/master/tophub"
 
-# value of AUTOTVM_TOPHUB_LOCATION_VAR to specify to not read from TopHub
-AUTOTVM_TOPHUB_NONE_LOCATION = "NONE"
+# value of AUTOTVM_TOPHUB_LOC_VAR to specify to not read from TopHub
+AUTOTVM_TOPHUB_NONE_LOC = "NONE"
 
 # root path to store TopHub files
 AUTOTVM_TOPHUB_ROOT_PATH = os.path.join(os.path.expanduser('~'), ".tvm", "tophub")
@@ -72,8 +72,8 @@ def _alias(name):
     return table.get(name, name)
 
 def _get_tophub_location():
-    location = os.getenv(AUTOTVM_TOPHUB_LOCATION_VAR, None)
-    return AUTOTVM_TOPHUB_DEFAULT_LOCATION if location is None else location
+    location = os.getenv(AUTOTVM_TOPHUB_LOC_VAR, None)
+    return AUTOTVM_TOPHUB_DEFAULT_LOC if location is None else location
 
 def context(target, extra_files=None):
     """Return the dispatch context with pre-tuned parameters.
@@ -89,7 +89,7 @@ def context(target, extra_files=None):
         Extra log files to load
     """
     tophub_location = _get_tophub_location()
-    if tophub_location == AUTOTVM_TOPHUB_NONE_LOCATION:
+    if tophub_location == AUTOTVM_TOPHUB_NONE_LOC:
         return EmptyContext()
 
     best_context = ApplyHistoryBest([])

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -18,8 +18,8 @@
 TopHub: Tensor Operator Hub
 To get the best performance, we typically need auto-tuning for the specific devices.
 TVM releases pre-tuned parameters in TopHub for some common networks and hardware targets.
-TVM will download these parameters for you when you call nnvm.compiler.build_module
-or relay.build.
+TVM will download these parameters for you when you call
+nnvm.compiler.build_module or relay.build.
 """
 # pylint: disable=invalid-name
 

--- a/python/tvm/autotvm/tophub.py
+++ b/python/tvm/autotvm/tophub.py
@@ -18,7 +18,8 @@
 TopHub: Tensor Operator Hub
 To get the best performance, we typically need auto-tuning for the specific devices.
 TVM releases pre-tuned parameters in TopHub for some common networks and hardware targets.
-TVM will download these parameters for you when you call nnvm.compiler.build_module .
+TVM will download these parameters for you when you call nnvm.compiler.build_module
+or relay.build.
 """
 # pylint: disable=invalid-name
 

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -138,7 +138,7 @@ class BuildModule(object):
         return ret
 
 
-def build(mod, target=None, target_host=None, params=None):
+def build(mod, target=None, target_host=None, params=None, enable_tophub=True):
     """Helper function that builds a Relay function to run on TVM graph
     runtime.
 
@@ -164,6 +164,10 @@ def build(mod, target=None, target_host=None, params=None):
     params : dict of str to NDArray
         Input parameters to the graph that do not change
         during inference time. Used for constant folding.
+
+    enable_tophub : bool
+        True to download pre-tuned parameters from TopHub.
+        False to disable.
 
     Returns
     -------
@@ -197,7 +201,7 @@ def build(mod, target=None, target_host=None, params=None):
 
     # If current dispatch context is fallback context (the default root context),
     # then load pre-tuned parameters from TopHub
-    if isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
+    if enable_tophub and isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
         tophub_context = autotvm.tophub.context(list(target.values()))
     else:
         tophub_context = autotvm.util.EmptyContext()

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -138,7 +138,7 @@ class BuildModule(object):
         return ret
 
 
-def build(mod, target=None, target_host=None, params=None, enable_tophub=True):
+def build(mod, target=None, target_host=None, params=None):
     """Helper function that builds a Relay function to run on TVM graph
     runtime.
 
@@ -164,10 +164,6 @@ def build(mod, target=None, target_host=None, params=None, enable_tophub=True):
     params : dict of str to NDArray
         Input parameters to the graph that do not change
         during inference time. Used for constant folding.
-
-    enable_tophub : bool
-        True to download pre-tuned parameters from TopHub.
-        False to disable.
 
     Returns
     -------
@@ -201,7 +197,7 @@ def build(mod, target=None, target_host=None, params=None, enable_tophub=True):
 
     # If current dispatch context is fallback context (the default root context),
     # then load pre-tuned parameters from TopHub
-    if enable_tophub and isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
+    if isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
         tophub_context = autotvm.tophub.context(list(target.values()))
     else:
         tophub_context = autotvm.util.EmptyContext()


### PR DESCRIPTION
Add a switch to disable downloading from TopHub. On machines which don't have internet access, failing to download from TopHub slows down `relay.build` significantly.

@merrymercy would you be able to take a look?