### PR TITLE
[Debugger] TVM graph runtime memory footprint breakdown.

### DIFF
--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -184,7 +184,7 @@ class GraphRuntimeDebug : public GraphRuntime {
 
     // Calculate intermediate feature map size.
     uint32_t inter_size = total_size - primary_inputs_size;
-    float percent_inter = std::round(static_cast<float>(inter_size) / total_size * 100);
+    float percent_inter = 100.0 - percent_primary_inputs;
 
     // Print the breakdown.
     LOG(INFO) << "Total memory allocation = " << total_size << " Bytes";

--- a/src/runtime/graph/debug/graph_runtime_debug.cc
+++ b/src/runtime/graph/debug/graph_runtime_debug.cc
@@ -145,7 +145,7 @@ class GraphRuntimeDebug : public GraphRuntime {
    * from begining upto the index-th node and return output of index-th node.
    * This is costly operation and suggest to use only for debug porpose.
    *
-   * \param index: The  index of the node.
+   * \param index: The index of the node.
    * \param data_out the node data.
    */
   void DebugGetNodeOutput(int index, DLTensor* data_out) {


### PR DESCRIPTION
As title.

For Resnet50, the output looks like this


~~~
[23:33:59] /home/ubuntu/workplace/tvm/t1/tvm/src/runtime/graph/debug/graph_runtime_debug.cc:189: Total memory allocation = 112698432 Bytes
[23:33:59] /home/ubuntu/workplace/tvm/t1/tvm/src/runtime/graph/debug/graph_runtime_debug.cc:190: Primary inputs (params + data) memory allocation = 102859936 (91%) Bytes
[23:33:59] /home/ubuntu/workplace/tvm/t1/tvm/src/runtime/graph/debug/graph_runtime_debug.cc:192: Intermediate feature maps memory allocation = 9838496 (9%) Bytes
~~~

@wweic @yzhliu @tqchen @shoubhik 