### PR TITLE
[Contrib][Cblas] Avoid allocating memory on every call to cblas batch gemm

### DIFF
--- a/src/contrib/cblas/cblas.cc
+++ b/src/contrib/cblas/cblas.cc
@@ -42,9 +42,9 @@ using namespace runtime;
 inline CBLAS_TRANSPOSE BooleanToTranspose(bool trans) { return trans ? CblasTrans : CblasNoTrans; }
 
 template <typename T>
-void ResizeVectorIfNecessary(std::vector<T>& vector, int desired_size) {
-  if (vector.size() < static_cast<size_t>(desired_size)) {
-    vector.resize(desired_size);
+void ResizeVectorIfNecessary(std::vector<T>* vector, int desired_size) {
+  if (vector->size() < static_cast<size_t>(desired_size)) {
+    vector->resize(desired_size);
   }
 }
 
@@ -77,9 +77,9 @@ struct CblasSgemmBatchOp {
     static std::vector<const float*> A_array;
     static std::vector<const float*> B_array;
     static std::vector<float*> C_array;
-    ResizeVectorIfNecessary(A_array, batch_size);
-    ResizeVectorIfNecessary(B_array, batch_size);
-    ResizeVectorIfNecessary(C_array, batch_size);
+    ResizeVectorIfNecessary(&A_array, batch_size);
+    ResizeVectorIfNecessary(&B_array, batch_size);
+    ResizeVectorIfNecessary(&C_array, batch_size);
     for (int i = 0; i < batch_size; ++i) {
       A_array[i] = A + i * a_stride;
       B_array[i] = B + i * b_stride;
@@ -125,9 +125,9 @@ struct CblasDgemmBatchOp {
     static std::vector<const double*> A_array;
     static std::vector<const double*> B_array;
     static std::vector<double*> C_array;
-    ResizeVectorIfNecessary(A_array, batch_size);
-    ResizeVectorIfNecessary(B_array, batch_size);
-    ResizeVectorIfNecessary(C_array, batch_size);
+    ResizeVectorIfNecessary(&A_array, batch_size);
+    ResizeVectorIfNecessary(&B_array, batch_size);
+    ResizeVectorIfNecessary(&C_array, batch_size);
     for (int i = 0; i < batch_size; ++i) {
       A_array[i] = A + i * a_stride;
       B_array[i] = B + i * b_stride;

--- a/src/contrib/cblas/cblas.cc
+++ b/src/contrib/cblas/cblas.cc
@@ -41,6 +41,13 @@ using namespace runtime;
 
 inline CBLAS_TRANSPOSE BooleanToTranspose(bool trans) { return trans ? CblasTrans : CblasNoTrans; }
 
+template <typename T>
+void ResizeVectorIfNecessary(std::vector<T>& vector, int desired_size) {
+  if (vector.size() < static_cast<size_t>(desired_size)) {
+    vector.resize(desired_size);
+  }
+}
+
 struct CblasSgemmOp {
   typedef float TDatatype;
   void operator()(bool ta, bool tb, int M, int N, int K, float alpha, float* A, int lda, float* B,
@@ -67,9 +74,12 @@ struct CblasSgemmBatchOp {
     CBLAS_TRANSPOSE trans_a = BooleanToTranspose(ta);
     CBLAS_TRANSPOSE trans_b = BooleanToTranspose(tb);
 #if USE_MKL_BLAS == 1
-    std::vector<const float*> A_array(batch_size);
-    std::vector<const float*> B_array(batch_size);
-    std::vector<float*> C_array(batch_size);
+    static std::vector<const float*> A_array;
+    static std::vector<const float*> B_array;
+    static std::vector<float*> C_array;
+    ResizeVectorIfNecessary(A_array, batch_size);
+    ResizeVectorIfNecessary(B_array, batch_size);
+    ResizeVectorIfNecessary(C_array, batch_size);
     for (int i = 0; i < batch_size; ++i) {
       A_array[i] = A + i * a_stride;
       B_array[i] = B + i * b_stride;
@@ -112,9 +122,12 @@ struct CblasDgemmBatchOp {
     CBLAS_TRANSPOSE trans_a = BooleanToTranspose(ta);
     CBLAS_TRANSPOSE trans_b = BooleanToTranspose(tb);
 #if USE_MKL_BLAS == 1
-    std::vector<const double*> A_array(batch_size);
-    std::vector<const double*> B_array(batch_size);
-    std::vector<double*> C_array(batch_size);
+    static std::vector<const double*> A_array;
+    static std::vector<const double*> B_array;
+    static std::vector<double*> C_array;
+    ResizeVectorIfNecessary(A_array, batch_size);
+    ResizeVectorIfNecessary(B_array, batch_size);
+    ResizeVectorIfNecessary(C_array, batch_size);
     for (int i = 0; i < batch_size; ++i) {
       A_array[i] = A + i * a_stride;
       B_array[i] = B + i * b_stride;


### PR DESCRIPTION
This change prevents memory allocation on each call to CblasSgemmBatchOp and CblasDgemmBatchOp.

@ajtulloch @yinghai would you be able to take a look?