### PR TITLE
[Rust] Fixes issue with CPP enums

### DIFF
--- a/rust/common/src/array.rs
+++ b/rust/common/src/array.rs
@@ -97,7 +97,7 @@ pub struct TVMContext {
 impl<'a> From<&'a TVMContext> for DLContext {
     fn from(ctx: &'a TVMContext) -> Self {
         Self {
-            device_type: ctx.device_type as i32,
+            device_type: ctx.device_type as _,
             device_id: ctx.device_id as i32,
         }
     }

--- a/rust/common/src/packed_func.rs
+++ b/rust/common/src/packed_func.rs
@@ -83,7 +83,7 @@ macro_rules! TVMPODValue {
                 use $name::*;
                 #[allow(non_upper_case_globals)]
                 unsafe {
-                    match type_code as i32 {
+                    match type_code as _ {
                         DLDataTypeCode_kDLInt => Int($value.v_int64),
                         DLDataTypeCode_kDLUInt => UInt($value.v_int64),
                         DLDataTypeCode_kDLFloat => Float($value.v_float64),


### PR DESCRIPTION
Fixes issue reported by user [here](https://discuss.tvm.ai/t/failed-to-compile-rust-bindings-tvm-common/4106).

Bindgen generates differing types on windows vs other platforms for CPP enums.