### PR TITLE
[AUTOTVM][DOCS] Add a link to the defining network description of auto-tuning tutorial

### DIFF
--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -39,8 +39,11 @@ import tvm.contrib.graph_runtime as runtime
 # First we need to define the network in relay frontend API.
 # We can load some pre-defined network from :code:`relay.testing`.
 # We can also load models from MXNet, ONNX and TensorFlow.
+# Alternatively, we can `build a Graph Convolutional Network (GCN) with Relay
+# <https://docs.tvm.ai/tutorials/frontend/build_gcn.html#building-a-graph-convolutional-network>`
 #
 # In this tutorial, we choose resnet-18 as tuning example.
+
 
 def get_network(name, batch_size):
     """Get the symbol definition and random weight of a network"""
@@ -72,6 +75,7 @@ def get_network(name, batch_size):
         raise ValueError("Unsupported network: " + name)
 
     return mod, params, input_shape, output_shape
+
 
 # Replace "llvm" with the correct target of your CPU.
 # For example, for AWS EC2 c5 instance with Intel Xeon
@@ -121,6 +125,7 @@ tuning_option = {
     ),
 }
 
+
 # You can skip the implementation of this function for this tutorial.
 def tune_kernels(tasks,
                  measure_option,
@@ -164,6 +169,7 @@ def tune_kernels(tasks,
                        callbacks=[
                            autotvm.callback.progress_bar(n_trial, prefix=prefix),
                            autotvm.callback.log_to_file(log_filename)])
+
 
 # Use graph tuner to achieve graph level optimal schedules
 # Set use_DP=False if it takes too long to finish.

--- a/tutorials/autotvm/tune_relay_x86.py
+++ b/tutorials/autotvm/tune_relay_x86.py
@@ -37,10 +37,9 @@ import tvm.contrib.graph_runtime as runtime
 # Define network
 # --------------
 # First we need to define the network in relay frontend API.
-# We can load some pre-defined network from :code:`relay.testing`.
+# We can either load some pre-defined network from :code:`relay.testing`
+# or building :any:`relay.testing.resnet` with relay.
 # We can also load models from MXNet, ONNX and TensorFlow.
-# Alternatively, we can `build a Graph Convolutional Network (GCN) with Relay
-# <https://docs.tvm.ai/tutorials/frontend/build_gcn.html#building-a-graph-convolutional-network>`
 #
 # In this tutorial, we choose resnet-18 as tuning example.
 


### PR DESCRIPTION
Hi @kevinthesun @comaniac 

Follow our [discussion](https://discuss.tvm.ai/t/refine-relay-with-autotvm-tutorial/3978) at tvm forum, I add a link to the autoTVM tutorial to direct the details of building NN with relay. I would appreciate if you can help to review/merge it, thanks.