### PR TITLE
[Relay][Compile_engine] Int64 shape handling for outputs.

### DIFF
--- a/tests/python/relay/test_backend_compile_engine.py
+++ b/tests/python/relay/test_backend_compile_engine.py
@@ -79,8 +79,23 @@ def test_compile_tuple_dup():
     relay.build(relay.Module.from_expr(f), 'llvm')
 
 
+def test_compile_full():
+    # Shape calculations can happen in int64. The test checks that full operator
+    # can handle when shapes are not int32
+    shape = (tvm.expr.IntImm('int32', 1),
+             tvm.expr.IntImm('int64', 16),
+             tvm.expr.IntImm('int64', 16),
+             tvm.expr.IntImm('int32', 64))
+    output = relay.full(relay.const(0, 'int32'), shape=shape, dtype='int32')
+    f = relay.Function([], output)
+    mod = relay.Module.from_expr(f)
+    mod = relay.qnn.transform.CanonicalizeOps()(mod)
+    relay.build(mod, 'llvm')
+
+
 if __name__ == "__main__":
     test_compile_engine()
     test_compile_placeholder_bypass()
     test_compile_injective_with_tuple()
     test_compile_tuple_dup()
+    test_compile_full()


### PR DESCRIPTION
Shape calculations can happen in int64 (as shapes are IndexExpr). Compile engine already ensures that the shapes of all inputs are in int32 for the codegen. But, it missed to handle the output shapes. This causes problem for full operator.

@icemelon9 @zhiics @yzhliu  @vinx13 