### PR TITLE
[QNN] Renaming dense operator.

### DIFF
--- a/python/tvm/relay/qnn/op/qnn.py
+++ b/python/tvm/relay/qnn/op/qnn.py
@@ -313,12 +313,12 @@ def add(lhs,
                      output_scale, output_zero_point)
 
 
-def quantized_dense(data,
-                    weight,
-                    input_zero_point,
-                    kernel_zero_point,
-                    units=None,
-                    out_dtype="int32"):
+def dense(data,
+          weight,
+          input_zero_point,
+          kernel_zero_point,
+          units=None,
+          out_dtype="int32"):
     """Qnn Dense operator.
     Applies a quantized linear transformation
 

--- a/tests/python/relay/test_qnn_dense.py
+++ b/tests/python/relay/test_qnn_dense.py
@@ -153,7 +153,7 @@ def qnn_dense_driver(test_configuration):
     quantized_kernel = relay.var(quantized_kernel_name,
                                  shape=test_configuration['kernel_shape'],
                                  dtype=in_dtype)
-    mod = relay.qnn.op.quantized_dense(
+    mod = relay.qnn.op.dense(
         quantized_data,
         quantized_kernel,
         test_configuration['input_zero_point'],


### PR DESCRIPTION
As Title

The dense operator was not following the right name style. We missed it in code review. This PR fixes it.

@vinx13 @zhiics 
