### PR TITLE
Add dmlc-core to the list of installed header directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,11 @@ if (INSTALL_DEV)
     PATTERN "*.h"
     )
   install(
+    DIRECTORY "3rdparty/dmlc-core/include/." DESTINATION "include"
+    FILES_MATCHING
+    PATTERN "*.h"
+    )
+  install(
     DIRECTORY "nnvm/include/." DESTINATION "include"
     FILES_MATCHING
     PATTERN "*.h"


### PR DESCRIPTION
There are dependencies on dmlc-core in TVM public API headers
(e.g. some headers include dmlc/logging.h) so it needs to be installed
as part of TVM for TVM headers to be actually usable.
