### PR TITLE
[Relay][Topi] Disable conv NHWC pack int8.

### DIFF
--- a/topi/python/topi/x86/conv2d.py
+++ b/topi/python/topi/x86/conv2d.py
@@ -110,12 +110,15 @@ def _declaration_conv(cfg, data, kernel, strides, padding, dilation, layout, out
     kh, kw, _, _ = get_const_tuple(kernel.shape)
     if layout == 'HWCN':
         return nn.conv2d_hwcn(data, kernel, strides, padding, dilation, out_dtype)
-    elif layout == 'NHWC' and kh == 1 and kw == 1 and kernel.dtype == "int8":
-        if cfg.is_fallback:
-            _get_default_config(cfg, data, kernel, strides, padding, out_dtype, False, layout)
-        # specialize for INT8 1X1 conv on X86
-        return conv2d_avx_1x1._declaration_conv_nhwc_pack(cfg, data, kernel, strides,
-                                                          padding, dilation, out_dtype)
+    # FIXME - https://github.com/dmlc/tvm/issues/4122
+    # _declaration_conv_nhwc_pack expects kernel layout to be HWOI. However, the tests use HWIO
+    # layout. Commenting until we have clarity about the nhwc_pack implementation from the author.
+    # elif layout == 'NHWC' and kh == 1 and kw == 1 and kernel.dtype == "int8":
+    #     if cfg.is_fallback:
+    #         _get_default_config(cfg, data, kernel, strides, padding, out_dtype, False, layout)
+    #     # specialize for INT8 1X1 conv on X86
+    #     return conv2d_avx_1x1._declaration_conv_nhwc_pack(cfg, data, kernel, strides,
+    #                                                       padding, dilation, out_dtype)
     elif layout == 'NHWC':
         return nn.conv2d_nhwc(data, kernel, strides, padding, dilation, out_dtype)
     raise ValueError("not support this layout {} yet".format(layout))


### PR DESCRIPTION
Currently, _declaration_conv_nhwc_pack expects (NHWC, HWOI). Since, TOPI has no way of identifying the kernel layout, this code is triggered for TFLite which has (NHWC, HWIO).

I tried to investigate if it is a simple fix. However, I am somewhat confused. The test "topi/tests/python/test_topi_conv2d_nhwc_pack_int8.py" sets up the conv with HWIO layout instead of HWOI. The failure was not triggered because input_channels = output_channels in the test. When I change the test, it starts failing. Currently, there is no test from the Relay side that exercises the commented code in this PR.

So, for now, I disabled the dispatch to that nwhc_pack compute. @llyfacebook Will you be to take a look at this? You can regenerate the error by commenting out the changes in conv2d.py

Why I am looking into this? - This causes issue while executing quantized TFLite model on Skylake machine (-mcpu=skylake-avx512).

@yzhliu @zhiics @tqchen 