### PR TITLE
Hide symbols from dependent libraries if HIDE_PRIVATE_SYMBOLS is ON.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,17 @@ target_link_libraries(tvm_topi tvm ${TVM_LINKER_LIBS} ${TVM_RUNTIME_LINKER_LIBS}
 target_link_libraries(tvm_runtime ${TVM_RUNTIME_LINKER_LIBS})
 target_link_libraries(nnvm_compiler tvm)
 
+if (HIDE_PRIVATE_SYMBOLS AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(HIDE_SYMBOLS_LINKER_FLAGS "-Wl,--exclude-libs,ALL")
+  # Note: 'target_link_options' with 'PRIVATE' keyword would be cleaner
+  # but it's not available until CMake 3.13. Switch to 'target_link_options'
+  # once minimum CMake version is bumped up to 3.13 or above.
+  target_link_libraries(tvm ${HIDE_SYMBOLS_LINKER_FLAGS})
+  target_link_libraries(tvm_topi ${HIDE_SYMBOLS_LINKER_FLAGS})
+  target_link_libraries(tvm_runtime ${HIDE_SYMBOLS_LINKER_FLAGS})
+  target_link_libraries(nnvm_compiler ${HIDE_SYMBOLS_LINKER_FLAGS})
+endif()
+
 # Related headers
 target_include_directories(
   tvm


### PR DESCRIPTION
In current implementation HIDE_PRIVATE_SYMBOLS hides symbols from TVM
itself but not from its dependent libraries. This is problematic when
other third-party libraries with the same symbols are linked to the
same executable.

One example is using TVM with Mesa OpenCL drivers: they depend on LLVM
and load its shared libraries with RTLD_GLOBAL flag, which results in
conflicts with LLVM symbols that TVM uses. Arguably this particular
issue belongs to Mesa (here's their tracking bug:
https://gitlab.freedesktop.org/mesa/mesa/issues/236) but in general
that's the right thing to do regardless of this particular bug.

Note that I'm not enabling this functionality for Darwin as in my
earlier tests their linker didn't seem to understand "--exclude-libs"
(but I don't have test platform ATM to double-check).