### PR TITLE
[Relay][CanonicalizeOps] Make Bias_add shape same as the other operand

### DIFF
--- a/tests/python/relay/test_pass_alter_op_layout.py
+++ b/tests/python/relay/test_pass_alter_op_layout.py
@@ -134,7 +134,8 @@ def test_alter_layout():
                             kernel_layout="OIHW16i",
                             data_layout="NCHW16c")
         b = relay.expand_dims(bias, axis=1, num_newaxis=2)
-        b = relay.layout_transform(b, "CHW", "CHW16c")
+        b = relay.expand_dims(b, axis=0, num_newaxis=1)
+        b = relay.layout_transform(b, "NCHW", "NCHW16c")
         y = relay.add(y, b)
 
         y = relay.nn.relu(y)
@@ -304,7 +305,8 @@ def test_alter_layout_broadcast_op():
         weight = relay.var("weight")
         x = relay.layout_transform(x, "NCHW", "NCHW16c")
         bias = relay.expand_dims(bias, 1, 2)
-        bias = relay.layout_transform(bias, "CHW", "CHW16c")
+        bias = relay.expand_dims(bias, 0, 1)
+        bias = relay.layout_transform(bias, "NCHW", "NCHW16c")
         scale = relay.layout_transform(scale, "CHW", "CHW16c")
         y = relay.nn.conv2d(x, weight, channels=64, kernel_size=(3, 3), padding=(1, 1),
                             data_layout="NCHW16c")

--- a/tests/python/relay/test_pass_simplify_inference.py
+++ b/tests/python/relay/test_pass_simplify_inference.py
@@ -29,6 +29,9 @@ def test_simplify_batchnorm(dtype='float32'):
         if num_newaxis:
             scale = rly.expand_dims(scale, axis=1, num_newaxis=num_newaxis)
             shift = rly.expand_dims(shift, axis=1, num_newaxis=num_newaxis)
+        if num_newaxis != 3:
+            shift = rly.expand_dims(shift, axis=0, num_newaxis=1)
+            scale = rly.expand_dims(scale, axis=0, num_newaxis=1)
         return x * scale + shift
 
     def check(dim, axis, nstep):


### PR DESCRIPTION
Currently, the bias_add expansion is minimal, i.e., it expands the bias to the minimum number of dimensions and then rely on broadcast mechanism. This PR explicitly matches the dimension of bias_add to be exactly same as the other operand. This helps with the later stage in AlterOpLayout.

@icemelon9 @yzhliu @ZihengJiang 

Alternative impl - Make AlterOpLayout flexible - https://github.com/dmlc/tvm/pull/4040
