### PR TITLE
[Relay][VM] Improve profiler setup

### DIFF
--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -98,6 +98,11 @@ void VirtualMachineDebug::InvokePacked(Index packed_index,
                                        Index output_size,
                                        const std::vector<Object>& args) {
   auto ctx = VirtualMachine::GetParamsContext();
+  // warmup
+  VirtualMachine::InvokePacked(packed_index, func, arg_count, output_size,
+                               args);
+  TVMSynchronize(ctx.device_type, ctx.device_id, nullptr);
+
   auto op_begin = std::chrono::high_resolution_clock::now();
   VirtualMachine::InvokePacked(packed_index, func, arg_count, output_size,
                                args);


### PR DESCRIPTION
1. add warmup in profile runtime.
2. add autotvm context and target host logic in profiler compiler logic.

cc @zhiics @icemelon9 @jroesch