### PR TITLE
[CodeGen] Disable -mfloat-abi hard option for LLVM < 6.0

### DIFF
--- a/src/codegen/llvm/llvm_common.cc
+++ b/src/codegen/llvm/llvm_common.cc
@@ -100,6 +100,9 @@ void ParseLLVMTargetOptions(const std::string& target_str,
       *mattr = value;
     } else if (key == "-mfloat-abi") {
       if (value == "hard") {
+#if TVM_LLVM_VERSION < 60
+        LOG(FATAL) << "-mfloat-abi hard is only supported for LLVM > 6.0";
+#endif
         soft_float_abi = false;
       } else if (value == "soft") {
         soft_float_abi = true;


### PR DESCRIPTION
The -mfloat-abi hard option does not work for LLVM < 6.0 as it is ignored. This adds a fatal error when using unsupported LLVM versions so that the failure
is not silent.
