### PR TITLE
[Relay][VM] Fix constant folding issue in VM compiler

### DIFF
--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -62,8 +62,6 @@ class VMCompilerProfiler(vm.VMCompiler):
         vm : VirtualMachineProfiler
             The profile VM runtime.
 
-        params : dict
-            The parameters of the final graph.
         """
         target = self.update_target(target)
         target_host = self.update_target_host(target, target_host)
@@ -75,8 +73,7 @@ class VMCompilerProfiler(vm.VMCompiler):
 
         with tophub_context:
             self._compile(mod, target, target_host)
-        params = self.get_params()
-        return VirtualMachineProfiler(self._get_vm()), params
+        return VirtualMachineProfiler(self._get_vm())
 
 class VirtualMachineProfiler(vm.VirtualMachine):
     """Relay profile VM runtime."""

--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -23,25 +23,6 @@ Provides extra APIs for profiling vm execution.
 import tvm
 from . import vm, _vm
 
-def _update_target(target):
-    target = target if target else tvm.target.current_target()
-    if target is None:
-        raise ValueError("Target is not set in env or passed as argument.")
-
-    tgts = {}
-    if isinstance(target, (str, tvm.target.Target)):
-        dev_type = tvm.expr.IntImm("int32", tvm.nd.context(str(target)).device_type)
-        tgts[dev_type] = tvm.target.create(target)
-    elif isinstance(target, dict):
-        for dev, tgt in target.items():
-            dev_type = tvm.expr.IntImm("int32", tvm.nd.context(dev).device_type)
-            tgts[dev_type] = tvm.target.create(tgt)
-    else:
-        raise TypeError("target is expected to be str, tvm.target.Target, " +
-                        "or dict of str to str/tvm.target.Target, but received " +
-                        "{}".format(type(target)))
-    return tgts
-
 class VMCompilerProfiler(vm.VMCompiler):
     """Build Relay module to run on VM runtime."""
     def __init__(self):
@@ -81,7 +62,7 @@ class VMCompilerProfiler(vm.VMCompiler):
         vm : VirtualMachineProfiler
             The profile VM runtime.
         """
-        target = _update_target(target)
+        target = self.update_target(target)
         target_host = self.update_target_host(target, target_host)
 
         if params:

--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -30,7 +30,6 @@ class VMCompilerProfiler(vm.VMCompiler):
         self._compile = self.mod["compile"]
         self._get_vm = self.mod["get_vm"]
         self._set_params_func = self.mod["set_params"]
-        self._get_params_func = self.mod["get_params"]
 
     def compile(self, mod, target=None, target_host=None, params=None):
         """

--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -22,6 +22,46 @@ Provides extra APIs for profiling vm execution.
 """
 from . import vm, _vm
 
+def compile(mod, target=None, target_host=None, params=None):
+    """
+    Parameters
+    ----------
+    mod : relay.Module
+        The Relay module to build.
+
+    target : str, :any:`tvm.target.Target`, or dict of str(i.e.
+        device/context name) to str/tvm.target.Target, optional
+        For heterogeneous compilation, it is a dictionary indicating context
+        to target mapping. For homogeneous compilation, it is a build target.
+
+    target_host : str or :any:`tvm.target.Target`, optional
+        Host compilation target, if target is device.
+        When TVM compiles device specific program such as CUDA,
+        we also need host(CPU) side code to interact with the driver
+        to setup the dimensions and parameters correctly.
+        target_host is used to specify the host side codegen target.
+        By default, llvm is used if it is enabled,
+        otherwise a stackvm intepreter is used.
+
+    params : dict of str to NDArray
+        Input parameters to the graph that do not change
+        during inference time. Used for constant folding.
+
+    Returns
+    -------
+    vm : VirtualMachineProfiler
+        The profile VM runtime.
+    """
+    compiler = VMCompilerProfiler()
+    target = compiler.update_target(target)
+    target_host = compiler.update_target_host(target, target_host)
+    if params:
+        compiler.set_params(params)
+    tophub_context = compiler.tophub_context(target)
+    with tophub_context:
+        compiler._compile(mod, target, target_host)
+    return VirtualMachineProfiler(compiler._get_vm())
+
 class VMCompilerProfiler(vm.VMCompiler):
     """Build Relay module to run on VM runtime."""
     def __init__(self):
@@ -30,49 +70,6 @@ class VMCompilerProfiler(vm.VMCompiler):
         self._compile = self.mod["compile"]
         self._get_vm = self.mod["get_vm"]
         self._set_params_func = self.mod["set_params"]
-
-    def compile(self, mod, target=None, target_host=None, params=None):
-        """
-        Parameters
-        ----------
-        mod : relay.Module
-            The Relay module to build.
-
-        target : str, :any:`tvm.target.Target`, or dict of str(i.e.
-            device/context name) to str/tvm.target.Target, optional
-            For heterogeneous compilation, it is a dictionary indicating context
-            to target mapping. For homogeneous compilation, it is a build target.
-
-        target_host : str or :any:`tvm.target.Target`, optional
-            Host compilation target, if target is device.
-            When TVM compiles device specific program such as CUDA,
-            we also need host(CPU) side code to interact with the driver
-            to setup the dimensions and parameters correctly.
-            target_host is used to specify the host side codegen target.
-            By default, llvm is used if it is enabled,
-            otherwise a stackvm intepreter is used.
-
-        params : dict of str to NDArray
-            Input parameters to the graph that do not change
-            during inference time. Used for constant folding.
-
-        Returns
-        -------
-        vm : VirtualMachineProfiler
-            The profile VM runtime.
-
-        """
-        target = self.update_target(target)
-        target_host = self.update_target_host(target, target_host)
-
-        if params:
-            self.set_params(params)
-
-        tophub_context = self.tophub_context(target)
-
-        with tophub_context:
-            self._compile(mod, target, target_host)
-        return VirtualMachineProfiler(self._get_vm())
 
 class VirtualMachineProfiler(vm.VirtualMachine):
     """Relay profile VM runtime."""

--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -30,6 +30,7 @@ class VMCompilerProfiler(vm.VMCompiler):
         self._compile = self.mod["compile"]
         self._get_vm = self.mod["get_vm"]
         self._set_params_func = self.mod["set_params"]
+        self._get_params_func = self.mod["get_params"]
 
     def compile(self, mod, target=None, target_host=None, params=None):
         """
@@ -60,6 +61,9 @@ class VMCompilerProfiler(vm.VMCompiler):
         -------
         vm : VirtualMachineProfiler
             The profile VM runtime.
+
+        params : dict
+            The parameters of the final graph.
         """
         target = self.update_target(target)
         target_host = self.update_target_host(target, target_host)
@@ -71,7 +75,8 @@ class VMCompilerProfiler(vm.VMCompiler):
 
         with tophub_context:
             self._compile(mod, target, target_host)
-        return VirtualMachineProfiler(self._get_vm())
+        params = self.get_params()
+        return VirtualMachineProfiler(self._get_vm()), params
 
 class VirtualMachineProfiler(vm.VirtualMachine):
     """Relay profile VM runtime."""

--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=no-else-return, unidiomatic-typecheck, undefined-variable, invalid-name
+# pylint: disable=no-else-return, unidiomatic-typecheck, undefined-variable, invalid-name, redefined-builtin
 """
 The Relay Virtual Machine profiler.
 

--- a/python/tvm/relay/backend/profiler_vm.py
+++ b/python/tvm/relay/backend/profiler_vm.py
@@ -20,7 +20,6 @@ The Relay Virtual Machine profiler.
 
 Provides extra APIs for profiling vm execution.
 """
-import tvm
 from . import vm, _vm
 
 class VMCompilerProfiler(vm.VMCompiler):

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -132,7 +132,6 @@ class VMCompiler(object):
         self._compile = self.mod["compile"]
         self._get_vm = self.mod["get_vm"]
         self._set_params_func = self.mod["set_params"]
-        self._get_params_func = self.mod["get_params"]
 
     def set_params(self, params):
         """Set constant parameters for the model"""
@@ -182,14 +181,6 @@ class VMCompiler(object):
         else:
             tophub_context = autotvm.util.EmptyContext()
         return tophub_context
-
-    def get_params(self):
-        """Return the updated weights."""
-        params = self._get_params_func()
-        ret = {}
-        for key, value in params.items():
-            ret[key] = value.data
-        return ret
 
     def compile(self, mod, target=None, target_host=None, params=None):
         """

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=no-else-return, unidiomatic-typecheck, undefined-variable, invalid-name
+# pylint: disable=no-else-return, unidiomatic-typecheck, undefined-variable, invalid-name, redefined-builtin
 """
 The Relay Virtual Machine.
 

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -25,29 +25,10 @@ import numpy as np
 import tvm
 from tvm import autotvm
 from tvm._ffi.runtime_ctypes import TVMByteArray
+from tvm.relay import expr as _expr
 from . import _vm
 from . import vmobj as _obj
 from .interpreter import Executor
-
-
-def _update_target(target):
-    target = target if target else tvm.target.current_target()
-    if target is None:
-        raise ValueError("Target is not set in env or passed as argument.")
-
-    tgts = {}
-    if isinstance(target, (str, tvm.target.Target)):
-        dev_type = tvm.expr.IntImm("int32", tvm.nd.context(str(target)).device_type)
-        tgts[dev_type] = tvm.target.create(target)
-    elif isinstance(target, dict):
-        for dev, tgt in target.items():
-            dev_type = tvm.expr.IntImm("int32", tvm.nd.context(dev).device_type)
-            tgts[dev_type] = tvm.target.create(tgt)
-    else:
-        raise TypeError("target is expected to be str, tvm.target.Target, " +
-                        "or dict of str to str/tvm.target.Target, but received " +
-                        "{}".format(type(target)))
-    return tgts
 
 def _convert(arg, cargs):
     if isinstance(arg, (np.ndarray, tvm.nd.NDArray)):
@@ -150,8 +131,58 @@ class VMCompiler(object):
         self.mod = _vm._VMCompiler()
         self._compile = self.mod["compile"]
         self._get_vm = self.mod["get_vm"]
+        self._set_params_func = self.mod["set_params"]
 
-    def compile(self, mod, target=None, target_host=None):
+    def set_params(self, params):
+        """Set constant parameters for the model"""
+        inputs = {}
+        for name, param in params.items():
+            if isinstance(param, np.ndarray):
+                param = _nd.array(param)
+            inputs[name] = _expr.const(param)
+        self._set_params_func(inputs)
+
+    def update_target(self, target):
+        """Update target"""
+        target = target if target else tvm.target.current_target()
+        if target is None:
+            raise ValueError("Target is not set in env or passed as argument.")
+        tgts = {}
+        if isinstance(target, (str, tvm.target.Target)):
+            dev_type = tvm.expr.IntImm("int32", tvm.nd.context(str(target)).device_type)
+            tgts[dev_type] = tvm.target.create(target)
+        elif isinstance(target, dict):
+            for dev, tgt in target.items():
+                dev_type = tvm.expr.IntImm("int32", tvm.nd.context(dev).device_type)
+                tgts[dev_type] = tvm.target.create(tgt)
+        else:
+            raise TypeError("target is expected to be str, tvm.target.Target, " +
+                            "or dict of str to str/tvm.target.Target, but received " +
+                            "{}".format(type(target)))
+        return tgts
+
+    def update_target_host(self, target, target_host):
+        """Update target host"""
+        target_host = None if target_host == "" else target_host
+        if not target_host:
+            for device_type, tgt in target.items():
+                if device_type.value == tvm.nd.cpu(0).device_type:
+                    target_host = tgt
+                    break
+        if not target_host:
+            target_host = "llvm" if tvm.module.enabled("llvm") else "stackvm"
+        return tvm.target.create(target_host)
+
+    def tophub_context(self, target):
+        # If current dispatch context is fallback context (the default root context),
+        # then load pre-tuned parameters from TopHub
+        if isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
+            tophub_context = autotvm.tophub.context(list(target.values()))
+        else:
+            tophub_context = autotvm.util.EmptyContext()
+        return tophub_context
+
+    def compile(self, mod, target=None, target_host=None, params=None):
         """
         Parameters
         ----------
@@ -172,28 +203,22 @@ class VMCompiler(object):
             By default, llvm is used if it is enabled,
             otherwise a stackvm intepreter is used.
 
+        params : dict of str to NDArray
+            Input parameters to the graph that do not change
+            during inference time. Used for constant folding.
+
         Returns
         -------
         vm : VirtualMachine
             The VM runtime.
         """
-        target = _update_target(target)
-        target_host = None if target_host == "" else target_host
-        if not target_host:
-            for device_type, tgt in target.items():
-                if device_type.value == tvm.nd.cpu(0).device_type:
-                    target_host = tgt
-                    break
-        if not target_host:
-            target_host = "llvm" if tvm.module.enabled("llvm") else "stackvm"
-        target_host = tvm.target.create(target_host)
+        target = self.update_target(target)
+        target_host = self.update_target_host(target, target_host)
 
-        # If current dispatch context is fallback context (the default root context),
-        # then load pre-tuned parameters from TopHub
-        if isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
-            tophub_context = autotvm.tophub.context(list(target.values()))
-        else:
-            tophub_context = autotvm.util.EmptyContext()
+        if params:
+            self.set_params(params)
+
+        tophub_context = self.tophub_context(target)
 
         with tophub_context:
             self._compile(mod, target, target_host)

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -221,8 +221,6 @@ class VMCompiler(object):
         vm : VirtualMachine
             The VM runtime.
 
-        params : dict
-            The parameters of the final graph.
         """
         target = self.update_target(target)
         target_host = self.update_target_host(target, target_host)
@@ -234,8 +232,7 @@ class VMCompiler(object):
 
         with tophub_context:
             self._compile(mod, target, target_host)
-        params = self.get_params()
-        return VirtualMachine(self._get_vm()), params
+        return VirtualMachine(self._get_vm())
 
 class VMExecutor(Executor):
     """
@@ -264,7 +261,7 @@ class VMExecutor(Executor):
         self.ctx = ctx
         self.target = target
         compiler = VMCompiler()
-        self.vm, _ = compiler.compile(mod, target)
+        self.vm = compiler.compile(mod, target)
         self.vm.init(ctx)
 
     def _make_executor(self, expr=None):

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -264,7 +264,7 @@ class VMExecutor(Executor):
         self.ctx = ctx
         self.target = target
         compiler = VMCompiler()
-        self.vm = compiler.compile(mod, target)
+        self.vm, _ = compiler.compile(mod, target)
         self.vm.init(ctx)
 
     def _make_executor(self, expr=None):

--- a/python/tvm/relay/backend/vm.py
+++ b/python/tvm/relay/backend/vm.py
@@ -125,6 +125,47 @@ class VirtualMachine(object):
         return self.mod
 
 
+def compile(mod, target=None, target_host=None, params=None):
+    """
+    Parameters
+    ----------
+    mod : relay.Module
+        The Relay module to build.
+
+    target : str, :any:`tvm.target.Target`, or dict of str(i.e.
+        device/context name) to str/tvm.target.Target, optional
+        For heterogeneous compilation, it is a dictionary indicating context
+        to target mapping. For homogeneous compilation, it is a build target.
+
+    target_host : str or :any:`tvm.target.Target`, optional
+        Host compilation target, if target is device.
+        When TVM compiles device specific program such as CUDA,
+        we also need host(CPU) side code to interact with the driver
+        to setup the dimensions and parameters correctly.
+        target_host is used to specify the host side codegen target.
+        By default, llvm is used if it is enabled,
+        otherwise a stackvm intepreter is used.
+
+    params : dict of str to NDArray
+        Input parameters to the graph that do not change
+        during inference time. Used for constant folding.
+
+    Returns
+    -------
+    vm : VirtualMachine
+        The VM runtime.
+    """
+    compiler = VMCompiler()
+
+    target = compiler.update_target(target)
+    target_host = compiler.update_target_host(target, target_host)
+    if params:
+        compiler.set_params(params)
+    tophub_context = compiler.tophub_context(target)
+    with tophub_context:
+        compiler._compile(mod, target, target_host)
+    return VirtualMachine(compiler._get_vm())
+
 class VMCompiler(object):
     """Build Relay module to run on VM runtime."""
     def __init__(self):
@@ -182,49 +223,6 @@ class VMCompiler(object):
             tophub_context = autotvm.util.EmptyContext()
         return tophub_context
 
-    def compile(self, mod, target=None, target_host=None, params=None):
-        """
-        Parameters
-        ----------
-        mod : relay.Module
-            The Relay module to build.
-
-        target : str, :any:`tvm.target.Target`, or dict of str(i.e.
-            device/context name) to str/tvm.target.Target, optional
-            For heterogeneous compilation, it is a dictionary indicating context
-            to target mapping. For homogeneous compilation, it is a build target.
-
-        target_host : str or :any:`tvm.target.Target`, optional
-            Host compilation target, if target is device.
-            When TVM compiles device specific program such as CUDA,
-            we also need host(CPU) side code to interact with the driver
-            to setup the dimensions and parameters correctly.
-            target_host is used to specify the host side codegen target.
-            By default, llvm is used if it is enabled,
-            otherwise a stackvm intepreter is used.
-
-        params : dict of str to NDArray
-            Input parameters to the graph that do not change
-            during inference time. Used for constant folding.
-
-        Returns
-        -------
-        vm : VirtualMachine
-            The VM runtime.
-
-        """
-        target = self.update_target(target)
-        target_host = self.update_target_host(target, target_host)
-
-        if params:
-            self.set_params(params)
-
-        tophub_context = self.tophub_context(target)
-
-        with tophub_context:
-            self._compile(mod, target, target_host)
-        return VirtualMachine(self._get_vm())
-
 class VMExecutor(Executor):
     """
     An implementation of the executor interface for
@@ -251,8 +249,7 @@ class VMExecutor(Executor):
         self.mod = mod
         self.ctx = ctx
         self.target = target
-        compiler = VMCompiler()
-        self.vm = compiler.compile(mod, target)
+        self.vm = compile(mod, target)
         self.vm.init(ctx)
 
     def _make_executor(self, expr=None):

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -267,7 +267,6 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
   void VisitExpr_(const ConstantNode* const_node) {
     size_t konst_idx = context_->constants.size();
     std::string name = "p" + std::to_string(konst_idx);
-    context_->constant_indices[name] = konst_idx;
     context_->constants.push_back(const_node->data);
     Emit(Instruction::LoadConst(konst_idx, NewRegister()));
   }
@@ -398,7 +397,6 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
       }
       size_t konst_idx = context_->constants.size();
       std::string name = "p" + std::to_string(konst_idx);
-      context_->constant_indices[name] = konst_idx;
       context_->constants.push_back(shape_tensor);
       Emit(Instruction::LoadConst(konst_idx, NewRegister()));
       return last_register_;

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -266,7 +266,6 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
 
   void VisitExpr_(const ConstantNode* const_node) {
     size_t konst_idx = context_->constants.size();
-    std::string name = "p" + std::to_string(konst_idx);
     context_->constants.push_back(const_node->data);
     Emit(Instruction::LoadConst(konst_idx, NewRegister()));
   }
@@ -396,7 +395,6 @@ class VMFunctionCompiler : ExprFunctor<void(const Expr& expr)> {
         }
       }
       size_t konst_idx = context_->constants.size();
-      std::string name = "p" + std::to_string(konst_idx);
       context_->constants.push_back(shape_tensor);
       Emit(Instruction::LoadConst(konst_idx, NewRegister()));
       return last_register_;

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -798,22 +798,10 @@ PackedFunc VMCompiler::GetFunction(const std::string& name,
         this->SetParam(kv.first, kv.second->data);
       }
     });
-  } else if (name == "get_params") {
-    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
-      *rv = this->GetParams();
-    });
   } else {
     LOG(FATAL) << "Unknown packed function: " << name;
     return PackedFunc([sptr_to_self, name](TVMArgs args, TVMRetValue* rv) {});
   }
-}
-
-Map<std::string, Constant> VMCompiler::GetParams() {
-  Map<std::string, Constant> ret;
-  for (const auto& kv : out_params_) {
-    ret.Set(kv.first, ConstantNode::make(kv.second));
-  }
-  return ret;
 }
 
 void VMCompiler::SetParam(const std::string& name, runtime::NDArray data_in) {
@@ -902,10 +890,6 @@ void VMCompiler::Compile(Module mod,
   // populate constants
   for (auto data : context_.constants) {
     vm_->constants.push_back(Object::Tensor(data));
-  }
-  // populate output parameters
-  for (auto p : context_.constant_indices) {
-    out_params_[p.first] = context_.constants[p.second];
   }
 
   LibraryCodegen();

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -100,11 +100,29 @@ class VMCompiler : public runtime::ModuleNode {
     vm_ = std::make_shared<VirtualMachine>();
   }
 
-  void Compile(const Module& mod_ref,
+  /*!
+   * \brief Set the parameters
+   *
+   * \param name name of parameter
+   * \param data_in input DLTensor
+   */
+  void SetParam(const std::string& name, runtime::NDArray data_in);
+
+  void Compile(Module mod,
                const TargetsMap& targets,
                const tvm::Target& target_host);
 
  protected:
+  /*!
+   * \brief Bind params to function by using name
+   * \param func Relay function
+   * \param params params dict
+   * \return relay::Function
+   */
+  relay::Function BindParamsByName(
+      relay::Function func,
+      const std::unordered_map<std::string, runtime::NDArray>& params);
+
   Module OptimizeModule(const Module& mod, const TargetsMap& targets);
 
   void PopulateGlobalMap();
@@ -120,6 +138,8 @@ class VMCompiler : public runtime::ModuleNode {
   VMCompilerContext context_;
   /*! \brief Compiled virtual machine. */
   std::shared_ptr<VirtualMachine> vm_;
+  /*! \brief parameters */
+  std::unordered_map<std::string, runtime::NDArray> params_;
 };
 
 }  // namespace vm

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -103,13 +103,6 @@ class VMCompiler : public runtime::ModuleNode {
   }
 
   /*!
-   * \brief Get params dictionary
-   *
-   * \return Map<std::string, Constant> params dictionary
-   */
-  Map<std::string, Constant> GetParams();
-
-  /*!
    * \brief Set the parameters
    *
    * \param name name of parameter
@@ -149,8 +142,6 @@ class VMCompiler : public runtime::ModuleNode {
   std::shared_ptr<VirtualMachine> vm_;
   /*! \brief parameters */
   std::unordered_map<std::string, runtime::NDArray> params_;
-  /*! \brief Output parameters */
-  std::unordered_map<std::string, runtime::NDArray> out_params_;
 };
 
 }  // namespace vm

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -72,6 +72,8 @@ struct VMCompilerContext {
   TagMap tag_map;
   // Map from global var to a unique integer
   GlobalMap global_map;
+  // Map from name to constant index
+  std::unordered_map<std::string, size_t> constant_indices;
   // List of constants
   std::vector<NDArray> constants;
   // List of cached functions
@@ -99,6 +101,13 @@ class VMCompiler : public runtime::ModuleNode {
   virtual void InitVM() {
     vm_ = std::make_shared<VirtualMachine>();
   }
+
+  /*!
+   * \brief Get params dictionary
+   *
+   * \return Map<std::string, Constant> params dictionary
+   */
+  Map<std::string, Constant> GetParams();
 
   /*!
    * \brief Set the parameters
@@ -140,6 +149,8 @@ class VMCompiler : public runtime::ModuleNode {
   std::shared_ptr<VirtualMachine> vm_;
   /*! \brief parameters */
   std::unordered_map<std::string, runtime::NDArray> params_;
+  /*! \brief Output parameters */
+  std::unordered_map<std::string, runtime::NDArray> out_params_;
 };
 
 }  // namespace vm

--- a/src/relay/backend/vm/compiler.h
+++ b/src/relay/backend/vm/compiler.h
@@ -72,8 +72,6 @@ struct VMCompilerContext {
   TagMap tag_map;
   // Map from global var to a unique integer
   GlobalMap global_map;
-  // Map from name to constant index
-  std::unordered_map<std::string, size_t> constant_indices;
   // List of constants
   std::vector<NDArray> constants;
   // List of cached functions
@@ -110,6 +108,14 @@ class VMCompiler : public runtime::ModuleNode {
    */
   void SetParam(const std::string& name, runtime::NDArray data_in);
 
+  /*!
+   * \brief Compile functions in a Module
+   *
+   * \param mod Relay Module
+   * \param targets For heterogeneous compilation, it is a dictionary indicating context
+                    to target mapping. For homogeneous compilation, it is a build target.
+   * \param target_host Host compilation target, if target is device.
+   */
   void Compile(Module mod,
                const TargetsMap& targets,
                const tvm::Target& target_host);

--- a/src/runtime/vm/profiler/vm.cc
+++ b/src/runtime/vm/profiler/vm.cc
@@ -98,6 +98,11 @@ void VirtualMachineDebug::InvokePacked(Index packed_index,
                                        Index output_size,
                                        const std::vector<Object>& args) {
   auto ctx = VirtualMachine::GetParamsContext();
+  // warmup
+  VirtualMachine::InvokePacked(packed_index, func, arg_count, output_size,
+                               args);
+  TVMSynchronize(ctx.device_type, ctx.device_id, nullptr);
+
   auto op_begin = std::chrono::high_resolution_clock::now();
   VirtualMachine::InvokePacked(packed_index, func, arg_count, output_size,
                                args);

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -48,14 +48,14 @@ def veval(f, *args, ctx=tvm.cpu(), target="llvm"):
         mod = relay.Module()
         mod["main"] = f
         compiler = relay.vm.VMCompiler()
-        vm, _ = compiler.compile(mod, target)
+        vm = compiler.compile(mod, target)
         vm.init(tvm.cpu())
         return vm.invoke("main", *args)
     else:
         assert isinstance(f, relay.Module), "expected expression or module"
         mod = f
         compiler = relay.vm.VMCompiler()
-        vm, _ = compiler.compile(mod, target)
+        vm = compiler.compile(mod, target)
         vm.init(tvm.cpu())
         ret = vm.invoke("main", *args)
         return ret
@@ -583,7 +583,7 @@ def test_set_params():
     y = relay.nn.bias_add(relay.nn.dense(x, w), b)
     mod["main"] = relay.Function([x, w, b], y)
     compiler = relay.vm.VMCompiler()
-    vm, params = compiler.compile(mod, 'llvm')
+    vm = compiler.compile(mod, 'llvm')
     vm.init(tvm.cpu())
     
     x_np = np.random.uniform(size=(10, 5)).astype('float32')

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -47,15 +47,13 @@ def veval(f, *args, ctx=tvm.cpu(), target="llvm"):
     if isinstance(f, relay.Expr):
         mod = relay.Module()
         mod["main"] = f
-        compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target)
+        vm = relay.vm.compile(mod, target)
         vm.init(tvm.cpu())
         return vm.invoke("main", *args)
     else:
         assert isinstance(f, relay.Module), "expected expression or module"
         mod = f
-        compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target)
+        vm = relay.vm.compile(mod, target)
         vm.init(tvm.cpu())
         ret = vm.invoke("main", *args)
         return ret
@@ -582,8 +580,7 @@ def test_set_params():
     b = relay.var('b', shape=(6,))
     y = relay.nn.bias_add(relay.nn.dense(x, w), b)
     mod["main"] = relay.Function([x, w, b], y)
-    compiler = relay.vm.VMCompiler()
-    vm = compiler.compile(mod, 'llvm')
+    vm = relay.vm.compile(mod, 'llvm')
     vm.init(tvm.cpu())
     
     x_np = np.random.uniform(size=(10, 5)).astype('float32')

--- a/tests/python/relay/test_vm.py
+++ b/tests/python/relay/test_vm.py
@@ -48,14 +48,14 @@ def veval(f, *args, ctx=tvm.cpu(), target="llvm"):
         mod = relay.Module()
         mod["main"] = f
         compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target)
+        vm, _ = compiler.compile(mod, target)
         vm.init(tvm.cpu())
         return vm.invoke("main", *args)
     else:
         assert isinstance(f, relay.Module), "expected expression or module"
         mod = f
         compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target)
+        vm, _ = compiler.compile(mod, target)
         vm.init(tvm.cpu())
         ret = vm.invoke("main", *args)
         return ret
@@ -583,7 +583,7 @@ def test_set_params():
     y = relay.nn.bias_add(relay.nn.dense(x, w), b)
     mod["main"] = relay.Function([x, w, b], y)
     compiler = relay.vm.VMCompiler()
-    vm = compiler.compile(mod, 'llvm')
+    vm, params = compiler.compile(mod, 'llvm')
     vm.init(tvm.cpu())
     
     x_np = np.random.uniform(size=(10, 5)).astype('float32')

--- a/tests/python/relay/test_vm_serialization.py
+++ b/tests/python/relay/test_vm_serialization.py
@@ -32,14 +32,12 @@ def create_vm(f, ctx=tvm.cpu(), target="llvm", params=None):
     if isinstance(f, relay.Expr):
         mod = relay.Module()
         mod["main"] = f
-        compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target=target, params=params)
+        vm = _vm.compile(mod, target=target, params=params)
         vm.init(ctx)
         return vm
     else:
         assert isinstance(f, relay.Module), "expected mod as relay.Module"
-        compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(f, target=target, params=params)
+        vm = _vm.compile(f, target=target, params=params)
         vm.init(ctx)
         return vm
 

--- a/tests/python/relay/test_vm_serialization.py
+++ b/tests/python/relay/test_vm_serialization.py
@@ -33,13 +33,13 @@ def create_vm(f, ctx=tvm.cpu(), target="llvm", params=None):
         mod = relay.Module()
         mod["main"] = f
         compiler = relay.vm.VMCompiler()
-        vm, _ = compiler.compile(mod, target=target, params=params)
+        vm = compiler.compile(mod, target=target, params=params)
         vm.init(ctx)
         return vm
     else:
         assert isinstance(f, relay.Module), "expected mod as relay.Module"
         compiler = relay.vm.VMCompiler()
-        vm, _ = compiler.compile(f, target=target, params=params)
+        vm = compiler.compile(f, target=target, params=params)
         vm.init(ctx)
         return vm
 

--- a/tests/python/relay/test_vm_serialization.py
+++ b/tests/python/relay/test_vm_serialization.py
@@ -28,18 +28,18 @@ from tvm.relay.prelude import Prelude
 from tvm.contrib import util
 from tvm.relay import testing
 
-def create_vm(f, ctx=tvm.cpu(), target="llvm"):
+def create_vm(f, ctx=tvm.cpu(), target="llvm", params=None):
     if isinstance(f, relay.Expr):
         mod = relay.Module()
         mod["main"] = f
         compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target)
+        vm = compiler.compile(mod, target=target, params=params)
         vm.init(ctx)
         return vm
     else:
         assert isinstance(f, relay.Module), "expected mod as relay.Module"
         compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(f, target)
+        vm = compiler.compile(f, target=target, params=params)
         vm.init(ctx)
         return vm
 
@@ -61,7 +61,7 @@ def run_network(mod,
         return result.asnumpy().astype(dtype)
 
     def get_serialized_output(mod, data, params, target, ctx, dtype='float32'):
-        vm = create_vm(mod, ctx, target)
+        vm = create_vm(mod, ctx, target, params=params)
         ser = serializer.Serializer(vm)
         code, lib = ser.serialize()
         deser = deserializer.Deserializer(code, lib)

--- a/tests/python/relay/test_vm_serialization.py
+++ b/tests/python/relay/test_vm_serialization.py
@@ -33,13 +33,13 @@ def create_vm(f, ctx=tvm.cpu(), target="llvm", params=None):
         mod = relay.Module()
         mod["main"] = f
         compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(mod, target=target, params=params)
+        vm, _ = compiler.compile(mod, target=target, params=params)
         vm.init(ctx)
         return vm
     else:
         assert isinstance(f, relay.Module), "expected mod as relay.Module"
         compiler = relay.vm.VMCompiler()
-        vm = compiler.compile(f, target=target, params=params)
+        vm, _ = compiler.compile(f, target=target, params=params)
         vm.init(ctx)
         return vm
 

--- a/tests/python/unittest/test_runtime_vm_profiler.py
+++ b/tests/python/unittest/test_runtime_vm_profiler.py
@@ -22,13 +22,11 @@ import pytest
 from tvm import relay
 from tvm.relay.testing import resnet
 
-@pytest.mark.skip
 def test_basic():
     mod, params = resnet.get_workload()
-    compiler = relay.profiler_vm.VMCompilerProfiler()
     target = 'llvm'
     ctx = tvm.cpu()
-    vm = compiler.compile(mod, target)
+    vm = relay.profiler_vm.compile(mod, target)
     vm.init(ctx)
     vm.load_params(params)
 


### PR DESCRIPTION
This speeds up mxnet resnset18 by 4x because it fixes constant folding. Now vm is just 
1.4x slower than relay graph runtime. 

1. allow pass params when compile a module
2. enhance profiler robustness

cc @jroesch @zhiics @icemelon9 