### PR TITLE
[VTA] hotfix for de10-nano driver

### DIFF
--- a/cmake/modules/VTA.cmake
+++ b/cmake/modules/VTA.cmake
@@ -84,7 +84,7 @@ elseif(PYTHON)
     # Rules for Zynq-class FPGAs with pynq OS support (see pynq.io)
     if(${VTA_TARGET} STREQUAL "pynq" OR
        ${VTA_TARGET} STREQUAL "ultra96")
-      file(GLOB FPGA_RUNTIME_SRCS vta/src/pynq/pynq_driver.cc)
+      list(APPEND FPGA_RUNTIME_SRCS vta/src/pynq/pynq_driver.cc)
       # Rules for Pynq v2.4
       find_library(__cma_lib NAMES cma PATH /usr/lib)
     elseif(${VTA_TARGET} STREQUAL "de10nano")  # DE10-Nano rules


### PR DESCRIPTION
Issue:
git clone latest vta and run it on xilinx FPGA board, vta crashed due
to the "call stack overflow" which caused by a infinite recursive
function call. this issue ever happen before and get addressed by
PR 3843.

Analysis:
seems like de10-nano driver PR  used old code base then the  logic change
of 3843 get eliminated.

Solution:
add the logic back.