### PR TITLE
Add a python how to example of deploying tvm module with tvm runtime only

### DIFF
--- a/apps/howto_deploy/python_deploy.py
+++ b/apps/howto_deploy/python_deploy.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Copyright (c) 2017 by Contributors
+# brief Example code on load and run TVM module.s
+# file python_deploy.py
+
+import tvm
+import numpy as np
+
+def verify(mod, fname):
+  # Get the function from the module
+  f = mod.get_function(fname)
+  # Use tvm.nd.array to convert numpy ndarray to tvm
+  # NDArray type, so that function can be invoked normally
+  N = 10 
+  x = tvm.nd.array(np.arange(N, dtype=np.float32))
+  y = tvm.nd.array(np.zeros(N, dtype=np.float32))
+  # Invoke the function
+  f(x, y)
+  np_x = x.asnumpy() 
+  np_y = y.asnumpy() 
+  # Verify correctness of function
+  assert(np.all([xi+1 == yi for xi, yi in zip(np_x, np_y)]))
+  print("Finish verification...")
+  
+
+if __name__ == "__main__":
+  # The normal dynamic loading method for deployment
+  mod_dylib = tvm.module.load("lib/test_addone_dll.so")
+  print("Verify dynamic loading from test_addone_dll.so")
+  verify(mod_dylib, "addone")
+  # There might be methods to use the system lib way in
+  # python, but dynamic loading is good enough for now.

--- a/apps/howto_deploy/run_example.sh
+++ b/apps/howto_deploy/run_example.sh
@@ -25,5 +25,8 @@ export DYLD_LIBRARY_PATH=../../build:${DYLD_LIBRARY_PATH}
 echo "Run the deployment with all in one packed library..."
 lib/cpp_deploy_pack
 
-echo "Run the deployment with all in normal library..."
+echo "Run the cpp deployment with all in normal library..."
 lib/cpp_deploy_normal
+
+echo "Run the python deployment with all in normal library..."
+python python_deploy.py


### PR DESCRIPTION
TVM has the capability to deploy modules not only with cpp APIs as specified in (https://docs.tvm.ai/deploy/cpp_deploy.html), but also with python APIs. 

This PR adds an example tvm module deployment with python APIs. The original deployment test script remains unchanged and runs smoothly with an added python API test.  
