### PR TITLE
Add parser support for CAST tflite operator

### DIFF
--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -230,6 +230,24 @@ def test_forward_transpose():
     _test_forward_transpose((2, 3, 4, 5), ())
 
 #######################################################################
+# Cast
+# --------
+
+def _test_cast(data, cast_dtype):
+    """ One iteration of CAST """
+    with tf.Graph().as_default():
+        in_data = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+        out = math_ops.cast(in_data, cast_dtype)
+        compare_tflite_with_tvm(data, 'Placeholder:0', [in_data], [out])
+
+
+def test_forward_cast():
+    """ CAST """
+    _test_cast(np.arange(6.0, dtype=np.float32).reshape((1, 6)), cast_dtype=tf.int32)
+    _test_cast(np.arange(6.0, dtype=np.float32).reshape((1, 6)), cast_dtype=tf.uint8)
+    _test_cast(np.arange(6.0, dtype=np.int32).reshape((1, 6)), cast_dtype=tf.int64)
+
+#######################################################################
 # tile
 # ---------
 
@@ -996,6 +1014,9 @@ if __name__ == '__main__':
 
     # Transpose
     test_forward_transpose()
+
+    # Cast
+    test_forward_cast()
 
     # Tile
     test_forward_tile()


### PR DESCRIPTION
This implementation provides cast to limited number of dtypes that tflite
currently supports for placeholder op. The encoding values for
placeholder dtypes are taken from the tflite flatbuff schema.

- The tflite unsupported dtypes issue refers to: https://github.com/tensorflow/tensorflow/issues/24825
- tflite flatbuff schema: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema.fbs 

