### PR TITLE
[DOCKER] Fix broken test environment for test_gemm_acc32_vnni.py

### DIFF
--- a/docker/install/ubuntu_install_python_package.sh
+++ b/docker/install/ubuntu_install_python_package.sh
@@ -21,4 +21,4 @@ set -u
 set -o pipefail
 
 # install libraries for python package on ubuntu
-pip3 install pylint==1.9.4 six numpy pytest cython decorator scipy tornado typed_ast pytest mypy orderedset antlr4-python3-runtime attrs requests Pillow packaging
+pip3 install pylint==1.9.4 six numpy pytest cython decorator scipy tornado typed_ast pytest mypy orderedset antlr4-python3-runtime attrs requests Pillow packaging nose


### PR DESCRIPTION
The following commit:

bb82e09f9c38e65a62f416e4b4600375fb50a839
Author: Jianyu Huang <jianyu.huang@utexas.edu>
Date:   Fri Sep 13 13:27:40 2019 -0700
Add AVX512VNNI support for TVM (#3388)

Introduced a test case dependency on the nose package which is
currently not installed by the docker install scripts.  Add the
package.

Change-Id: I96debb44801f4a2ea98e4a72daa495342a44b7d8