### PR TITLE
[DOCKER] torch install depends on future package

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -23,5 +23,9 @@ set -o pipefail
 # fix to certain version for now
 pip3 install onnx==1.5.0
 
+# torch depends on a number of other packages, but unhelpfully, does
+# not expose that in the wheel!!!
+pip3 install future
+
 pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl
 pip3 install torchvision


### PR DESCRIPTION
The torch package depends on the future package but the torch wheel
does not expose that dependency resulting in an inconsitent install.

Ideally the wheel should declare all of its dependencies, I'm not sure
why the packagers have choosen not to do this, for now the simple work
around is to explicitly install the future package.

Change-Id: Ic9f0f4bb4c78ab65706fc1b20c1b4fd287856a9e