### PR TITLE
Change default value of override for Registry::Register?

### DIFF
--- a/include/tvm/runtime/registry.h
+++ b/include/tvm/runtime/registry.h
@@ -249,10 +249,10 @@ class Registry {
   /*!
    * \brief Register a function with given name
    * \param name The name of the function.
-   * \param override Whether allow oveeride existing function.
-   * \return Reference to theregistry.
+   * \param override Whether allow overriding existing function.
+   * \return Reference to the registry.
    */
-  TVM_DLL static Registry& Register(const std::string& name, bool override = false);  // NOLINT(*)
+  TVM_DLL static Registry& Register(const std::string& name, bool override = true);  // NOLINT(*)
   /*!
    * \brief Erase global function from registry, if exist.
    * \param name The name of the function.


### PR DESCRIPTION
I'm not very sure whether this is the right fix. If not, please advise other solutions.

TVM runtime was recently integrated into MXNet through https://github.com/apache/incubator-mxnet/pull/15550.

One problem pops up today is that it complains that one of the packed functions was registered more than once as the following. It looks like that there are two translation units registering `module._Enabled` respectively in the same registry, and `override=False` leads to error.

```
  what():  [05:35:49] /home/ubuntu/unison/mxnet4/gpu/3rdparty/tvm/src/runtime/registry.cc:79: Check failed: override: Global PackedFunc module._Enabled is already registered
Stack trace:
  [bt] (0) /home/ubuntu/unison/mxnet4/gpu/3rdparty/tvm/build/libtvm.so(tvm::runtime::Registry::Register(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)+0x47b) [0x7f1a00dfe3db]
```
The MXNet PR that can be used to reproduce the problem: https://github.com/apache/incubator-mxnet/pull/16414. In my case, it only happens when built with CUDA enabled. Pure CPU build is fine.

@tqchen @yzhliu 