### PR TITLE
[Docs] Add dependency of compilation with LLVM

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -54,7 +54,7 @@ Our goal is to build the shared libraries:
 .. code:: bash
 
     sudo apt-get update
-    sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake
+    sudo apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
 The minimal building requirements are
 


### PR DESCRIPTION
Fix issue [#4111](https://github.com/dmlc/tvm/issues/4111).
ATT, `libedit-dev` land `ibxml2-dev` is required when building tvm with LLVM enabled.