### PR TITLE
Fix infer type of kernel in dense.

### DIFF
--- a/src/relay/op/nn/nn.h
+++ b/src/relay/op/nn/nn.h
@@ -49,7 +49,7 @@ bool DenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     // validate the weight shape is proper if defined
     // Assign weight type
     Array<IndexExpr> wshape({param->units, dshape[dshape.size() - 1]});
-    reporter->Assign(types[1], TensorTypeNode::make(wshape, data->dtype));
+    reporter->Assign(types[1], TensorTypeNode::make(wshape, weight->dtype));
     oshape.Set((oshape.size() - 1), param->units);
   } else {
     if (weight == nullptr) return false;

--- a/src/relay/op/nn/nn.h
+++ b/src/relay/op/nn/nn.h
@@ -36,7 +36,7 @@ bool DenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
   CHECK_EQ(types.size(), 3);
   const auto* data = types[0].as<TensorTypeNode>();
   const auto* weight = types[1].as<TensorTypeNode>();
-  if (data == nullptr) return false;
+  if (data == nullptr || weight == nullptr) return false;
 
   const AttrType* param = attrs.as<AttrType>();
   CHECK(param != nullptr);
@@ -52,7 +52,6 @@ bool DenseRel(const Array<Type>& types, int num_inputs, const Attrs& attrs,
     reporter->Assign(types[1], TensorTypeNode::make(wshape, weight->dtype));
     oshape.Set((oshape.size() - 1), param->units);
   } else {
-    if (weight == nullptr) return false;
     Array<tvm::Expr> wshape = weight->shape;
     oshape.Set((oshape.size() - 1), wshape[0]);
   }

--- a/tests/python/relay/test_op_level1.py
+++ b/tests/python/relay/test_op_level1.py
@@ -382,6 +382,21 @@ def test_dense():
             tvm.testing.assert_allclose(op_res2.asnumpy(), ref_res, rtol=1e-5)
 
 
+def test_dense_dtype():
+    data_dtype = 'uint8'
+    weight_dtype = 'int8'
+    out_dtype = 'uint8'
+    n, c , h, w = tvm.var("n"), tvm.var("c"), tvm.var("h"), tvm.var("w")
+    x = relay.var("x", relay.TensorType((n, c, h, w), data_dtype))
+    w = relay.var("w", relay.TensorType((2, w), weight_dtype))
+    y = relay.nn.dense(x, w, units=2, out_dtype=out_dtype)
+    assert "units=2" in y.astext()
+    yy = run_infer_type(y)
+    assert yy.checked_type == relay.TensorType((n, c, h, 2), out_dtype)
+    assert run_infer_type(yy.args[0]).checked_type.dtype == 'uint8'
+    assert run_infer_type(yy.args[1]).checked_type.dtype == 'int8'
+
+
 def test_bitserial_dense():
     m, k = tvm.var("m"), tvm.var("k")
     x = relay.var("x", relay.TensorType((m, k), "int16"))
@@ -405,3 +420,4 @@ if __name__ == "__main__":
     test_batch_norm()
     test_dense()
     test_bitserial_dense()
+    test_dense_dtype()


### PR DESCRIPTION
With the introduction of quantization the kernel and data dtypes can be different (uint8 vs int8). So we can no longer make the assumption that kernel dtype will be the same as data dtype.
In this PR we correctly assign the weight dtype to `weight->dtype`