### PR TITLE
[Relay] Improve build error when no lowered funcs are produced

### DIFF
--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -460,11 +460,14 @@ class RelayBuildModule : public runtime::ModuleNode {
     ret_.params = graph_codegen_->GetParams();
 
     auto lowered_funcs = graph_codegen_->GetLoweredFunc();
-    CHECK(lowered_funcs.size() != 0) << "no lowered funcs exist in the compiled module";
-    ret_.mod = tvm::build(
-      lowered_funcs,
-      target_host_,
-      BuildConfig::Current());
+    if (lowered_funcs.size() == 0) {
+      LOG(WARNING) << "no lowered funcs exist in the compiled module";
+    } else {
+      ret_.mod = tvm::build(
+        lowered_funcs,
+        target_host_,
+        BuildConfig::Current());
+    }
   }
 
  protected:

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -460,12 +460,11 @@ class RelayBuildModule : public runtime::ModuleNode {
     ret_.params = graph_codegen_->GetParams();
 
     auto lowered_funcs = graph_codegen_->GetLoweredFunc();
-    if (lowered_funcs.size() != 0) {
-      ret_.mod = tvm::build(
-        lowered_funcs,
-        target_host_,
-        BuildConfig::Current());
-    }
+    CHECK(lowered_funcs.size() != 0) << "no lowered funcs exist in the compiled module";
+    ret_.mod = tvm::build(
+      lowered_funcs,
+      target_host_,
+      BuildConfig::Current());
   }
 
  protected:


### PR DESCRIPTION
If you accidentally create a module with no lowered funcs via `relay.build`, interaction with the module down the road segfaults without an error message.  For example, the annotated line in the program below would segfault, because I have accidentally passed `params` to `relay.build`, causing the entire program to be const-folded away.
```python
x = relay.var('x', shape=(1, 16, 64, 64), dtype='float32')
conv_expr = relay.nn.conv2d(
        x, relay.var('w'),
        kernel_size=(3, 3),
        padding=(1, 1),
        channels=16)
func = relay.Function(relay.analysis.free_vars(conv_expr), conv_expr)
mod = relay.Module.from_expr(func)

x_data = np.random.uniform(size=(1, 16, 64, 64)).astype('float32')
w_data = np.random.uniform(size=(16, 16, 3, 3)).astype('float32')
params = { 'x': x_data, 'w': w_data }

with tvm.build_config(disable_vectorize=True):
    graph, c_mod, params = relay.build(mod, target="c", params=params)
print(c_mod.get_source())  # <-- crashes here
```
This PR adds an error message to prevent the generation of modules without lowered funcs.

CC @jroesch @zhiics @tqchen 