### PR TITLE
Optimizing autotvm task extraction speed

### DIFF
--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -139,7 +139,7 @@ def extract_from_multiple_program(funcs, params, ops, target, target_host=None):
             # wrap build call in thread to avoid multiprocessing problems
             mod = relay.Module.from_expr(func)
             build_thread = threading.Thread(target=_lower,
-                                            args=(mod, target, target_host, param))
+                                            args=(mod, target, param))
             build_thread.start()
             build_thread.join()
 

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -53,6 +53,7 @@ def _lower(func,
     grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
     return grc.codegen(mod["main"])
 
+
 def extract_from_program(func, params, ops, target, target_host=None):
     """ Extract tuning tasks from a relay program.
 

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -45,11 +45,11 @@ def _lower(func,
         with relay.build_config(opt_level=3, disabled_pass={"AlterOpLayout"}):
             import vta
             with vta.build_config():
-                _, mod, _ = relay.optimize(func, target, params)
+                mod, _ = relay.optimize(func, target, params)
                 grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
                 return grc.codegen(mod["main"])
     # default case
-    _, mod, _ = relay.optimize(func, target, params)
+    mod, _ = relay.optimize(func, target, params)
     grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
     return grc.codegen(mod["main"])
 

--- a/python/tvm/autotvm/task/relay_integration.py
+++ b/python/tvm/autotvm/task/relay_integration.py
@@ -34,9 +34,8 @@ logger = logging.getLogger('autotvm')
 # TODO(moreau89) find a more elegant way to lower for VTAs
 def _lower(func,
            target,
-           target_host,
            params):
-    """ Helper to build VTA properly.
+    """ Helper to lower VTA properly.
     """
 
     from tvm import relay
@@ -49,13 +48,10 @@ def _lower(func,
                 _, mod, _ = relay.optimize(func, target, params)
                 grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
                 return grc.codegen(mod["main"])
-
-    
     # default case
     _, mod, _ = relay.optimize(func, target, params)
     grc = graph_runtime_codegen.GraphRuntimeCodegen(None, target)
     return grc.codegen(mod["main"])
-
 
 def extract_from_program(func, params, ops, target, target_host=None):
     """ Extract tuning tasks from a relay program.

--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -28,7 +28,7 @@ from . import module
 from . import adt
 from . import analysis
 from . import transform
-from .build_module import build, create_executor
+from .build_module import build, create_executor, optimize
 from .transform import build_config
 from . import prelude
 from . import parser

--- a/python/tvm/relay/backend/graph_runtime_codegen.py
+++ b/python/tvm/relay/backend/graph_runtime_codegen.py
@@ -36,7 +36,7 @@ contrib.graph_runtime or any other TVM runtime compatible systems.
 from __future__ import absolute_import
 
 from tvm.ndarray import empty
-from tvm.relay import build_module
+from tvm.relay import _build_module
 from tvm import target as _target
 from tvm import expr as _expr
 
@@ -44,7 +44,7 @@ class GraphRuntimeCodegen(object):
     """The compiler from Relay to the TVM runtime system."""
 
     def __init__(self, mod, target):
-        self._mod = build_module._GraphRuntimeCodegen()
+        self._mod = _build_module._GraphRuntimeCodegen()
         self._init = self._mod["init"]
         self._codegen = self._mod["codegen"]
         self._get_graph_json = self._mod["get_graph_json"]

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -60,6 +60,7 @@ class BuildModule(object):
         self._get_graph_json = self.mod["get_graph_json"]
         self._get_module = self.mod["get_module"]
         self._build = self.mod["build"]
+        self._optimize = self.mod["optimize"]
         self._set_params_func = self.mod["set_params"]
         self._get_params_func = self.mod["get_params"]
 
@@ -112,6 +113,46 @@ class BuildModule(object):
         params = self.get_params()
 
         return graph_json, mod, params
+
+    def optimize(self, func, target=None, params=None):
+        """
+        Parameters
+        ----------
+        func: relay.Function
+            The function to build.
+
+        target : str, :any:`tvm.target.Target`, or dict of str(i.e.
+        device/context name) to str/tvm.target.Target, optional
+            For heterogeneous compilation, it is a dictionary indicating context
+            to target mapping. For homogeneous compilation, it is a build target.
+
+        params : dict of str to NDArray
+            Input parameters to the graph that do not change
+            during inference time. Used for constant folding.
+
+        Returns
+        -------
+        graph_json : str
+            The json string that can be accepted by graph runtime.
+
+        mod : relay.Module
+            The optimized relay module.
+
+        params : dict
+            The parameters of the final graph.
+        """
+        target = _update_target(target)
+
+        # Setup the params.
+        if params:
+            self._set_params(params)
+        mod = self._optimize(func, target)
+        # Get artifacts
+        graph_json = self.get_json()
+        params = self.get_params()
+
+        return graph_json, mod, params
+
 
     def _set_params(self, params):
         inputs = {}
@@ -205,6 +246,61 @@ def build(mod, target=None, target_host=None, params=None):
     with tophub_context:
         bld_mod = BuildModule()
         graph_json, mod, params = bld_mod.build(func, target, target_host, params)
+    return graph_json, mod, params
+
+
+def optimize(mod, target=None, params=None):
+    """Helper function that builds a Relay function to run on TVM graph
+    runtime.
+
+    Parameters
+    ----------
+    mod : relay.Module
+        The module to build. Using relay.Function is deprecated.
+
+    target : str, :any:`tvm.target.Target`, or dict of str(i.e. device/context
+    name) to str/tvm.target.Target, optional
+        For heterogeneous compilation, it is a dictionary indicating context to
+        target mapping. For homogeneous compilation, it is a build target.
+
+    params : dict of str to NDArray
+        Input parameters to the graph that do not change
+        during inference time. Used for constant folding.
+
+    Returns
+    -------
+    graph_json : str
+        The json string that can be accepted by graph runtime.
+
+    mod : relay.Module
+        The optimized relay module.
+
+    params : dict
+        The parameters of the final graph.
+    """
+    if isinstance(mod, _Module):
+        func = mod["main"]
+    elif isinstance(mod, _expr.Function):
+        func = mod
+        warnings.warn(
+            "Please use input parameter mod (tvm.relay.module.Module) "
+            "instead of deprecated parameter func (tvm.relay.expr.Function)",
+            DeprecationWarning)
+    else:
+        raise ValueError("Type of input parameter mod must be tvm.relay.module.Module")
+
+    target = _update_target(target)
+
+    # If current dispatch context is fallback context (the default root context),
+    # then load pre-tuned parameters from TopHub
+    if isinstance(autotvm.DispatchContext.current, autotvm.FallbackContext):
+        tophub_context = autotvm.tophub.context(list(target.values()))
+    else:
+        tophub_context = autotvm.util.EmptyContext()
+
+    with tophub_context:
+        bld_mod = BuildModule()
+        graph_json, mod, params = bld_mod.optimize(func, target, params)
     return graph_json, mod, params
 
 

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -147,7 +147,7 @@ class BuildModule(object):
         # Get artifacts
         params = self.get_params()
 
-        return graph_json, mod, params
+        return mod, params
 
 
     def _set_params(self, params):

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -132,9 +132,6 @@ class BuildModule(object):
 
         Returns
         -------
-        graph_json : str
-            The json string that can be accepted by graph runtime.
-
         mod : relay.Module
             The optimized relay module.
 
@@ -148,7 +145,6 @@ class BuildModule(object):
             self._set_params(params)
         mod = self._optimize(func, target)
         # Get artifacts
-        graph_json = self.get_json()
         params = self.get_params()
 
         return graph_json, mod, params
@@ -250,8 +246,7 @@ def build(mod, target=None, target_host=None, params=None):
 
 
 def optimize(mod, target=None, params=None):
-    """Helper function that builds a Relay function to run on TVM graph
-    runtime.
+    """Helper function that optimizes a Relay module.
 
     Parameters
     ----------
@@ -269,9 +264,6 @@ def optimize(mod, target=None, params=None):
 
     Returns
     -------
-    graph_json : str
-        The json string that can be accepted by graph runtime.
-
     mod : relay.Module
         The optimized relay module.
 
@@ -300,8 +292,8 @@ def optimize(mod, target=None, params=None):
 
     with tophub_context:
         bld_mod = BuildModule()
-        graph_json, mod, params = bld_mod.optimize(func, target, params)
-    return graph_json, mod, params
+        mod, params = bld_mod.optimize(func, target, params)
+    return mod, params
 
 
 class GraphExecutor(_interpreter.Executor):

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -296,7 +296,7 @@ class RelayBuildModule : public runtime::ModuleNode {
 
     // Perform Module->Module optimizations.
     relay::Module relay_module = relay::ModuleNode::FromExpr(func);
- 
+
     Array<Pass> pass_seqs;
 
     // Run all dialect legalization passes.

--- a/src/relay/backend/build_module.cc
+++ b/src/relay/backend/build_module.cc
@@ -151,15 +151,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     } else if (name == "optimize") {
       return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
         CHECK_EQ(args.num_args, 2);
-        Function func = args[0];
-        if (this->params_.size()) {
-          func = this->BindParamsByName(func, this->params_);
-        }
-        // Perform Module->Module optimizations.
-        relay::Module relay_module = relay::ModuleNode::FromExpr(func);
-        relay_module = Optimize(relay_module, args[1], this->params_);
-        CHECK(relay_module.defined());
-        *rv = relay_module;
+        *rv = this->Optimize(args[0], args[1], this->params_);
       });
     } else {
       LOG(FATAL) << "Unknown packed function: " << name;
@@ -286,19 +278,25 @@ class RelayBuildModule : public runtime::ModuleNode {
   }
 
   /*!
-   * \brief Optimize a Relay module.
+   * \brief Optimize a Relay Function.
    *
-   * \param relay_module The input Relay module where optmization will be
-   *        applied on.
+   * \param func The input Function where optmization will be applied on.
    * \param targets The device type to `Target` mapping.
    * \param params The param name to value mapping.
    *
    * \return relay::Module The updated Relay module after optimization.
    */
   relay::Module Optimize(
-      relay::Module relay_module,
+      Function func,
       const TargetsMap& targets,
       const std::unordered_map<std::string, runtime::NDArray>& params) {
+    if (params.size()) {
+      func = BindParamsByName(func, params);
+    }
+
+    // Perform Module->Module optimizations.
+    relay::Module relay_module = relay::ModuleNode::FromExpr(func);
+ 
     Array<Pass> pass_seqs;
 
     // Run all dialect legalization passes.
@@ -358,6 +356,7 @@ class RelayBuildModule : public runtime::ModuleNode {
     // Fuse the operations if it is needed.
     relay_module = transform::FuseOps()(relay_module);
     relay_module = transform::InferType()(relay_module);
+    CHECK(relay_module.defined());
 
     return relay_module;
   }
@@ -453,14 +452,8 @@ class RelayBuildModule : public runtime::ModuleNode {
   void BuildRelay(
       Function func,
       const std::unordered_map<std::string, tvm::runtime::NDArray>& params) {
-    if (params.size()) {
-      func = BindParamsByName(func, params);
-    }
-
-    // Perform Module->Module optimizations.
-    relay::Module relay_module = relay::ModuleNode::FromExpr(func);
-    relay_module = Optimize(relay_module, targets_, params);
-    CHECK(relay_module.defined());
+    // Optimize input Relay Function and returns Relay Module
+    relay::Module relay_module = Optimize(func, targets_, params);
     // Get the updated function.
     func = relay_module->Lookup("main");
 


### PR DESCRIPTION
In autotvm, users can extract tuning tasks from models that are imported from relay.testing or other frameworks like tensorflow, however, current task extraction execution path contains unnecessary building of relay module into binary code. This PR is to optimize such an execution path and to save task extraction time.

It essentially exposes another interface from inside RelayBuildModule class, "optimize", that generates an optimized relay module (optimizing by FuseOps pass is essential). This output module can be fed to GraphRuntimeCodegen that goes through relay AST and detects corresponding tuning tasks while doing so. The new execution path eliminates the unnecessary tvm::build call, which takes a lot of time, without affecting the original task extraction goal.

Experiments of extracting tuning tasks from relay.testing models:

model | before(s) | after(s) | speedup
--- | --- | --- | ---
resnet-18 | 137.04 | 15.61 | 8.78x
resnet-34 | 137.11 | 15.74 | 8.71x
resnet-50 | 250.77 | 21.88 | 11.46x
resnet-101 | 251.06 | 22.33 | 11.24x
vgg-16 | 53.64 | 0.58 | 92.48x
vgg-19 | 53.63 | 0.58 | 92.46x
mobilenet | 108.7 | 18.42 | 5.9x
squeezenet_v1.1 | 89.62 | 0.53 | 169.09x
inception_v3 | 325.19 | 34.51 | 9.42x

The extracted tasks have been verified with original results.
