### PR TITLE
[DOCKER] Pin torchvision==0.4.1

### DIFF
--- a/docker/install/ubuntu_install_onnx.sh
+++ b/docker/install/ubuntu_install_onnx.sh
@@ -27,5 +27,4 @@ pip3 install onnx==1.5.0
 # not expose that in the wheel!!!
 pip3 install future
 
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1.post2-cp36-cp36m-linux_x86_64.whl
-pip3 install torchvision
+pip3 install torch==1.2.0 torchvision==0.4.0


### PR DESCRIPTION
The existing sequence of pip install commands fetches and installs
torch==1.0.1.post2 then fetches an unpinned version of torchvision,
recent torchvision packages hardwire the specific torch version they
depend on, the overall effect is that we install a pinned torch
version then replace it with whatever version the torchvision package
depends on.

The most recent torchvision==0.4.1 package results in some test case
failures.

This patch pins torchvision back to 0.4.0, the most recent version
that the test suite worked.  Removing the explicit torch install
because it is implied and pinned as dependency of torchvision.

Change-Id: Ib30bf6aed79ff130ea15ef5134fefb0508790574