### PR TITLE
Disable CPU Affinity by default

### DIFF
--- a/src/runtime/threading_backend.cc
+++ b/src/runtime/threading_backend.cc
@@ -81,7 +81,7 @@ class ThreadGroup::Impl {
     num_workers_used = std::min(num_workers_, num_workers_used);
 
     const char *val = getenv("TVM_BIND_THREADS");
-    if (val == nullptr || atoi(val) == 1) {
+    if (val != nullptr && atoi(val) == 1) {
       // Do not set affinity if there are more workers than found cores
       if (sorted_order_.size() >= static_cast<unsigned int>(num_workers_)) {
           SetAffinity(exclude_worker0, mode == kLittle);


### PR DESCRIPTION
TVM Runtime uses CPU Affinity by default.
It simply sets thread0 to use core0, thread1 to use core1, etc.
Lets say we have 8 cores box.
User runs two TVM instances and sets number of threads to be 4. 
`export TVM_NUM_THREADS=4`
Both TVM runtimes will use and share cores 0,1,2,3. Cores 4,5,6,7 will not be used.
As a result runtime performance will be 2 times slower.
I think CPU Affinity should not be enables by default. Most of the users are not aware of CPU Affinity in TVM.
If we disable CPU Affinity before running the test above then OS maps TVM runtime threads to particular cores itself. As a result each TVM runtime will gets its own 4 cores and all 8 available cores on the box will be utilized.
As a result two TVM runtimes will run in parallel without stepping on each other.

This PR disables CPU Affinity by default.
To enable CPU Affinity user needs explicitly set `TVM_BIND_THREADS` to be `1`