### PR TITLE
[CI] Move golang tests to the end

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,10 +202,10 @@ stage('Build') {
         make(ci_cpu, 'build', '-j2')
         pack_lib('cpu', tvm_lib)
         timeout(time: max_time, unit: 'MINUTES') {
-          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_unittest.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_integration.sh"
           sh "${docker_run} ${ci_cpu} ./tests/scripts/task_python_vta.sh"
+          sh "${docker_run} ${ci_cpu} ./tests/scripts/task_golang.sh"
         }
       }
     }


### PR DESCRIPTION
Golang tests needs to use python script, which might get affected by stale cython package because cython won't be built until the python tests. 

Should prevent the problem of stale cython that causes golang tests to fail in the future. cc @yzhliu  