### PR TITLE
[relay][vm] Reuse allocated device memory

### DIFF
--- a/include/tvm/runtime/vm.h
+++ b/include/tvm/runtime/vm.h
@@ -747,6 +747,12 @@ class VirtualMachine : public runtime::ModuleNode {
 
   /*! \brief The parameter name to data mapping. */
   std::unordered_map<std::string, ObjectRef> params_;
+
+  /*!
+   * \brief The constant pool for runtime. It caches the device dependent
+   * object to avoid rellocation of constants during inference.
+   */
+  std::vector<ObjectRef> const_pool_;
 };
 
 }  // namespace vm


### PR DESCRIPTION
The current implementation of vm `LoadConst` instruction attempts to call `CopyTo` method to allocate memory on device for each invocation. This is not problematic for execution on CPU as the constant pool always stores the allocated objects. However, this is very expensive when we perform inference on GPU as `CopyTo` needs to allocate device memory every time.

This PR introduces a runtime time constant pool to cache the allocated device memory and reuse it whenever possible. For example, the memory will be setup during warmup and inference will not allocate new device memory any more. It reduces the inference time of MXNet ResNet-50 V1 from 57ms to 16+ms on P2. 

cc @wweic @icemelon9 @jroesch @tqchen 
