### PR TITLE
[Relay] Setting Legalize opt_level to 1.

### DIFF
--- a/src/relay/pass/legalize.cc
+++ b/src/relay/pass/legalize.cc
@@ -103,7 +103,7 @@ Pass Legalize(const std::string& legalize_map_attr_name) {
       [=](Function f, Module m, PassContext pc) {
         return Downcast<Function>(relay::legalize::Legalize(f, legalize_map_attr_name));
       };
-  return CreateFunctionPass(pass_func, 0, "Legalize", {ir::StringImm::make("InferType")});
+  return CreateFunctionPass(pass_func, 1, "Legalize", {ir::StringImm::make("InferType")});
 }
 
 TVM_REGISTER_API("relay._transform.Legalize").set_body_typed(Legalize);


### PR DESCRIPTION
The opt_level for legalize is set at 0 currently. We did this because we wanted to ensure that QNN (or dialects) can run there legalize functions before starting the Relay passes.

However, I think we should have legalize opt_level atleast 1. The main reason is that if there is a graph that is just Relay (no dialect), we will run Legalize function for it. This is against the opt_level=0 expectation, where no performance optimization should be done. It means that Dialects will now have to run at least at opt_level=1, but I think that is a reasonable trade-off.

What do you think? @zhiics @tqchen 