### PR TITLE
[hotfix] missing include headers

### DIFF
--- a/src/arithmetic/const_fold.h
+++ b/src/arithmetic/const_fold.h
@@ -28,6 +28,7 @@
 #include <tvm/ir_mutator.h>
 #include <tvm/expr_operator.h>
 #include <algorithm>
+#include <cmath>
 #include "int_operator.h"
 
 namespace tvm {

--- a/src/codegen/codegen_cuda.cc
+++ b/src/codegen/codegen_cuda.cc
@@ -24,6 +24,7 @@
 #include <tvm/base.h>
 #include <tvm/runtime/registry.h>
 #include <tvm/packed_func_ext.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include "codegen_cuda.h"

--- a/src/codegen/codegen_opencl.cc
+++ b/src/codegen/codegen_opencl.cc
@@ -22,6 +22,7 @@
  * \file codegen_opencl.cc
  */
 #include <tvm/packed_func_ext.h>
+#include <cmath>
 #include <vector>
 #include <string>
 #include "codegen_opencl.h"


### PR DESCRIPTION
This PR fixes the compilation error on Ubuntu 18.04 with GCC 7.4 due to missing headers.
