### PR TITLE
[CUDA] Update have_int8 condition to run on compute capability 7.x devices

### DIFF
--- a/python/tvm/contrib/nvcc.py
+++ b/python/tvm/contrib/nvcc.py
@@ -245,8 +245,8 @@ def have_int8(compute_version):
     compute_version : str
         compute capability of a GPU (e.g. "6.1")
     """
-    major, minor = parse_compute_version(compute_version)
-    if major == 6 and minor == 1:
+    major, _ = parse_compute_version(compute_version)
+    if major >= 6:
         return True
 
     return False


### PR DESCRIPTION
Update have_int8 condition to run on compute capability 7.x devices since IDP4A instruction is also available on recent (volta, turing) architectures https://docs.nvidia.com/cuda/cuda-binary-utilities/index.html#volta.

@tqchen @masahi 