### PR TITLE
[VTA] Performance optimize, remove unnecessary contigious memory use.

### DIFF
--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -443,18 +443,15 @@ class UopQueue : public BaseQueue<VTAUop> {
       sram_begin_ = sram_end_;
     }
   }
-
   /*! \brief clear cache and reset base queue buffer.*/
   void Reset() {
     cache_.clear();
     cache_idx_ = 0;
     BaseQueue<VTAUop>::Reset();
   }
-
   void AutoReadBarrier() {
     ReadBarrier();
   }
-
   /*! \brief Writer barrier to make sure that data written by CPU is visible to VTA. */
   void ReadBarrier() {
     CHECK(fpga_buff_ != nullptr);

--- a/vta/src/runtime.cc
+++ b/vta/src/runtime.cc
@@ -348,7 +348,7 @@ class BaseQueue {
    * \brief Reset the pointer of the buffer.
    *  Set SRAM pointer to be the current end.
    */
-  void Reset() {
+  virtual void Reset() {
     dram_buffer_.clear();
     sram_begin_ = sram_end_;
   }
@@ -443,9 +443,18 @@ class UopQueue : public BaseQueue<VTAUop> {
       sram_begin_ = sram_end_;
     }
   }
+
+  /*! \brief clear cache and reset base queue buffer.*/
+  void Reset() {
+    cache_.clear();
+    cache_idx_ = 0;
+    BaseQueue<VTAUop>::Reset();
+  }
+
   void AutoReadBarrier() {
     ReadBarrier();
   }
+
   /*! \brief Writer barrier to make sure that data written by CPU is visible to VTA. */
   void ReadBarrier() {
     CHECK(fpga_buff_ != nullptr);


### PR DESCRIPTION
Issue:
Uop maintain a cache vector to copy uop data into contigious DRAM memory for
FPGA/Simulator use, but this cache vector not get clear after FPGA/Simulator
core run, in Resnet18 case, if we printf the cache size in UopQueue::ReadBarrier
function, we can saw such cache size keep increase, this would cause
no use data copy and unnecessary contigous DRAM memory malloc.

Analysis:
This issue caused by not clear cache_ vector when do
uop_queue_.Reset().

Solution:
Override BaseQueue Reset function in UopQueue and add cache_ clear
logic.

